### PR TITLE
feat: stream available slash commands per acp session

### DIFF
--- a/packages/desktop/src/main/features/acp/connection.ts
+++ b/packages/desktop/src/main/features/acp/connection.ts
@@ -9,6 +9,7 @@ import { EventPublisher } from "@orpc/server";
 import debug from "debug";
 import type { StreamEvent, LoadSessionResult } from "../../../shared/features/acp/types";
 
+const connLog = debug("neovate:acp-connection");
 const preloadLog = debug("neovate:acp-preload");
 
 /** Auto-cancel permission requests after 5 minutes of no UI response. */
@@ -19,6 +20,7 @@ function eventBelongsToSession(event: StreamEvent, sessionId: string): boolean {
     case "acpx_event":
       return event.event.session_id === sessionId;
     case "user_message":
+    case "available_commands":
       return event.sessionId === sessionId;
     case "permission_request":
       return event.data.sessionId === sessionId;
@@ -62,6 +64,7 @@ export class AcpConnection {
   private preloadedSessions = new Map<string, PreloadedSession>();
   private preloadPromises = new Map<string, Promise<void>>();
   private activePreload: string | null = null;
+  private commandsBySession = new Map<string, string[]>();
 
   constructor(id: string) {
     this.id = id;
@@ -79,6 +82,7 @@ export class AcpConnection {
   emitSessionUpdate(notification: SessionNotification): void {
     const update = notification.update;
     const sid = notification.sessionId;
+    connLog("[%s] sessionUpdate type=%s sid=%s", this.id, update.sessionUpdate, sid);
 
     if (update.sessionUpdate === "user_message_chunk" && update.content.type === "text") {
       this.publisher.publish("session", {
@@ -89,11 +93,29 @@ export class AcpConnection {
       return;
     }
 
+    if (update.sessionUpdate === "available_commands_update") {
+      const commands = update.availableCommands
+        .map((entry: { name: string }) => entry.name)
+        .filter((name: string) => typeof name === "string" && name.trim().length > 0);
+      connLog("[%s] available_commands_update sid=%s commands=%o", this.id, sid, commands);
+      this.commandsBySession.set(sid, commands);
+      this.publisher.publish("session", {
+        type: "available_commands",
+        sessionId: sid,
+        commands,
+      });
+      return;
+    }
+
     const drafts = sessionUpdateToEventDrafts(notification);
     for (const draft of drafts) {
       const event = createAcpxEvent({ sessionId: sid, seq: this.seq++ }, draft);
       this.publisher.publish("session", { type: "acpx_event", event });
     }
+  }
+
+  getAvailableCommands(sessionId: string): string[] {
+    return this.commandsBySession.get(sessionId) ?? [];
   }
 
   handlePermissionRequest(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {

--- a/packages/desktop/src/main/features/acp/router.ts
+++ b/packages/desktop/src/main/features/acp/router.ts
@@ -123,13 +123,19 @@ export const acpRouter = os.acp.router({
     manager.setSessionRecord(input.connectionId, record);
     writeSessionRecord(record).catch(() => {});
 
+    const commands = conn.getAvailableCommands(result.sessionId);
     const elapsed = Math.round(performance.now() - t0);
     acpLog("newSession: success in %dms", elapsed, {
       connectionId: input.connectionId,
       sessionId: result.sessionId,
       agentSessionId: result.agentSessionId,
+      commands,
     });
-    return { sessionId: result.sessionId, agentSessionId: result.agentSessionId };
+    return {
+      sessionId: result.sessionId,
+      agentSessionId: result.agentSessionId,
+      commands: commands.length > 0 ? commands : undefined,
+    };
   }),
 
   listSessions: os.acp.listSessions.handler(async ({ input, context }) => {

--- a/packages/desktop/src/renderer/src/features/acp/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/acp/components/message-input.tsx
@@ -5,8 +5,9 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Button } from "../../../components/ui/button";
 import { SendHorizonal, Square, Paperclip } from "lucide-react";
-import { SlashCommandsExtension } from "./slash-commands-extension";
+import { createSlashCommandsExtension } from "./slash-commands-extension";
 import { createMentionExtension } from "./mention-extension";
+import { useAcpStore } from "../store";
 import type { JSONContent } from "@tiptap/react";
 
 type Props = {
@@ -60,6 +61,16 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
 
   const mentionExtension = useMemo(() => createMentionExtension(() => cwdRef.current), []);
 
+  const slashCommandsExtension = useMemo(
+    () =>
+      createSlashCommandsExtension(() => {
+        const { activeSessionId, sessions } = useAcpStore.getState();
+        if (!activeSessionId) return [];
+        return sessions.get(activeSessionId)?.availableCommands ?? [];
+      }),
+    [],
+  );
+
   const send = useCallback(() => {
     sendRef.current();
   }, []);
@@ -76,7 +87,7 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
         placeholder: "Type a message...",
       }),
       mentionExtension,
-      SlashCommandsExtension,
+      slashCommandsExtension,
       Extension.create({
         name: "chatKeymap",
         addProseMirrorPlugins() {

--- a/packages/desktop/src/renderer/src/features/acp/components/slash-commands-extension.ts
+++ b/packages/desktop/src/renderer/src/features/acp/components/slash-commands-extension.ts
@@ -5,131 +5,137 @@ import { createElement, createRef } from "react";
 import { Terminal } from "lucide-react";
 import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
 import { positionAboveInput } from "./suggestion-position";
+import debug from "debug";
 
-const COMMANDS: SuggestionItem[] = [
-  { label: "/clear", description: "Clear conversation" },
-  { label: "/compact", description: "Compact history" },
-  { label: "/help", description: "Show help" },
-];
+const slashLog = debug("neovate:slash-commands");
 
-export const SlashCommandsExtension = Node.create({
-  name: "slashCommand",
-  group: "inline",
-  inline: true,
-  atom: true,
+export function createSlashCommandsExtension(getCommands: () => string[]) {
+  return Node.create({
+    name: "slashCommand",
+    group: "inline",
+    inline: true,
+    atom: true,
 
-  addAttributes() {
-    return {
-      label: { default: null },
-    };
-  },
+    addAttributes() {
+      return {
+        label: { default: null },
+      };
+    },
 
-  parseHTML() {
-    return [{ tag: "span[data-slash-command]" }];
-  },
+    parseHTML() {
+      return [{ tag: "span[data-slash-command]" }];
+    },
 
-  renderHTML({ node, HTMLAttributes }) {
-    return [
-      "span",
-      mergeAttributes(HTMLAttributes, {
-        "data-slash-command": "",
-        class: "slash-command",
-      }),
-      node.attrs.label,
-    ];
-  },
+    renderHTML({ node, HTMLAttributes }) {
+      return [
+        "span",
+        mergeAttributes(HTMLAttributes, {
+          "data-slash-command": "",
+          class: "slash-command",
+        }),
+        node.attrs.label,
+      ];
+    },
 
-  addOptions() {
-    return {
-      suggestion: {
-        char: "/",
-        startOfLine: true,
-        items: ({ query }: { query: string }) =>
-          COMMANDS.filter((c) => c.label.toLowerCase().includes(query.toLowerCase())),
-        command: ({
-          editor,
-          range,
-          props,
-        }: {
-          editor: Editor;
-          range: { from: number; to: number };
-          props: SuggestionItem;
-        }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .insertContent([
-              { type: "slashCommand", attrs: { label: props.label } },
-              { type: "text", text: " " },
-            ])
-            .run();
-        },
-        render: () => {
-          let root: ReturnType<typeof createRoot> | null = null;
-          let container: HTMLDivElement | null = null;
-          const ref = createRef<SuggestionListHandle>();
+    addOptions() {
+      return {
+        suggestion: {
+          char: "/",
+          startOfLine: true,
+          items: ({ query }: { query: string }): SuggestionItem[] => {
+            const commands = getCommands();
+            slashLog("items query=%s commands=%o", query, commands);
+            const items: SuggestionItem[] = commands.map((name) => ({
+              label: `/${name}`,
+            }));
+            if (!query) return items;
+            return items.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()));
+          },
+          command: ({
+            editor,
+            range,
+            props,
+          }: {
+            editor: Editor;
+            range: { from: number; to: number };
+            props: SuggestionItem;
+          }) => {
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertContent([
+                { type: "slashCommand", attrs: { label: props.label } },
+                { type: "text", text: " " },
+              ])
+              .run();
+          },
+          render: () => {
+            let root: ReturnType<typeof createRoot> | null = null;
+            let container: HTMLDivElement | null = null;
+            const ref = createRef<SuggestionListHandle>();
 
-          return {
-            onStart(props: SuggestionProps<SuggestionItem>) {
-              container = document.createElement("div");
-              container.style.position = "fixed";
-              container.style.zIndex = "50";
-              container.dataset.suggestionPopup = "";
-              document.body.appendChild(container);
-              root = createRoot(container);
-              root.render(
-                createElement(SuggestionList, {
-                  ref,
-                  items: props.items,
-                  command: props.command,
-                  header: "Commands",
-                  icon: createElement(Terminal, { className: "h-4 w-4" }),
-                }),
-              );
-              positionAboveInput(props.editor, container);
-            },
-            onUpdate(props: SuggestionProps<SuggestionItem>) {
-              root?.render(
-                createElement(SuggestionList, {
-                  ref,
-                  items: props.items,
-                  command: props.command,
-                  header: "Commands",
-                  icon: createElement(Terminal, { className: "h-4 w-4" }),
-                }),
-              );
-              if (container) positionAboveInput(props.editor, container);
-            },
-            onKeyDown(props: { event: KeyboardEvent }) {
-              if (props.event.key === "Escape") {
+            return {
+              onStart(props: SuggestionProps<SuggestionItem>) {
+                container = document.createElement("div");
+                container.style.position = "fixed";
+                container.style.zIndex = "50";
+                container.dataset.suggestionPopup = "";
+                document.body.appendChild(container);
+                root = createRoot(container);
+                root.render(
+                  createElement(SuggestionList, {
+                    ref,
+                    items: props.items,
+                    command: props.command,
+                    header: "Commands",
+                    icon: createElement(Terminal, { className: "h-4 w-4" }),
+                  }),
+                );
+                positionAboveInput(props.editor, container);
+              },
+              onUpdate(props: SuggestionProps<SuggestionItem>) {
+                root?.render(
+                  createElement(SuggestionList, {
+                    ref,
+                    items: props.items,
+                    command: props.command,
+                    header: "Commands",
+                    icon: createElement(Terminal, { className: "h-4 w-4" }),
+                  }),
+                );
+                if (container) positionAboveInput(props.editor, container);
+              },
+              onKeyDown(props: { event: KeyboardEvent }) {
+                if (props.event.key === "Escape") {
+                  cleanup();
+                  return true;
+                }
+                return ref.current?.onKeyDown(props) ?? false;
+              },
+              onExit() {
                 cleanup();
-                return true;
-              }
-              return ref.current?.onKeyDown(props) ?? false;
-            },
-            onExit() {
-              cleanup();
-            },
-          };
+              },
+            };
 
-          function cleanup() {
-            root?.unmount();
-            container?.remove();
-            root = null;
-            container = null;
-          }
+            function cleanup() {
+              root?.unmount();
+              container?.remove();
+              root = null;
+              container = null;
+            }
+          },
         },
-      },
-    };
-  },
+      };
+    },
 
-  addProseMirrorPlugins() {
-    return [
-      Suggestion({
-        editor: this.editor,
-        ...this.options.suggestion,
-      }),
-    ];
-  },
-});
+    addProseMirrorPlugins() {
+      return [
+        Suggestion({
+          editor: this.editor,
+          ...this.options.suggestion,
+        }),
+      ];
+    },
+  });
+}

--- a/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-prompt.ts
+++ b/packages/desktop/src/renderer/src/features/acp/hooks/use-acp-prompt.ts
@@ -13,6 +13,7 @@ export function useAcpPrompt() {
   const appendChunk = useAcpStore((s) => s.appendChunk);
   const setStreaming = useAcpStore((s) => s.setStreaming);
   const createSession = useAcpStore((s) => s.createSession);
+  const setAvailableCommands = useAcpStore((s) => s.setAvailableCommands);
   const addTiming = useAcpStore((s) => s.addTiming);
 
   useEffect(() => {
@@ -29,7 +30,7 @@ export function useAcpPrompt() {
       if (!resolvedSessionId) {
         const sessionStart = performance.now();
         acpPromptLog("sendPrompt: creating session", { connectionId });
-        const { sessionId: newSessionId } = await client.acp.newSession({
+        const { sessionId: newSessionId, commands } = await client.acp.newSession({
           connectionId,
         });
         resolvedSessionId = newSessionId;
@@ -37,6 +38,7 @@ export function useAcpPrompt() {
         acpPromptLog("sendPrompt: session created in %dms", sessionElapsed, {
           connectionId,
           sessionId: resolvedSessionId,
+          commands,
         });
         addTiming({
           phase: "prompt",
@@ -51,6 +53,9 @@ export function useAcpPrompt() {
           connectionId,
           projectPath ? { cwd: projectPath } : undefined,
         );
+        if (commands?.length) {
+          setAvailableCommands(resolvedSessionId, commands);
+        }
       }
 
       acpPromptLog("sendPrompt: start", {
@@ -147,7 +152,7 @@ export function useAcpPrompt() {
         acpPromptLog("sendPrompt: cleanup", { connectionId, sessionId: resolvedSessionId });
       }
     },
-    [addUserMessage, appendChunk, setStreaming, createSession, addTiming],
+    [addUserMessage, appendChunk, setStreaming, createSession, setAvailableCommands, addTiming],
   );
 
   const cancel = useCallback(async (connectionId: string, sessionId: string) => {

--- a/packages/desktop/src/renderer/src/features/acp/store.ts
+++ b/packages/desktop/src/renderer/src/features/acp/store.ts
@@ -8,6 +8,9 @@ import type {
   TimingEntry,
 } from "../../../../shared/features/acp/types";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import debug from "debug";
+
+const storeLog = debug("neovate:acp-store");
 
 enableMapSet();
 
@@ -41,6 +44,7 @@ export type AcpSession = {
   streaming: boolean;
   promptError: string | null;
   pendingPermission: PendingPermission | null;
+  availableCommands: string[];
 };
 
 type AcpState = {
@@ -69,6 +73,7 @@ type AcpState = {
   setStreaming: (sessionId: string, streaming: boolean) => void;
   setPromptError: (sessionId: string, error: string | null) => void;
   setPendingPermission: (sessionId: string, perm: PendingPermission | null) => void;
+  setAvailableCommands: (sessionId: string, commands: string[]) => void;
   appendChunk: (sessionId: string, event: StreamEvent) => void;
   addTiming: (entry: TimingEntry) => void;
   clearTimings: () => void;
@@ -116,6 +121,7 @@ export const useAcpStore = create<AcpState>()(
           streaming: false,
           promptError: null,
           pendingPermission: null,
+          availableCommands: [],
         });
         state.activeSessionId = sessionId;
       });
@@ -167,6 +173,14 @@ export const useAcpStore = create<AcpState>()(
       });
     },
 
+    setAvailableCommands: (sessionId, commands) => {
+      storeLog("setAvailableCommands sid=%s commands=%o", sessionId, commands);
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (session) session.availableCommands = commands;
+      });
+    },
+
     addTiming: (entry) => {
       set((state) => {
         state.timings.push(entry);
@@ -190,6 +204,12 @@ export const useAcpStore = create<AcpState>()(
             requestId: event.requestId,
             data: event.data,
           };
+          return;
+        }
+
+        if (event.type === "available_commands") {
+          storeLog("appendChunk: available_commands sid=%s commands=%o", sessionId, event.commands);
+          session.availableCommands = event.commands;
           return;
         }
 

--- a/packages/desktop/src/shared/features/acp/contract.ts
+++ b/packages/desktop/src/shared/features/acp/contract.ts
@@ -25,7 +25,9 @@ export const acpContract = {
   newSession: oc
     .input(z.object({ connectionId: z.string(), cwd: z.string().optional() }))
     .errors(connectionNotFoundError)
-    .output(type<{ sessionId: string; agentSessionId?: string; modes?: string[] }>()),
+    .output(
+      type<{ sessionId: string; agentSessionId?: string; modes?: string[]; commands?: string[] }>(),
+    ),
 
   listSessions: oc
     .input(z.object({ connectionId: z.string() }))

--- a/packages/desktop/src/shared/features/acp/types.ts
+++ b/packages/desktop/src/shared/features/acp/types.ts
@@ -22,7 +22,8 @@ export type StreamEvent =
       requestId: string;
       data: RequestPermissionRequest;
     }
-  | { type: "timing"; entry: TimingEntry };
+  | { type: "timing"; entry: TimingEntry }
+  | { type: "available_commands"; sessionId: string; commands: string[] };
 
 /** Lightweight session metadata for the sidebar list */
 export type SessionInfo = {


### PR DESCRIPTION
Track and publish per-session available command updates from ACP and persist them in the renderer store. Wire the new commands list into slash command suggestions and include initial commands in the newSession response.

Still has problem: https://github.com/neovateai/neovate-desktop/issues/37