### PR TITLE
feat: add session history listing and restore support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@electron-toolkit/utils": "^4.0.0",
         "@orpc/contract": "^1.13.5",
         "@orpc/server": "^1.13.5",
-        "acpx": "github:neovateai/acpx#c8240f4",
+        "acpx": "github:neovateai/acpx#e9c0e00",
         "electron-updater": "^6.3.9",
         "immer": "^11.1.4",
         "motion": "^12.34.3",
@@ -526,7 +526,7 @@
 
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
-    "acpx": ["acpx@github:neovateai/acpx#c8240f4", { "dependencies": { "@agentclientprotocol/sdk": "^0.14.1", "commander": "^13.0.0", "skillflag": "^0.1.4" }, "bin": { "acpx": "dist/cli.js" } }, "neovateai-acpx-c8240f4"],
+    "acpx": ["acpx@github:neovateai/acpx#e9c0e00", { "dependencies": { "@agentclientprotocol/sdk": "^0.14.1", "commander": "^13.0.0", "skillflag": "^0.1.4" }, "bin": { "acpx": "dist/cli.js" } }, "neovateai-acpx-e9c0e00"],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -31,7 +31,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@orpc/contract": "^1.13.5",
     "@orpc/server": "^1.13.5",
-    "acpx": "github:neovateai/acpx#c8240f4",
+    "acpx": "github:neovateai/acpx#e9c0e00",
     "electron-updater": "^6.3.9",
     "immer": "^11.1.4",
     "motion": "^12.34.3",

--- a/packages/desktop/src/main/features/acp/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/acp/__tests__/router.test.ts
@@ -14,6 +14,10 @@ function makeContext(overrides?: Partial<AppContext["acpConnectionManager"]>): A
         throw new ORPCError("NOT_FOUND", { defined: true, message: `Unknown connection: ${id}` });
       }),
       getClient: vi.fn(),
+      getAgentCommand: vi.fn().mockReturnValue(""),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getSessionRecord: vi.fn(),
+      setSessionRecord: vi.fn(),
       getStderr: vi.fn().mockReturnValue([]),
       disconnect: vi.fn(),
       disconnectAll: vi.fn(),

--- a/packages/desktop/src/main/features/acp/connection-manager.ts
+++ b/packages/desktop/src/main/features/acp/connection-manager.ts
@@ -1,4 +1,4 @@
-import { AcpClient, resolveAgentCommand } from "acpx";
+import { AcpClient, resolveAgentCommand, type SessionRecord } from "acpx";
 import { ORPCError } from "@orpc/server";
 import { AcpConnection } from "./connection";
 import { getShellEnvironment } from "./shell-env";
