### PR TITLE
feat: persist app theme via config store and router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 ## Project Info
 
 - Settings directory: `~/.neovate-desktop`
+- Run `bun ready` after task is completed

--- a/packages/desktop/src/main/__tests__/router.test.ts
+++ b/packages/desktop/src/main/__tests__/router.test.ts
@@ -8,6 +8,7 @@ describe("main router context wiring", () => {
   it("listAgents returns built-in agents from acp registry", async () => {
     const context = {
       acpConnectionManager: {} as unknown as AppDependencies["acpConnectionManager"],
+      configStore: {} as unknown as AppDependencies["configStore"],
       projectStore: {} as unknown as AppDependencies["projectStore"],
     } satisfies AppDependencies;
 
@@ -24,6 +25,7 @@ describe("main router context wiring", () => {
   it("ping returns pong", async () => {
     const context = {
       acpConnectionManager: {} as unknown as AppDependencies["acpConnectionManager"],
+      configStore: {} as unknown as AppDependencies["configStore"],
       projectStore: {} as unknown as AppDependencies["projectStore"],
     } satisfies AppDependencies;
     const result = await call(router.ping, undefined, { context });

--- a/packages/desktop/src/main/core/browser-window-manager.ts
+++ b/packages/desktop/src/main/core/browser-window-manager.ts
@@ -12,7 +12,10 @@ type WindowStore = { bounds: Electron.Rectangle };
 export class BrowserWindowManager implements IBrowserWindowManager {
   #mainWindow: BrowserWindow | null = null;
   #windows = new Map<string, BrowserWindow>();
-  #store = new Store<WindowStore>({ name: "window-state", cwd: path.join(os.homedir(), ".neovate-desktop") });
+  #store = new Store<WindowStore>({
+    name: "window-state",
+    cwd: path.join(os.homedir(), ".neovate-desktop"),
+  });
 
   get mainWindow(): BrowserWindow | null {
     return this.#mainWindow;

--- a/packages/desktop/src/main/features/acp/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/acp/__tests__/router.test.ts
@@ -7,6 +7,7 @@ import { AcpConnection } from "../connection";
 
 function makeContext(overrides?: Partial<AppContext["acpConnectionManager"]>): AppContext {
   return {
+    configStore: {} as any,
     projectStore: {} as any,
     acpConnectionManager: {
       connect: vi.fn(),

--- a/packages/desktop/src/main/features/config/config-store.ts
+++ b/packages/desktop/src/main/features/config/config-store.ts
@@ -1,0 +1,32 @@
+import os from "node:os";
+import path from "node:path";
+import Store from "electron-store";
+import type { AppConfig } from "../../../shared/features/config/types";
+
+export class ConfigStore {
+  private store: Store<AppConfig>;
+
+  constructor() {
+    this.store = new Store<AppConfig>({
+      name: "config",
+      cwd: path.join(os.homedir(), ".neovate-desktop"),
+      defaults: {
+        theme: "system",
+      },
+    });
+  }
+
+  getAll(): AppConfig {
+    return {
+      theme: this.store.get("theme"),
+    };
+  }
+
+  get<K extends keyof AppConfig>(key: K): AppConfig[K] {
+    return this.store.get(key);
+  }
+
+  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): void {
+    this.store.set(key, value);
+  }
+}

--- a/packages/desktop/src/main/features/config/router.ts
+++ b/packages/desktop/src/main/features/config/router.ts
@@ -1,0 +1,15 @@
+import { implement } from "@orpc/server";
+import { configContract } from "../../../shared/features/config/contract";
+import type { AppContext } from "../../router";
+
+const os = implement({ config: configContract }).$context<AppContext>();
+
+export const configRouter = os.config.router({
+  get: os.config.get.handler(({ context }) => {
+    return context.configStore.getAll();
+  }),
+
+  set: os.config.set.handler(({ input, context }) => {
+    context.configStore.set(input.key, input.value);
+  }),
+});

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { setBaseDir } from "acpx";
 import debug from "debug";
 import { AcpConnectionManager } from "./features/acp/connection-manager";
 import { getShellEnvironment } from "./features/acp/shell-env";
+import { ConfigStore } from "./features/config/config-store";
 import { ProjectStore } from "./features/project/project-store";
 import { MainApp } from "./app";
 import type { AppContext } from "./router";
@@ -24,9 +25,11 @@ if (is.dev && process.env.ELECTRON_CDP_PORT) {
 getShellEnvironment();
 
 const connectionManager = new AcpConnectionManager();
+const configStore = new ConfigStore();
 const projectStore = new ProjectStore();
 const appContext: AppContext = {
   acpConnectionManager: connectionManager,
+  configStore,
   projectStore,
 };
 

--- a/packages/desktop/src/main/router.ts
+++ b/packages/desktop/src/main/router.ts
@@ -2,13 +2,16 @@ import { implement } from "@orpc/server";
 import type { AnyRouter } from "@orpc/server";
 import { contract } from "../shared/contract";
 import { acpRouter } from "./features/acp/router";
+import { configRouter } from "./features/config/router";
 import { projectRouter } from "./features/project/router";
 import { utilsRouter } from "./features/utils/router";
 import type { AcpConnectionManager } from "./features/acp/connection-manager";
+import type { ConfigStore } from "./features/config/config-store";
 import type { ProjectStore } from "./features/project/project-store";
 
 export type AppContext = {
   acpConnectionManager: AcpConnectionManager;
+  configStore: ConfigStore;
   projectStore: ProjectStore;
 };
 
@@ -20,6 +23,7 @@ export function buildRouter(pluginRouters: Map<string, AnyRouter>) {
   return {
     ping: os.ping.handler(() => "pong" as const),
     acp: acpRouter,
+    config: configRouter,
     project: projectRouter,
     utils: utilsRouter,
     ...Object.fromEntries(pluginRouters),

--- a/packages/desktop/src/renderer/src/components/ui/theme-toggle.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/theme-toggle.tsx
@@ -1,10 +1,12 @@
 import { Moon01Icon, Sun01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useTheme } from "next-themes";
+import { useConfigStore } from "../../features/config/store";
 import { Button } from "./button";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { resolvedTheme, setTheme } = useTheme();
+  const { resolvedTheme } = useTheme();
+  const setTheme = useConfigStore((s) => s.setTheme);
 
   return (
     <Button

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -1,6 +1,7 @@
-import { StrictMode, createContext, useContext } from "react";
+import { StrictMode, createContext, useContext, useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { ThemeProvider } from "next-themes";
+import { ThemeProvider, useTheme } from "next-themes";
+import { useConfigStore } from "../features/config/store";
 import { DisposableStore } from "./disposable";
 import type { IRendererApp } from "./types";
 import type { RendererPlugin, PluginContext } from "./plugin";
@@ -24,6 +25,21 @@ export function usePluginContext(): PluginContext {
   return ctx;
 }
 
+/** Syncs persisted config theme → next-themes on load */
+function ThemeSync() {
+  const configTheme = useConfigStore((s) => s.theme);
+  const loaded = useConfigStore((s) => s.loaded);
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    if (loaded) {
+      setTheme(configTheme);
+    }
+  }, [configTheme, loaded, setTheme]);
+
+  return null;
+}
+
 const BUILTIN_PLUGINS: RendererPlugin[] = [filesPlugin, gitPlugin];
 
 export interface RendererAppOptions {
@@ -40,6 +56,7 @@ export class RendererApp implements IRendererApp {
 
   async start(): Promise<void> {
     const ctx: PluginContext = { app: this, orpcClient: client };
+    await useConfigStore.getState().load();
     await this.pluginManager.configContributions();
     await this.pluginManager.activate(ctx);
     await this.render(ctx);
@@ -59,6 +76,7 @@ export class RendererApp implements IRendererApp {
         <RendererAppContext.Provider value={this}>
           <PluginContextReact.Provider value={ctx}>
             <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+              <ThemeSync />
               <App />
             </ThemeProvider>
           </PluginContextReact.Provider>

--- a/packages/desktop/src/renderer/src/features/config/store.ts
+++ b/packages/desktop/src/renderer/src/features/config/store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { AppConfig, Theme } from "../../../../shared/features/config/types";
+import { client } from "../../orpc";
+
+type ConfigState = AppConfig & {
+  loaded: boolean;
+  load: () => Promise<void>;
+  setTheme: (theme: Theme) => void;
+};
+
+export const useConfigStore = create<ConfigState>()(
+  immer((set) => ({
+    theme: "system",
+    loaded: false,
+
+    load: async () => {
+      const config = await client.config.get();
+      set((state) => {
+        state.theme = config.theme;
+        state.loaded = true;
+      });
+    },
+
+    setTheme: (theme) => {
+      client.config.set({ key: "theme", value: theme }).catch(() => {});
+      set((state) => {
+        state.theme = theme;
+      });
+    },
+  })),
+);

--- a/packages/desktop/src/shared/contract.ts
+++ b/packages/desktop/src/shared/contract.ts
@@ -1,11 +1,13 @@
 import { oc, type } from "@orpc/contract";
 import { acpContract } from "./features/acp/contract";
+import { configContract } from "./features/config/contract";
 import { projectContract } from "./features/project/contract";
 import { utilsContract } from "./features/utils/contract";
 
 export const contract = {
   ping: oc.output(type<"pong">()),
   acp: acpContract,
+  config: configContract,
   project: projectContract,
   utils: utilsContract,
 };

--- a/packages/desktop/src/shared/features/config/contract.ts
+++ b/packages/desktop/src/shared/features/config/contract.ts
@@ -1,0 +1,11 @@
+import { oc, type } from "@orpc/contract";
+import { z } from "zod";
+import type { AppConfig } from "./types";
+
+export const configContract = {
+  get: oc.output(type<AppConfig>()),
+
+  set: oc
+    .input(z.object({ key: z.literal("theme"), value: z.enum(["system", "light", "dark"]) }))
+    .output(type<void>()),
+};

--- a/packages/desktop/src/shared/features/config/types.ts
+++ b/packages/desktop/src/shared/features/config/types.ts
@@ -1,0 +1,5 @@
+export type Theme = "system" | "light" | "dark";
+
+export type AppConfig = {
+  theme: Theme;
+};


### PR DESCRIPTION
Added a shared config contract plus main-process ConfigStore and router for persisting app configuration (currently theme). Updated the renderer to load/sync the persisted theme on startup and route theme changes through the config store.