### PR TITLE
feat: preload acp sessions to speed up session loading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,12 @@ This prints logs to the terminal and saves them to `/tmp/dev.log` for searching 
 
 You can filter by namespace (e.g. `DEBUG=neovate:acp-router` for just the router).
 
+## Environment Variables
+
+| Variable                  | Default | Description                                                                         |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `NEOVATE_PRELOAD_SESSION` | `all`   | `all` = preload all sessions, `latest` = only the most recent, `false` = no preload |
+
 ## Code Style
 
 - Linting: [oxlint](https://oxc.rs/)

--- a/packages/desktop/src/main/features/acp/connection.ts
+++ b/packages/desktop/src/main/features/acp/connection.ts
@@ -6,7 +6,10 @@ import type {
   RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 import { EventPublisher } from "@orpc/server";
-import type { StreamEvent } from "../../../shared/features/acp/types";
+import debug from "debug";
+import type { StreamEvent, LoadSessionResult } from "../../../shared/features/acp/types";
+
+const preloadLog = debug("neovate:acp-preload");
 
 /** Auto-cancel permission requests after 5 minutes of no UI response. */
 export const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -44,6 +47,11 @@ type PendingPermission = {
   timer: ReturnType<typeof setTimeout>;
 };
 
+export type PreloadedSession = {
+  events: StreamEvent[];
+  result: LoadSessionResult;
+};
+
 export class AcpConnection {
   readonly id: string;
   private _client?: AcpClient;
@@ -51,6 +59,9 @@ export class AcpConnection {
   private pendingPermissions = new Map<string, PendingPermission>();
   private requestIdCounter = 0;
   private seq = 0;
+  private preloadedSessions = new Map<string, PreloadedSession>();
+  private preloadPromises = new Map<string, Promise<void>>();
+  private activePreload: string | null = null;
 
   constructor(id: string) {
     this.id = id;
@@ -113,6 +124,86 @@ export class AcpConnection {
   subscribeSession(sessionId: string, signal?: AbortSignal): AsyncGenerator<StreamEvent> {
     const raw = this.publisher.subscribe("session", { signal });
     return filterStreamBySession(raw, sessionId);
+  }
+
+  preloadSession(sessionId: string, cwd?: string): Promise<void> {
+    if (!this._client) return Promise.resolve();
+    if (this.preloadedSessions.has(sessionId)) return Promise.resolve();
+    if (this.preloadPromises.has(sessionId)) return this.preloadPromises.get(sessionId)!;
+
+    const promise = this.doPreload(sessionId, cwd).finally(() => {
+      this.preloadPromises.delete(sessionId);
+    });
+    this.preloadPromises.set(sessionId, promise);
+    return promise;
+  }
+
+  private async doPreload(sessionId: string, cwd?: string): Promise<void> {
+    this.activePreload = sessionId;
+    preloadLog("starting preload for session %s", sessionId);
+
+    const done = new AbortController();
+    const subscription = this.subscribeSession(sessionId, done.signal);
+    const events: StreamEvent[] = [];
+
+    try {
+      let loadError: unknown;
+      const loadPromise = this._client!.loadSession(sessionId, cwd)
+        .then((result) => {
+          done.abort("load_done");
+          return { sessionId, agentSessionId: result.agentSessionId };
+        })
+        .catch((error: unknown) => {
+          loadError = error;
+          done.abort("load_error");
+          return undefined;
+        });
+
+      try {
+        for await (const event of subscription) {
+          events.push(event);
+        }
+      } catch {
+        // subscription ends when done is aborted
+      } finally {
+        subscription.return(undefined);
+      }
+
+      const result = await loadPromise;
+      if (loadError || !result) {
+        preloadLog(
+          "preload skipped for session %s (agent rejected, likely empty session): %s",
+          sessionId,
+          JSON.stringify(loadError),
+        );
+        return;
+      }
+      // Only cache if this preload wasn't superseded
+      if (this.activePreload === sessionId) {
+        this.preloadedSessions.set(sessionId, { events, result });
+        preloadLog("cached %d events for session %s", events.length, sessionId);
+      }
+    } catch (error) {
+      preloadLog("preload failed for session %s: %s", sessionId, JSON.stringify(error));
+    } finally {
+      if (this.activePreload === sessionId) {
+        this.activePreload = null;
+      }
+    }
+  }
+
+  async consumePreload(sessionId: string): Promise<PreloadedSession | undefined> {
+    const inflight = this.preloadPromises.get(sessionId);
+    if (inflight) {
+      preloadLog("consumePreload: waiting for in-flight preload of session %s", sessionId);
+      await inflight;
+    }
+    const cached = this.preloadedSessions.get(sessionId);
+    if (cached) {
+      this.preloadedSessions.delete(sessionId);
+      preloadLog("consumed preload for session %s (%d events)", sessionId, cached.events.length);
+    }
+    return cached;
   }
 
   dispose(): void {

--- a/packages/desktop/src/main/features/acp/router.ts
+++ b/packages/desktop/src/main/features/acp/router.ts
@@ -17,6 +17,9 @@ import { AGENT_OVERRIDES } from "./connection-manager";
 import type { AppContext } from "../../router";
 import type { AcpConnectionManager } from "./connection-manager";
 
+/** "all" (default) | "latest" | "false" */
+const PRELOAD_SESSION_MODE = process.env.NEOVATE_PRELOAD_SESSION ?? "all";
+
 const os = implement({ acp: acpContract }).$context<AppContext>();
 const acpLog = debug("neovate:acp-router");
 
@@ -162,6 +165,29 @@ export const acpRouter = os.acp.router({
     return sessions;
   }),
 
+  preloadSessions: os.acp.preloadSessions.handler(async ({ input, context }) => {
+    if (PRELOAD_SESSION_MODE === "false") return;
+
+    const ids = PRELOAD_SESSION_MODE === "latest" ? input.sessionIds.slice(0, 1) : input.sessionIds;
+
+    acpLog("preloadSessions: start (mode=%s, count=%d)", PRELOAD_SESSION_MODE, ids.length, {
+      connectionId: input.connectionId,
+    });
+
+    try {
+      const conn = context.acpConnectionManager.getOrThrow(input.connectionId);
+      // Preload sequentially to avoid flooding the agent
+      for (const sessionId of ids) {
+        await conn.preloadSession(sessionId, input.cwd);
+      }
+    } catch (error) {
+      acpLog("preloadSessions: failed silently", {
+        connectionId: input.connectionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }),
+
   loadSession: os.acp.loadSession.handler(async function* ({ input, signal, context }) {
     const t0 = performance.now();
     let firstEventAt: number | undefined;
@@ -171,6 +197,19 @@ export const acpRouter = os.acp.router({
       cwd: input.cwd,
     });
     const conn = context.acpConnectionManager.getOrThrow(input.connectionId);
+
+    // Check if this session was preloaded (waits for in-flight preload if any)
+    const cached = await conn.consumePreload(input.sessionId);
+    if (cached) {
+      acpLog("loadSession: serving from preload cache (%d events)", cached.events.length);
+      for (const event of cached.events) {
+        yield event;
+      }
+      const totalMs = performance.now() - t0;
+      yield timingEntry("loadSession", "time_to_first_event", 0);
+      yield timingEntry("loadSession", "total", totalMs);
+      return cached.result;
+    }
 
     const done = new AbortController();
     if (signal) {

--- a/packages/desktop/src/renderer/src/features/acp/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/agent-chat.tsx
@@ -61,7 +61,22 @@ export function AgentChat() {
       // Re-fetch persisted sessions for the restored connection
       client.acp
         .listSessions({ connectionId: existing })
-        .then(setAgentSessions)
+        .then((sessions) => {
+          setAgentSessions(sessions);
+          // Preload sessions
+          if (sessions.length > 0) {
+            const sessionIds = [...sessions]
+              .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+              .map((s) => s.sessionId);
+            client.acp
+              .preloadSessions({
+                connectionId: existing,
+                sessionIds,
+                cwd: activeProjectPath,
+              })
+              .catch(() => {});
+          }
+        })
         .catch(() => setAgentSessions([]));
     } else {
       setActiveConnectionId(null);

--- a/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-connect.ts
+++ b/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-connect.ts
@@ -44,6 +44,15 @@ export function useAcpConnect() {
               timestamp: Date.now(),
             });
             setAgentSessions(sessions);
+
+            // Preload sessions so they're ready when the user clicks them
+            if (sessions.length > 0) {
+              const sessionIds = [...sessions]
+                .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+                .map((s) => s.sessionId);
+              connectLog("preloading %d sessions", sessionIds.length);
+              client.acp.preloadSessions({ connectionId, sessionIds, cwd }).catch(() => {});
+            }
           })
           .catch(() => {});
 

--- a/packages/desktop/src/shared/features/acp/contract.ts
+++ b/packages/desktop/src/shared/features/acp/contract.ts
@@ -32,6 +32,17 @@ export const acpContract = {
     .errors(connectionNotFoundError)
     .output(type<SessionInfo[]>()),
 
+  preloadSessions: oc
+    .input(
+      z.object({
+        connectionId: z.string(),
+        sessionIds: z.array(z.string()),
+        cwd: z.string().optional(),
+      }),
+    )
+    .errors(connectionNotFoundError)
+    .output(type<void>()),
+
   loadSession: oc
     .input(
       z.object({


### PR DESCRIPTION
Added an ACP preloadSessions endpoint and connection-side caching so session events can be preloaded and served from cache during loadSession. Updated the renderer to trigger session preloading after connecting/restoring and documented the NEOVATE_PRELOAD_SESSION env var to control preload behavior.