### PR TITLE
feat: add file path search suggestions for mentions

### DIFF
--- a/packages/desktop/src/main/features/utils/router.ts
+++ b/packages/desktop/src/main/features/utils/router.ts
@@ -1,10 +1,14 @@
 import { spawn, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import debug from "debug";
 import { implement } from "@orpc/server";
 import { utilsContract } from "../../../shared/features/utils/contract";
 import type { App } from "../../../shared/features/utils/types";
 import type { AppContext } from "../../router";
 import { getShellEnvironment } from "../acp/shell-env";
+import { searchPaths } from "./search-paths";
+
+const log = debug("neovate:utils-router");
 
 const os = implement({ utils: utilsContract }).$context<AppContext>();
 
@@ -96,5 +100,10 @@ export const utilsRouter = os.utils.router({
     const shellEnv = await getShellEnvironment();
     const apps = ALL_APPS.filter((app) => checkApp(app, shellEnv));
     return { apps };
+  }),
+
+  searchPaths: os.utils.searchPaths.handler(async ({ input }) => {
+    log("searchPaths request cwd=%s query=%s", input.cwd, input.query);
+    return searchPaths(input.cwd, input.query, input.maxResults);
   }),
 });

--- a/packages/desktop/src/main/features/utils/search-paths.ts
+++ b/packages/desktop/src/main/features/utils/search-paths.ts
@@ -1,0 +1,123 @@
+import { execFile } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import debug from "debug";
+import { getShellEnvironment } from "../acp/shell-env";
+
+const log = debug("neovate:search-paths");
+const EXCLUDED_DIRS = new Set(["node_modules", ".git", "dist", "build"]);
+
+let cachedRgPath: string | null | undefined; // undefined = not yet resolved
+
+async function findRg(): Promise<string | null> {
+  if (cachedRgPath !== undefined) return cachedRgPath;
+
+  const shellEnv = await getShellEnvironment();
+  const env = { ...process.env, ...shellEnv };
+
+  return new Promise((resolve) => {
+    execFile("which", ["rg"], { env }, (err, stdout) => {
+      cachedRgPath = err ? null : stdout.trim();
+      log("rg lookup: %s", cachedRgPath ?? "not found, using fallback");
+      resolve(cachedRgPath);
+    });
+  });
+}
+
+function rgSearch(rgPath: string, cwd: string, query: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "--files",
+      "--iglob",
+      `*${query}*`,
+      "--glob",
+      "!node_modules/**",
+      "--glob",
+      "!.git/**",
+      "--glob",
+      "!dist/**",
+      "--glob",
+      "!build/**",
+      cwd,
+    ];
+
+    execFile(rgPath, args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
+      if (err && !stdout) {
+        // rg exits with code 1 when no matches, which is fine
+        if (err.message.includes("exit code 1")) {
+          resolve([]);
+          return;
+        }
+        reject(err);
+        return;
+      }
+      const lines = stdout.split("\n").filter(Boolean);
+      const relativePaths = lines.map((p) => relative(cwd, p));
+      resolve(relativePaths);
+    });
+  });
+}
+
+async function fallbackSearch(cwd: string, query: string, maxResults: number): Promise<string[]> {
+  const results: string[] = [];
+  const lowerQuery = query.toLowerCase();
+
+  async function walk(dir: string) {
+    if (results.length > maxResults) return;
+
+    let entries;
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (results.length > maxResults) return;
+      if (EXCLUDED_DIRS.has(entry)) continue;
+
+      const fullPath = join(dir, entry);
+      let info;
+      try {
+        info = await stat(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (info.isDirectory()) {
+        await walk(fullPath);
+      } else {
+        const relPath = relative(cwd, fullPath);
+        if (relPath.toLowerCase().includes(lowerQuery)) {
+          results.push(relPath);
+        }
+      }
+    }
+  }
+
+  await walk(cwd);
+  return results;
+}
+
+export async function searchPaths(
+  cwd: string,
+  query: string,
+  maxResults = 100,
+): Promise<{ paths: string[]; truncated: boolean }> {
+  log("searchPaths cwd=%s query=%s maxResults=%d", cwd, query, maxResults);
+  const rgPath = await findRg();
+
+  let paths: string[];
+  if (rgPath) {
+    paths = await rgSearch(rgPath, cwd, query);
+  } else {
+    paths = await fallbackSearch(cwd, query, maxResults);
+  }
+
+  const truncated = paths.length > maxResults;
+  if (truncated) paths = paths.slice(0, maxResults);
+  paths.sort();
+
+  log("searchPaths result: %d paths, truncated=%s", paths.length, truncated);
+  return { paths, truncated };
+}

--- a/packages/desktop/src/renderer/src/features/acp/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/agent-chat.tsx
@@ -154,7 +154,7 @@ export function AgentChat() {
     return (
       <div className="flex h-full flex-col">
         <WelcomePanel />
-        <MessageInput onSend={handleSend} onCancel={() => {}} streaming={false} />
+        <MessageInput onSend={handleSend} onCancel={() => {}} streaming={false} cwd={cwd} />
       </div>
     );
   }
@@ -178,6 +178,7 @@ export function AgentChat() {
         onSend={handleSend}
         onCancel={handleCancel}
         streaming={activeSession.streaming}
+        cwd={cwd}
       />
     </div>
   );

--- a/packages/desktop/src/renderer/src/features/acp/components/mention-extension.ts
+++ b/packages/desktop/src/renderer/src/features/acp/components/mention-extension.ts
@@ -2,77 +2,103 @@ import Mention from "@tiptap/extension-mention";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import { createRoot } from "react-dom/client";
 import { createElement, createRef } from "react";
+import { File } from "lucide-react";
 import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
+import { client } from "../../../orpc";
+import { positionAboveInput } from "./suggestion-position";
 
-const MOCK_FILES: SuggestionItem[] = [
-  { label: "package.json" },
-  { label: "tsconfig.json" },
-  { label: "README.md" },
-];
+function fileName(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+}
 
-export const MentionExtension = Mention.configure({
-  HTMLAttributes: { class: "mention" },
-  suggestion: {
-    items: ({ query }: { query: string }) =>
-      MOCK_FILES.filter((f) => f.label.toLowerCase().includes(query.toLowerCase())),
-    render: () => {
-      let root: ReturnType<typeof createRoot> | null = null;
-      let container: HTMLDivElement | null = null;
-      const ref = createRef<SuggestionListHandle>();
+function dirName(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i <= 0 ? "" : p.slice(0, i);
+}
 
-      return {
-        onStart(props: SuggestionProps) {
-          container = document.createElement("div");
-          container.style.position = "absolute";
-          container.style.zIndex = "50";
-          container.dataset.suggestionPopup = "";
-          document.body.appendChild(container);
-          root = createRoot(container);
-          root.render(
-            createElement(SuggestionList, {
-              ref,
-              items: props.items as SuggestionItem[],
-              command: props.command as (item: SuggestionItem) => void,
-            }),
-          );
-          updatePosition(props, container);
-        },
-        onUpdate(props: SuggestionProps) {
-          root?.render(
-            createElement(SuggestionList, {
-              ref,
-              items: props.items as SuggestionItem[],
-              command: props.command as (item: SuggestionItem) => void,
-            }),
-          );
-          if (container) updatePosition(props, container);
-        },
-        onKeyDown(props: { event: KeyboardEvent }) {
-          if (props.event.key === "Escape") {
+export function createMentionExtension(getCwd: () => string) {
+  return Mention.configure({
+    HTMLAttributes: { class: "mention" },
+    suggestion: {
+      items: async ({ query }: { query: string }): Promise<SuggestionItem[]> => {
+        const cwd = getCwd();
+        console.debug("[mention] items called, cwd=%s query=%s", cwd, query);
+        if (!cwd) return [];
+
+        try {
+          const { paths } = await client.utils.searchPaths({
+            cwd,
+            query,
+            maxResults: 20,
+          });
+          console.debug("[mention] searchPaths returned %d results", paths.length);
+          return paths.map((p) => ({
+            id: p,
+            label: p,
+            title: fileName(p),
+            description: dirName(p),
+          }));
+        } catch (err) {
+          console.debug("[mention] searchPaths error", err);
+          return [];
+        }
+      },
+      render: () => {
+        let root: ReturnType<typeof createRoot> | null = null;
+        let container: HTMLDivElement | null = null;
+        const ref = createRef<SuggestionListHandle>();
+
+        return {
+          onStart(props: SuggestionProps) {
+            container = document.createElement("div");
+            container.style.position = "fixed";
+            container.style.zIndex = "50";
+            container.dataset.suggestionPopup = "";
+            document.body.appendChild(container);
+            root = createRoot(container);
+            root.render(
+              createElement(SuggestionList, {
+                ref,
+                items: props.items as SuggestionItem[],
+                command: props.command as (item: SuggestionItem) => void,
+                header: "Files",
+                icon: createElement(File, { className: "h-4 w-4" }),
+              }),
+            );
+            positionAboveInput(props.editor, container);
+          },
+          onUpdate(props: SuggestionProps) {
+            root?.render(
+              createElement(SuggestionList, {
+                ref,
+                items: props.items as SuggestionItem[],
+                command: props.command as (item: SuggestionItem) => void,
+                header: "Files",
+                icon: createElement(File, { className: "h-4 w-4" }),
+              }),
+            );
+            if (container) positionAboveInput(props.editor, container);
+          },
+          onKeyDown(props: { event: KeyboardEvent }) {
+            if (props.event.key === "Escape") {
+              cleanup();
+              return true;
+            }
+            return ref.current?.onKeyDown(props) ?? false;
+          },
+          onExit() {
             cleanup();
-            return true;
-          }
-          return ref.current?.onKeyDown(props) ?? false;
-        },
-        onExit() {
-          cleanup();
-        },
-      };
+          },
+        };
 
-      function cleanup() {
-        root?.unmount();
-        container?.remove();
-        root = null;
-        container = null;
-      }
+        function cleanup() {
+          root?.unmount();
+          container?.remove();
+          root = null;
+          container = null;
+        }
+      },
     },
-  },
-});
-
-function updatePosition(props: SuggestionProps, container: HTMLDivElement) {
-  const rect = props.clientRect?.();
-  if (rect) {
-    container.style.left = `${rect.left}px`;
-    container.style.top = `${rect.bottom + 4}px`;
-  }
+  });
 }

--- a/packages/desktop/src/renderer/src/features/acp/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/message-input.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Extension, useEditor, EditorContent } from "@tiptap/react";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
@@ -6,7 +6,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { Button } from "../../../components/ui/button";
 import { SendHorizonal, Square, Paperclip } from "lucide-react";
 import { SlashCommandsExtension } from "./slash-commands-extension";
-import { MentionExtension } from "./mention-extension";
+import { createMentionExtension } from "./mention-extension";
 import type { JSONContent } from "@tiptap/react";
 
 type Props = {
@@ -14,6 +14,7 @@ type Props = {
   onCancel: () => void;
   streaming: boolean;
   disabled?: boolean;
+  cwd: string;
 };
 
 function extractText(doc: JSONContent): string {
@@ -52,8 +53,12 @@ function extractText(doc: JSONContent): string {
   return parts.join("").trim();
 }
 
-export function MessageInput({ onSend, onCancel, streaming, disabled }: Props) {
+export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Props) {
   const sendRef = useRef<() => void>(() => {});
+  const cwdRef = useRef(cwd);
+  cwdRef.current = cwd;
+
+  const mentionExtension = useMemo(() => createMentionExtension(() => cwdRef.current), []);
 
   const send = useCallback(() => {
     sendRef.current();
@@ -70,7 +75,7 @@ export function MessageInput({ onSend, onCancel, streaming, disabled }: Props) {
       Placeholder.configure({
         placeholder: "Type a message...",
       }),
-      MentionExtension,
+      mentionExtension,
       SlashCommandsExtension,
       Extension.create({
         name: "chatKeymap",

--- a/packages/desktop/src/renderer/src/features/acp/components/slash-commands-extension.ts
+++ b/packages/desktop/src/renderer/src/features/acp/components/slash-commands-extension.ts
@@ -2,7 +2,9 @@ import { Node, type Editor, mergeAttributes } from "@tiptap/react";
 import Suggestion, { type SuggestionProps } from "@tiptap/suggestion";
 import { createRoot } from "react-dom/client";
 import { createElement, createRef } from "react";
+import { Terminal } from "lucide-react";
 import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
+import { positionAboveInput } from "./suggestion-position";
 
 const COMMANDS: SuggestionItem[] = [
   { label: "/clear", description: "Clear conversation" },
@@ -71,7 +73,7 @@ export const SlashCommandsExtension = Node.create({
           return {
             onStart(props: SuggestionProps<SuggestionItem>) {
               container = document.createElement("div");
-              container.style.position = "absolute";
+              container.style.position = "fixed";
               container.style.zIndex = "50";
               container.dataset.suggestionPopup = "";
               document.body.appendChild(container);
@@ -81,9 +83,11 @@ export const SlashCommandsExtension = Node.create({
                   ref,
                   items: props.items,
                   command: props.command,
+                  header: "Commands",
+                  icon: createElement(Terminal, { className: "h-4 w-4" }),
                 }),
               );
-              updatePosition(props, container);
+              positionAboveInput(props.editor, container);
             },
             onUpdate(props: SuggestionProps<SuggestionItem>) {
               root?.render(
@@ -91,9 +95,11 @@ export const SlashCommandsExtension = Node.create({
                   ref,
                   items: props.items,
                   command: props.command,
+                  header: "Commands",
+                  icon: createElement(Terminal, { className: "h-4 w-4" }),
                 }),
               );
-              if (container) updatePosition(props, container);
+              if (container) positionAboveInput(props.editor, container);
             },
             onKeyDown(props: { event: KeyboardEvent }) {
               if (props.event.key === "Escape") {
@@ -127,11 +133,3 @@ export const SlashCommandsExtension = Node.create({
     ];
   },
 });
-
-function updatePosition(props: SuggestionProps<SuggestionItem>, container: HTMLDivElement) {
-  const rect = props.clientRect?.();
-  if (rect) {
-    container.style.left = `${rect.left}px`;
-    container.style.top = `${rect.bottom + 4}px`;
-  }
-}

--- a/packages/desktop/src/renderer/src/features/acp/components/suggestion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/suggestion-list.tsx
@@ -1,65 +1,83 @@
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState, type ReactNode } from "react";
 
 export type SuggestionItem = {
+  id?: string;
   label: string;
+  title?: string;
   description?: string;
 };
 
 type Props = {
   items: SuggestionItem[];
   command: (item: SuggestionItem) => void;
+  header?: string;
+  icon?: ReactNode;
 };
 
 export type SuggestionListHandle = {
   onKeyDown: (event: { event: KeyboardEvent }) => boolean;
 };
 
-export const SuggestionList = forwardRef<SuggestionListHandle, Props>(({ items, command }, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+export const SuggestionList = forwardRef<SuggestionListHandle, Props>(
+  ({ items, command, header, icon }, ref) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
 
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [items]);
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items]);
 
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
-      if (event.key === "ArrowUp") {
-        setSelectedIndex((i) => (i + items.length - 1) % items.length);
-        return true;
-      }
-      if (event.key === "ArrowDown") {
-        setSelectedIndex((i) => (i + 1) % items.length);
-        return true;
-      }
-      if (event.key === "Enter" || event.key === "Tab") {
-        const item = items[selectedIndex];
-        if (item) command(item);
-        return true;
-      }
-      return false;
-    },
-  }));
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === "ArrowUp") {
+          setSelectedIndex((i) => (i + items.length - 1) % items.length);
+          return true;
+        }
+        if (event.key === "ArrowDown") {
+          setSelectedIndex((i) => (i + 1) % items.length);
+          return true;
+        }
+        if (event.key === "Enter" || event.key === "Tab") {
+          const item = items[selectedIndex];
+          if (item) command(item);
+          return true;
+        }
+        return false;
+      },
+    }));
 
-  if (!items.length) return null;
+    if (!items.length) return null;
 
-  return (
-    <div className="border bg-popover text-popover-foreground rounded-lg shadow-md overflow-hidden p-1">
-      {items.map((item, index) => (
-        <button
-          key={item.label}
-          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left ${
-            index === selectedIndex ? "bg-accent" : ""
-          }`}
-          onClick={() => command(item)}
-          onMouseEnter={() => setSelectedIndex(index)}
-          type="button"
-        >
-          <span className="font-medium">{item.label}</span>
-          {item.description && <span className="text-muted-foreground">{item.description}</span>}
-        </button>
-      ))}
-    </div>
-  );
-});
+    return (
+      <div className="border border-b-0 bg-popover text-popover-foreground rounded-t-lg shadow-md overflow-hidden max-h-[300px] flex flex-col">
+        {header && (
+          <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground border-b border-border/50 shrink-0">
+            {header}
+          </div>
+        )}
+        <div className="p-1 overflow-y-auto">
+          {items.map((item, index) => (
+            <button
+              key={item.id ?? item.label}
+              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left ${
+                index === selectedIndex ? "bg-accent" : ""
+              }`}
+              onClick={() => command(item)}
+              onMouseEnter={() => setSelectedIndex(index)}
+              type="button"
+            >
+              {icon && <span className="shrink-0 text-muted-foreground">{icon}</span>}
+              <span className="truncate">{item.title ?? item.label}</span>
+              {item.description && (
+                <span className="ml-auto shrink-0 text-muted-foreground text-xs">
+                  {item.description}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
 
 SuggestionList.displayName = "SuggestionList";

--- a/packages/desktop/src/renderer/src/features/acp/components/suggestion-position.ts
+++ b/packages/desktop/src/renderer/src/features/acp/components/suggestion-position.ts
@@ -1,0 +1,20 @@
+import type { Editor } from "@tiptap/react";
+
+/**
+ * Position a suggestion popup above the input container, full width.
+ * Walks up from the editor DOM to find the `.border-t` wrapper
+ * (the MessageInput root div), then anchors the popup's bottom edge
+ * to the wrapper's top edge.
+ */
+export function positionAboveInput(editor: Editor, container: HTMLDivElement) {
+  let el: HTMLElement | null = editor.view.dom;
+  while (el && !el.classList.contains("border-t")) {
+    el = el.parentElement;
+  }
+  if (!el) return;
+
+  const rect = el.getBoundingClientRect();
+  container.style.left = `${rect.left}px`;
+  container.style.bottom = `${window.innerHeight - rect.top}px`;
+  container.style.width = `${rect.width}px`;
+}

--- a/packages/desktop/src/shared/features/utils/contract.ts
+++ b/packages/desktop/src/shared/features/utils/contract.ts
@@ -23,4 +23,14 @@ export const utilsContract = {
     .output(type<{ success: boolean }>()),
 
   detectApps: oc.output(type<{ apps: App[] }>()),
+
+  searchPaths: oc
+    .input(
+      z.object({
+        cwd: z.string(),
+        query: z.string(),
+        maxResults: z.number().optional(),
+      }),
+    )
+    .output(type<{ paths: string[]; truncated: boolean }>()),
 };


### PR DESCRIPTION
Added a utils.searchPaths RPC that searches for matching file paths (using ripgrep with a filesystem fallback) and exposed it via the main utils router. Updated the chat input mention and slash-command suggestion popups to use a shared positioning helper, improved suggestion list UI, and passed cwd through MessageInput to power file suggestions.

<img width="841" height="420" alt="image" src="https://github.com/user-attachments/assets/dafa6803-e00f-43de-9451-5cc3d271add2" />