@@ -6,13 +6,16 @@ import { getShellEnvironment } from "./shell-env";
 const MAX_STDERR_LINES = 100;
 
 export const AGENT_OVERRIDES: Record<string, string> = {
-  claude: "npx -y @zed-industries/claude-code-acp",
+  claude: "npx -y @zed-industries/claude-agent-acp",
 };
 
 type ManagedConnection = {
   connection: AcpConnection;
   client: AcpClient;
+  agentCommand: string;
+  cwd: string;
   stderr: string[];
+  sessionRecords: Map<string, SessionRecord>;
 };
 
 export class AcpConnectionManager {
@@ -52,7 +55,15 @@ export class AcpConnectionManager {
     await client.start();
     connection.setClient(client);
 
-    this.connections.set(id, { connection, client, stderr: stderrLines });
+    const resolvedCwd = cwd ?? process.cwd();
+    this.connections.set(id, {
+      connection,
+      client,
+      agentCommand,
+      cwd: resolvedCwd,
+      stderr: stderrLines,
+      sessionRecords: new Map(),
+    });
     return connection;
   }
 
@@ -73,6 +84,22 @@ export class AcpConnectionManager {
 
   getClient(id: string): AcpClient | undefined {
     return this.connections.get(id)?.client;
+  }
+
+  getAgentCommand(id: string): string | undefined {
+    return this.connections.get(id)?.agentCommand;
+  }
+
+  getCwd(id: string): string | undefined {
+    return this.connections.get(id)?.cwd;
+  }
+
+  getSessionRecord(connectionId: string, acpSessionId: string): SessionRecord | undefined {
+    return this.connections.get(connectionId)?.sessionRecords.get(acpSessionId);
+  }
+
+  setSessionRecord(connectionId: string, record: SessionRecord): void {
+    this.connections.get(connectionId)?.sessionRecords.set(record.acpSessionId, record);
   }
 
   getStderr(id: string): string[] {

--- a/packages/desktop/src/main/features/acp/connection.ts
+++ b/packages/desktop/src/main/features/acp/connection.ts
@@ -38,6 +38,17 @@ export class AcpConnection {
   }
 
   emitSessionUpdate(notification: SessionNotification): void {
+    const update = notification.update;
+
+    // Emit user messages as a dedicated event so the store can create separate messages
+    if (update.sessionUpdate === "user_message_chunk" && update.content.type === "text") {
+      this.publisher.publish("session", {
+        type: "user_message",
+        text: update.content.text,
+      });
+      return;
+    }
+
     const drafts = sessionUpdateToEventDrafts(notification);
     for (const draft of drafts) {
       const event = createAcpxEvent({ sessionId: this.id, seq: this.seq++ }, draft);

--- a/packages/desktop/src/main/features/acp/router.ts
+++ b/packages/desktop/src/main/features/acp/router.ts
@@ -1,5 +1,15 @@
+import { randomUUID } from "node:crypto";
 import { ORPCError, implement } from "@orpc/server";
-import { AgentSpawnError, listBuiltInAgents, formatErrorMessage } from "acpx";
+import {
+  AgentSpawnError,
+  listBuiltInAgents,
+  formatErrorMessage,
+  listSessionsForAgent,
+  writeSessionRecord,
+  isoNow,
+  SESSION_RECORD_SCHEMA,
+  type SessionRecord,
+} from "acpx";
 import { acpContract } from "../../../shared/features/acp/contract";
 import { AGENT_OVERRIDES } from "./connection-manager";
 import type { AppContext } from "../../router";
@@ -69,9 +79,32 @@ export const acpRouter = os.acp.router({
 
   newSession: os.acp.newSession.handler(async ({ input, context }) => {
     acpLog("newSession: start", { connectionId: input.connectionId, cwd: input.cwd });
-    const conn = context.acpConnectionManager.getOrThrow(input.connectionId);
+    const manager = context.acpConnectionManager;
+    const conn = manager.getOrThrow(input.connectionId);
 
-    const result = await conn.client.createSession(input.cwd ?? process.cwd());
+    const cwd = input.cwd ?? manager.getCwd(input.connectionId) ?? process.cwd();
+    const result = await conn.client.createSession(cwd);
+
+    const agentCommand = manager.getAgentCommand(input.connectionId) ?? "";
+    const now = isoNow();
+    const record: SessionRecord = {
+      schema: SESSION_RECORD_SCHEMA,
+      acpxRecordId: randomUUID(),
+      acpSessionId: result.sessionId,
+      agentSessionId: result.agentSessionId,
+      agentCommand,
+      cwd,
+      createdAt: now,
+      lastUsedAt: now,
+      lastSeq: 0,
+      eventLog: { active_path: "", segment_count: 0, max_segment_bytes: 0, max_segments: 0 },
+      messages: [],
+      updated_at: now,
+      cumulative_token_usage: {},
+      request_token_usage: {},
+    };
+    manager.setSessionRecord(input.connectionId, record);
+    writeSessionRecord(record).catch(() => {});
 
     acpLog("newSession: success", {
       connectionId: input.connectionId,
@@ -81,7 +114,34 @@ export const acpRouter = os.acp.router({
     return { sessionId: result.sessionId, agentSessionId: result.agentSessionId };
   }),
 
-  loadSession: os.acp.loadSession.handler(async ({ input, context }) => {
+  listSessions: os.acp.listSessions.handler(async ({ input, context }) => {
+    acpLog("listSessions: start", { connectionId: input.connectionId });
+    context.acpConnectionManager.getOrThrow(input.connectionId);
+
+    const agentCommand = context.acpConnectionManager.getAgentCommand(input.connectionId);
+    if (!agentCommand) {
+      throw new ORPCError("NOT_FOUND", {
+        defined: true,
+        message: `Unknown connection: ${input.connectionId}`,
+      });
+    }
+
+    const records = await listSessionsForAgent(agentCommand);
+    const sessions = records.map((r) => ({
+      sessionId: r.acpSessionId,
+      title: r.title ?? r.name,
+      cwd: r.cwd,
+      updatedAt: r.lastUsedAt,
+    }));
+
+    acpLog("listSessions: success", {
+      connectionId: input.connectionId,
+      count: sessions.length,
+    });
+    return sessions;
+  }),
+
+  loadSession: os.acp.loadSession.handler(async function* ({ input, signal, context }) {
     acpLog("loadSession: start", {
       connectionId: input.connectionId,
       sessionId: input.sessionId,
@@ -89,14 +149,59 @@ export const acpRouter = os.acp.router({
     });
     const conn = context.acpConnectionManager.getOrThrow(input.connectionId);
 
-    const result = await conn.client.loadSession(input.sessionId, input.cwd);
+    const done = new AbortController();
+    if (signal) {
+      signal.addEventListener("abort", () => done.abort(signal.reason), { once: true });
+    }
+
+    // Subscribe before loadSession so we capture replayed events
+    const subscription = conn.subscribeSession(done.signal);
+
+    let loadResult: { agentSessionId?: string } | undefined;
+    let loadError: unknown;
+
+    const loadPromise = conn.client
+      .loadSession(input.sessionId, input.cwd)
+      .then((result) => {
+        loadResult = result;
+        acpLog("loadSession: resolved", {
+          connectionId: input.connectionId,
+          sessionId: input.sessionId,
+          agentSessionId: result.agentSessionId,
+        });
+        done.abort("load_done");
+      })
+      .catch((error: unknown) => {
+        loadError = error;
+        acpLog("loadSession: rejected", {
+          connectionId: input.connectionId,
+          sessionId: input.sessionId,
+          error: formatErrorMessage(error),
+        });
+        done.abort("load_error");
+      });
+
+    try {
+      for await (const event of subscription) {
+        yield event;
+      }
+    } catch (e: unknown) {
+      if (!done.signal.aborted) {
+        throw e;
+      }
+    } finally {
+      subscription.return(undefined);
+    }
+
+    await loadPromise;
+    if (loadError) throw loadError;
 
     acpLog("loadSession: success", {
       connectionId: input.connectionId,
       sessionId: input.sessionId,
-      agentSessionId: result.agentSessionId,
+      agentSessionId: loadResult?.agentSessionId,
     });
-    return { sessionId: input.sessionId, agentSessionId: result.agentSessionId };
+    return { sessionId: input.sessionId, agentSessionId: loadResult?.agentSessionId };
   }),
 
   prompt: os.acp.prompt.handler(async function* ({ input, signal, context }) {
@@ -162,6 +267,17 @@ export const acpRouter = os.acp.router({
 
     await promptPromise;
     if (promptError) throw promptError;
+
+    // Persist session record with updated timestamp
+    const record = context.acpConnectionManager.getSessionRecord(
+      input.connectionId,
+      input.sessionId,
+    );
+    if (record) {
+      record.lastUsedAt = isoNow();
+      record.lastPromptAt = record.lastUsedAt;
+      writeSessionRecord(record).catch(() => {});
+    }
 
     acpLog("prompt: done", {
       connectionId: input.connectionId,

--- a/packages/desktop/src/renderer/src/App.tsx
+++ b/packages/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { AgentChat } from "./features/acp";
+import { AgentChat, SessionList } from "./features/acp";
 import {
   AppLayoutActivityBar,
   AppLayoutChatPanel,
@@ -22,9 +22,7 @@ export default function App() {
       <AppLayoutPrimarySidebar>
         <div className="flex h-full flex-col p-3">
           <h2 className="text-xs font-semibold text-muted-foreground">Sessions</h2>
-          <div className="flex flex-1 items-center justify-center">
-            <p className="text-xs text-muted-foreground">No sessions yet</p>
-          </div>
+          <SessionList />
         </div>
         <div className="mt-auto ml-auto px-1.5 pb-1.5">
           <ThemeToggle />

--- a/packages/desktop/src/renderer/src/features/acp/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/session-list.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useState } from "react";
+import { useAcpStore } from "../store";
+import { client } from "../../../orpc";
+import { cn } from "../../../lib/utils";
+import { Button } from "../../../components/ui/button";
+
+export function SessionList() {
+  const sessions = useAcpStore((s) => s.sessions);
+  const activeSessionId = useAcpStore((s) => s.activeSessionId);
+  const setActiveSession = useAcpStore((s) => s.setActiveSession);
+  const agentSessions = useAcpStore((s) => s.agentSessions);
+  const setAgentSessions = useAcpStore((s) => s.setAgentSessions);
+  const createSession = useAcpStore((s) => s.createSession);
+  const appendChunk = useAcpStore((s) => s.appendChunk);
+
+  const [loading, setLoading] = useState(false);
+  const [restoring, setRestoring] = useState<string | null>(null);
+
+  // Get connectionId from any active in-memory session
+  const anySession = Array.from(sessions.values())[0];
+  const connectionId = anySession?.connectionId;
+
+  const refresh = useCallback(async () => {
+    if (!connectionId) return;
+    setLoading(true);
+    try {
+      const list = await client.acp.listSessions({ connectionId });
+      setAgentSessions(list);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [connectionId, setAgentSessions]);
+
+  const loadSession = useCallback(
+    async (sessionId: string) => {
+      if (!connectionId) return;
+      // Already loaded in memory — just switch
+      if (sessions.has(sessionId)) {
+        setActiveSession(sessionId);
+        return;
+      }
+      setRestoring(sessionId);
+      try {
+        // Create the store session first so appendChunk has a target
+        createSession(sessionId, connectionId);
+        const iterator = await client.acp.loadSession({ connectionId, sessionId });
+        for await (const event of iterator) {
+          appendChunk(sessionId, event);
+        }
+      } catch {
+        // ignore
+      } finally {
+        setRestoring(null);
+      }
+    },
+    [connectionId, sessions, setActiveSession, createSession, appendChunk],
+  );
+
+  // In-memory session IDs for dedup
+  const loadedIds = new Set(sessions.keys());
+
+  // Persisted sessions not already loaded
+  const persistedOnly = agentSessions.filter((s) => !loadedIds.has(s.sessionId));
+
+  const inMemory = Array.from(sessions.values());
+  const hasAnything = inMemory.length > 0 || persistedOnly.length > 0;
+
+  if (!hasAnything) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-xs text-muted-foreground">No sessions yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {connectionId && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-full text-[10px]"
+          onClick={refresh}
+          disabled={loading}
+        >
+          {loading ? "Refreshing..." : "Refresh"}
+        </Button>
+      )}
+
+      <ul className="flex flex-col gap-0.5">
+        {/* In-memory sessions */}
+        {inMemory.map((session) => (
+          <li key={session.sessionId}>
+            <button
+              type="button"
+              onClick={() => setActiveSession(session.sessionId)}
+              className={cn(
+                "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                session.sessionId === activeSessionId
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:bg-accent/50",
+              )}
+            >
+              <span className="block truncate font-mono">{session.sessionId.slice(0, 8)}</span>
+              <span className="block truncate text-[10px] opacity-60">
+                {session.messages.length} message{session.messages.length !== 1 && "s"}
+                {session.streaming && " \u00b7 streaming"}
+              </span>
+            </button>
+          </li>
+        ))}
+
+        {/* Persisted sessions (not yet loaded) */}
+        {persistedOnly.length > 0 && inMemory.length > 0 && (
+          <li className="px-2 pt-1">
+            <span className="text-[10px] text-muted-foreground">History</span>
+          </li>
+        )}
+        {persistedOnly.map((info) => (
+          <li key={info.sessionId}>
+            <button
+              type="button"
+              onClick={() => loadSession(info.sessionId)}
+              disabled={restoring === info.sessionId}
+              className="w-full rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/50"
+            >
+              <span className="block truncate">
+                {restoring === info.sessionId
+                  ? "Restoring..."
+                  : info.title || info.sessionId.slice(0, 8)}
+              </span>
+              <span className="block truncate text-[10px] opacity-60">{info.cwd}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-connect.ts
+++ b/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-connect.ts
@@ -7,6 +7,7 @@ export function useAcpConnect() {
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
   const createSession = useAcpStore((s) => s.createSession);
+  const setAgentSessions = useAcpStore((s) => s.setAgentSessions);
 
   const connect = useCallback(
     async (agentId: string, cwd?: string) => {
@@ -19,6 +20,13 @@ export function useAcpConnect() {
           cwd,
         });
         createSession(sessionId, connectionId);
+
+        // Fetch persisted sessions after connect
+        client.acp
+          .listSessions({ connectionId })
+          .then(setAgentSessions)
+          .catch(() => {});
+
         return { connectionId, sessionId };
       } catch (error) {
         const message =
@@ -31,7 +39,7 @@ export function useAcpConnect() {
         setConnecting(false);
       }
     },
-    [createSession],
+    [createSession, setAgentSessions],
   );
 
   return { connect, connecting, connectError };

--- a/packages/desktop/src/renderer/src/features/acp/index.ts
+++ b/packages/desktop/src/renderer/src/features/acp/index.ts
@@ -1,4 +1,5 @@
 export { AgentChat } from "./components/agent-chat";
+export { SessionList } from "./components/session-list";
 export { useAcpStore } from "./store";
 export { useAcpConnect } from "./hooks/use-acp-connect";
 export { useAcpPrompt } from "./hooks/use-acp-prompt";

--- a/packages/desktop/src/renderer/src/features/acp/store.ts
+++ b/packages/desktop/src/renderer/src/features/acp/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { enableMapSet } from "immer";
-import type { AgentInfo, StreamEvent } from "../../../../shared/features/acp/types";
+import type { AgentInfo, SessionInfo, StreamEvent } from "../../../../shared/features/acp/types";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 
 enableMapSet();
@@ -39,10 +39,12 @@ type AcpState = {
   agents: AgentInfo[];
   sessions: Map<string, AcpSession>;
   activeSessionId: string | null;
+  agentSessions: SessionInfo[];
   _nextMessageId: number;
 
   setAgents: (agents: AgentInfo[]) => void;
   setActiveSession: (sessionId: string | null) => void;
+  setAgentSessions: (sessions: SessionInfo[]) => void;
   createSession: (sessionId: string, connectionId: string) => void;
   removeSession: (sessionId: string) => void;
   addUserMessage: (sessionId: string, content: string) => void;
@@ -57,11 +59,14 @@ export const useAcpStore = create<AcpState>()(
     agents: [],
     sessions: new Map(),
     activeSessionId: null,
+    agentSessions: [],
     _nextMessageId: 0,
 
     setAgents: (agents) => set({ agents }),
 
     setActiveSession: (sessionId) => set({ activeSessionId: sessionId }),
+
+    setAgentSessions: (agentSessions) => set({ agentSessions }),
 
     createSession: (sessionId, connectionId) => {
       set((state) => {
@@ -131,6 +136,16 @@ export const useAcpStore = create<AcpState>()(
             requestId: event.requestId,
             data: event.data,
           };
+          return;
+        }
+
+        if (event.type === "user_message") {
+          state._nextMessageId += 1;
+          session.messages.push({
+            id: String(state._nextMessageId),
+            role: "user",
+            content: event.text,
+          });
           return;
         }
 

--- a/packages/desktop/src/shared/features/acp/contract.ts
+++ b/packages/desktop/src/shared/features/acp/contract.ts
@@ -1,6 +1,6 @@
 import { oc, type, eventIterator } from "@orpc/contract";
 import { z } from "zod";
-import type { AgentInfo, StreamEvent, PromptResult } from "./types";
+import type { AgentInfo, SessionInfo, StreamEvent, LoadSessionResult, PromptResult } from "./types";
 
 const promptErrorDataSchema = type<{
   source: "acp_agent";
@@ -27,6 +27,11 @@ export const acpContract = {
     .errors(connectionNotFoundError)
     .output(type<{ sessionId: string; agentSessionId?: string; modes?: string[] }>()),
 
+  listSessions: oc
+    .input(z.object({ connectionId: z.string() }))
+    .errors(connectionNotFoundError)
+    .output(type<SessionInfo[]>()),
+
   loadSession: oc
     .input(
       z.object({
@@ -36,7 +41,7 @@ export const acpContract = {
       }),
     )
     .errors(connectionNotFoundError)
-    .output(type<{ sessionId: string; agentSessionId?: string }>()),
+    .output(eventIterator(type<StreamEvent>(), type<LoadSessionResult>())),
 
   prompt: oc
     .input(

--- a/packages/desktop/src/shared/features/acp/types.ts
+++ b/packages/desktop/src/shared/features/acp/types.ts
@@ -9,11 +9,26 @@ export type AgentInfo = {
 /** What the eventIterator yields to the renderer */
 export type StreamEvent =
   | { type: "acpx_event"; event: AcpxEvent }
+  | { type: "user_message"; text: string }
   | {
       type: "permission_request";
       requestId: string;
       data: RequestPermissionRequest;
     };
+
+/** Lightweight session metadata for the sidebar list */
+export type SessionInfo = {
+  sessionId: string;
+  title?: string;
+  cwd: string;
+  updatedAt: string;
+};
+
+/** Final return value when loadSession replay completes */
+export type LoadSessionResult = {
+  sessionId: string;
+  agentSessionId?: string;
+};
 
 /** Final return value when prompt completes */
 export type PromptResult = {


### PR DESCRIPTION
Adds persisted ACP session records with a new listSessions endpoint and a renderer sidebar SessionList to refresh and restore prior sessions. Updates loadSession to stream replay events via an event iterator and emits user message chunks as dedicated events for correct message reconstruction.