### PR TITLE
feat: add acp loadSession endpoint and return agentSessionId

### DIFF
--- a/packages/desktop/src/main/features/acp/connection-manager.ts
+++ b/packages/desktop/src/main/features/acp/connection-manager.ts
@@ -38,6 +38,7 @@ export class AcpConnectionManager {
     const client = new AcpClient({
       agentCommand,
       cwd: cwd ?? process.cwd(),
+      // TODO: implement configurable permission policies (approve-all, approve-reads, deny-all)
       permissionMode: "approve-reads",
       extraEnv,
       onSessionUpdate: (notification) => connection.emitSessionUpdate(notification),

--- a/packages/desktop/src/main/features/acp/router.ts
+++ b/packages/desktop/src/main/features/acp/router.ts
@@ -76,8 +76,27 @@ export const acpRouter = os.acp.router({
     acpLog("newSession: success", {
       connectionId: input.connectionId,
       sessionId: result.sessionId,
+      agentSessionId: result.agentSessionId,
     });
-    return { sessionId: result.sessionId };
+    return { sessionId: result.sessionId, agentSessionId: result.agentSessionId };
+  }),
+
+  loadSession: os.acp.loadSession.handler(async ({ input, context }) => {
+    acpLog("loadSession: start", {
+      connectionId: input.connectionId,
+      sessionId: input.sessionId,
+      cwd: input.cwd,
+    });
+    const conn = context.acpConnectionManager.getOrThrow(input.connectionId);
+
+    const result = await conn.client.loadSession(input.sessionId, input.cwd);
+
+    acpLog("loadSession: success", {
+      connectionId: input.connectionId,
+      sessionId: input.sessionId,
+      agentSessionId: result.agentSessionId,
+    });
+    return { sessionId: input.sessionId, agentSessionId: result.agentSessionId };
   }),
 
   prompt: os.acp.prompt.handler(async function* ({ input, signal, context }) {

--- a/packages/desktop/src/shared/features/acp/contract.ts
+++ b/packages/desktop/src/shared/features/acp/contract.ts
@@ -25,7 +25,18 @@ export const acpContract = {
   newSession: oc
     .input(z.object({ connectionId: z.string(), cwd: z.string().optional() }))
     .errors(connectionNotFoundError)
-    .output(type<{ sessionId: string; modes?: string[] }>()),
+    .output(type<{ sessionId: string; agentSessionId?: string; modes?: string[] }>()),
+
+  loadSession: oc
+    .input(
+      z.object({
+        connectionId: z.string(),
+        sessionId: z.string(),
+        cwd: z.string().optional(),
+      }),
+    )
+    .errors(connectionNotFoundError)
+    .output(type<{ sessionId: string; agentSessionId?: string }>()),
 
   prompt: oc
     .input(


### PR DESCRIPTION
Extended the ACP contract and router to return agentSessionId from newSession and added a new loadSession handler that loads an existing session via the ACP client. Also added a TODO comment for future configurable permission policies in the connection manager.