### PR TITLE
fix: fail fast and report agent spawn errors

### DIFF
--- a/packages/desktop/src/main/features/acp/connection-manager.ts
+++ b/packages/desktop/src/main/features/acp/connection-manager.ts
@@ -38,6 +38,13 @@ export class AcpConnectionManager {
       stdio: ["pipe", "pipe", "pipe"],
       cwd,
       env,
+      shell: true,
+    });
+
+    // Reject early if spawn itself fails (e.g. command not found)
+    await new Promise<void>((resolve, reject) => {
+      agentProcess.on("error", reject);
+      agentProcess.on("spawn", resolve);
     });
 
     // Buffer stderr lines for diagnostics

--- a/packages/desktop/src/main/features/acp/router.ts
+++ b/packages/desktop/src/main/features/acp/router.ts
@@ -46,9 +46,18 @@ export const acpRouter = os.acp.router({
     const agent = context.acpAgentRegistry.get(input.agentId);
     if (!agent) throw new Error(`Unknown agent: ${input.agentId}`);
 
-    const connection = await context.acpConnectionManager.connect(agent, input.cwd);
-    acpLog("connect: success", { connectionId: connection.id, agentId: input.agentId });
-    return { connectionId: connection.id };
+    try {
+      const connection = await context.acpConnectionManager.connect(agent, input.cwd);
+      acpLog("connect: success", { connectionId: connection.id, agentId: input.agentId });
+      return { connectionId: connection.id };
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? `Failed to start agent "${agent.name}": ${error.message}`
+          : `Failed to start agent "${agent.name}"`;
+      acpLog("connect: failed", { agentId: input.agentId, error: message });
+      throw new ORPCError("BAD_GATEWAY", { defined: true, message });
+    }
   }),
 
   newSession: os.acp.newSession.handler(async ({ input, context }) => {


### PR DESCRIPTION
Enable shell spawning and await the child process spawn/error events to reject early when the agent cannot start. Wrap ACP connect in try/catch to log failures and return a BAD_GATEWAY ORPCError with a clearer message.

Fix error when click connect.

```
Uncaught Exception:
Error: spawn npx ENOENT
at ChildProcess._handle.onexit (node:internal/child_process:286:19)
at onErrorNT (node:internal/child_process:484:16)
at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
```