### PR TITLE
feat: add session cache and skip replay on resume

### DIFF
--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -3,6 +3,10 @@ import debug from "debug";
 import { agentContract } from "../../../shared/features/agent/contract";
 import type { StreamEvent } from "../../../shared/features/agent/types";
 import type { AppContext } from "../../router";
+import {
+  loadSessionCache as readSessionCache,
+  saveSessionCache as writeSessionCache,
+} from "./session-cache";
 
 const agentLog = debug("neovate:agent-router");
 
@@ -70,6 +74,7 @@ export const agentRouter = os.agent.router({
         input.sessionId,
         input.cwd,
         emitter,
+        input.skipReplay,
       )) {
         eventCount += 1;
         if (!firstEventAt) {
@@ -198,6 +203,16 @@ export const agentRouter = os.agent.router({
     yield timingEntry("prompt", "time_to_first_event", ttfe);
     yield timingEntry("prompt", "total", totalMs);
     return { stopReason: "end_turn" };
+  }),
+
+  getSessionCache: os.agent.getSessionCache.handler(async ({ input }) => {
+    agentLog("getSessionCache: sessionId=%s", input.sessionId);
+    return readSessionCache(input.sessionId);
+  }),
+
+  saveSessionCache: os.agent.saveSessionCache.handler(async ({ input }) => {
+    agentLog("saveSessionCache: sessionId=%s msgs=%d", input.sessionId, input.data.messages.length);
+    writeSessionCache(input.sessionId, input.data);
   }),
 
   resolvePermission: os.agent.resolvePermission.handler(({ input, context }) => {

--- a/packages/desktop/src/main/features/agent/session-cache.ts
+++ b/packages/desktop/src/main/features/agent/session-cache.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import debug from "debug";
+import type { CachedSession } from "../../../shared/features/agent/types";
+
+const log = debug("neovate:session-cache");
+
+const CACHE_DIR = path.join(os.homedir(), ".neovate-desktop", "session-cache");
+
+function ensureCacheDir(): void {
+  if (!fs.existsSync(CACHE_DIR)) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    log("ensureCacheDir: created %s", CACHE_DIR);
+  }
+}
+
+function cachePath(sessionId: string): string {
+  return path.join(CACHE_DIR, `${sessionId}.json`);
+}
+
+export function saveSessionCache(sessionId: string, data: CachedSession): void {
+  const t0 = performance.now();
+  try {
+    ensureCacheDir();
+    const filePath = cachePath(sessionId);
+    fs.writeFileSync(filePath, JSON.stringify(data), "utf-8");
+    log(
+      "saveSessionCache: DONE sessionId=%s msgs=%d in %dms",
+      sessionId.slice(0, 8),
+      data.messages.length,
+      Math.round(performance.now() - t0),
+    );
+  } catch (error) {
+    log(
+      "saveSessionCache: ERROR sessionId=%s error=%s",
+      sessionId.slice(0, 8),
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+export function loadSessionCache(sessionId: string): CachedSession | null {
+  const t0 = performance.now();
+  const filePath = cachePath(sessionId);
+  try {
+    if (!fs.existsSync(filePath)) {
+      log("loadSessionCache: MISS sessionId=%s", sessionId.slice(0, 8));
+      return null;
+    }
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw) as CachedSession;
+    log(
+      "loadSessionCache: HIT sessionId=%s msgs=%d in %dms",
+      sessionId.slice(0, 8),
+      data.messages.length,
+      Math.round(performance.now() - t0),
+    );
+    return data;
+  } catch (error) {
+    log(
+      "loadSessionCache: ERROR sessionId=%s error=%s",
+      sessionId.slice(0, 8),
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+}

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -261,9 +261,10 @@ export class SessionManager {
     sessionId: string,
     cwd?: string,
     emitter?: (event: StreamEvent) => void,
+    skipReplay?: boolean,
   ): AsyncGenerator<StreamEvent> {
     const t0 = performance.now();
-    log("loadSession: START sessionId=%s cwd=%s", sessionId, cwd);
+    log("loadSession: START sessionId=%s cwd=%s skipReplay=%s", sessionId, cwd, !!skipReplay);
 
     const resolvedCwd = cwd ?? process.cwd();
     const options = await this.buildOptions(resolvedCwd);
@@ -296,15 +297,19 @@ export class SessionManager {
         yield { type: "available_commands", sessionId, commands };
       }
 
-      // Replay history from persisted messages
-      const messages = await getSessionMessages(sessionId);
-      log("loadSession: replaying %d historical messages", messages.length);
+      // Replay history from persisted messages (skip if renderer has cache)
+      if (!skipReplay) {
+        const messages = await getSessionMessages(sessionId);
+        log("loadSession: replaying %d historical messages", messages.length);
 
-      for (const msg of messages) {
-        for (const event of this.convertReplayMessage(sessionId, msg)) {
-          eventCount++;
-          yield event;
+        for (const msg of messages) {
+          for (const event of this.convertReplayMessage(sessionId, msg)) {
+            eventCount++;
+            yield event;
+          }
         }
+      } else {
+        log("loadSession: skipReplay=true, skipping message replay");
       }
     } catch (error) {
       log(

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -133,6 +133,8 @@ export function SessionList() {
   const createSession = useAgentStore((s) => s.createSession);
   const removeSession = useAgentStore((s) => s.removeSession);
   const appendChunk = useAgentStore((s) => s.appendChunk);
+  const restoreFromCache = useAgentStore((s) => s.restoreFromCache);
+  const setSdkReady = useAgentStore((s) => s.setSdkReady);
 
   const activeProject = useProjectStore((s) => s.activeProject);
   const archivedSessions = useProjectStore((s) => s.archivedSessions);
@@ -174,18 +176,47 @@ export function SessionList() {
       listLog("loadSession: START sid=%s cwd=%s", sessionId.slice(0, 8), activeProject?.path);
       const t0 = performance.now();
       setRestoring(sessionId);
+
+      const info = agentSessions.find((s) => s.sessionId === sessionId);
+      listLog(
+        "loadSession: info=%o",
+        info ? { title: info.title, cwd: info.cwd } : "not found in agentSessions",
+      );
+      createSession(
+        sessionId,
+        info ? { title: info.title, createdAt: info.createdAt, cwd: info.cwd } : undefined,
+      );
+
+      // Phase 1: Try loading from cache for instant display
+      let hasCachedMessages = false;
       try {
-        const info = agentSessions.find((s) => s.sessionId === sessionId);
+        const cached = await client.agent.getSessionCache({ sessionId });
+        if (cached && cached.messages.length > 0) {
+          restoreFromCache(sessionId, cached);
+          hasCachedMessages = true;
+          listLog(
+            "loadSession: cache HIT sid=%s msgs=%d in %dms",
+            sessionId.slice(0, 8),
+            cached.messages.length,
+            Math.round(performance.now() - t0),
+          );
+          // Stop showing "Restoring..." since messages are visible now
+          setRestoring((prev) => (prev === sessionId ? null : prev));
+        } else {
+          listLog("loadSession: cache MISS sid=%s", sessionId.slice(0, 8));
+        }
+      } catch (error) {
         listLog(
-          "loadSession: info=%o",
-          info ? { title: info.title, cwd: info.cwd } : "not found in agentSessions",
+          "loadSession: cache read error sid=%s error=%s",
+          sessionId.slice(0, 8),
+          error instanceof Error ? error.message : String(error),
         );
-        createSession(
-          sessionId,
-          info ? { title: info.title, createdAt: info.createdAt, cwd: info.cwd } : undefined,
-        );
+      }
+
+      // Phase 2: Resume SDK session (skip replay if we loaded from cache)
+      try {
         const iterator = await client.agent.loadSession(
-          { sessionId, cwd: activeProject?.path },
+          { sessionId, cwd: activeProject?.path, skipReplay: hasCachedMessages },
           { signal: ac.signal },
         );
         let eventCount = 0;
@@ -193,20 +224,47 @@ export function SessionList() {
           eventCount++;
           appendChunk(sessionId, event);
         }
+        setSdkReady(sessionId, true);
         listLog(
-          "loadSession: DONE sid=%s in %dms events=%d",
+          "loadSession: SDK ready sid=%s in %dms events=%d cached=%s",
           sessionId.slice(0, 8),
           Math.round(performance.now() - t0),
           eventCount,
+          hasCachedMessages,
         );
+
+        // Save cache for future loads (always save to keep it fresh)
+        const session = useAgentStore.getState().sessions.get(sessionId);
+        if (session && session.messages.length > 0) {
+          client.agent.saveSessionCache({
+            sessionId,
+            data: {
+              messages: session.messages.map((m) => ({
+                id: m.id,
+                role: m.role,
+                content: m.content,
+                thinking: m.thinking,
+              })),
+              title: session.title,
+              cwd: session.cwd,
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        }
       } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
         listLog(
           "loadSession: FAILED sid=%s in %dms error=%s",
           sessionId.slice(0, 8),
           Math.round(performance.now() - t0),
           error instanceof Error ? error.message : String(error),
         );
-        removeSession(sessionId);
+        // Only remove session if we didn't already show cached messages
+        if (!hasCachedMessages) {
+          removeSession(sessionId);
+        }
       } finally {
         if (loadAbortRef.current === ac) {
           loadAbortRef.current = null;
@@ -220,6 +278,8 @@ export function SessionList() {
       createSession,
       removeSession,
       appendChunk,
+      restoreFromCache,
+      setSdkReady,
       agentSessions,
       activeProject?.path,
     ],

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
@@ -22,9 +22,21 @@ export function useNewSession() {
         }
       }
 
+      const startActiveId = activeSessionId;
       newSessionLog("createNewSession: creating session cwd=%s", cwd);
       const { sessionId, commands } = await client.agent.newSession({ cwd });
       newSessionLog("createNewSession: created %s", sessionId);
+
+      // Guard: if user navigated to another session during the async gap, don't steal focus
+      const currentActiveId = useAgentStore.getState().activeSessionId;
+      if (currentActiveId !== startActiveId && currentActiveId !== null) {
+        newSessionLog(
+          "createNewSession: user navigated away (was=%s now=%s), skipping activation",
+          startActiveId,
+          currentActiveId,
+        );
+        return sessionId;
+      }
 
       const projectPath = useProjectStore.getState().activeProject?.path;
       createSession(sessionId, {

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-prompt.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-prompt.ts
@@ -58,6 +58,27 @@ export function usePrompt() {
       addUserMessage(resolvedSessionId, prompt);
       setStreaming(resolvedSessionId, true);
 
+      // Wait for SDK to be ready (may be resuming in background)
+      const currentSession = useAgentStore.getState().sessions.get(resolvedSessionId);
+      if (currentSession && !currentSession.sdkReady) {
+        promptLog("sendPrompt: waiting for SDK ready sid=%s", resolvedSessionId);
+        await new Promise<void>((resolve) => {
+          const unsub = useAgentStore.subscribe((state) => {
+            const s = state.sessions.get(resolvedSessionId!);
+            if (s?.sdkReady) {
+              unsub();
+              resolve();
+            }
+          });
+          // Check again in case it became ready between our check and subscribe
+          if (useAgentStore.getState().sessions.get(resolvedSessionId!)?.sdkReady) {
+            unsub();
+            resolve();
+          }
+        });
+        promptLog("sendPrompt: SDK now ready sid=%s", resolvedSessionId);
+      }
+
       const ac = new AbortController();
       abortRef.current = ac;
 
@@ -127,6 +148,25 @@ export function usePrompt() {
       } finally {
         setStreaming(resolvedSessionId, false);
         abortRef.current = null;
+
+        // Save session cache for instant restore on next load
+        const session = useAgentStore.getState().sessions.get(resolvedSessionId!);
+        if (session && session.messages.length > 0) {
+          client.agent.saveSessionCache({
+            sessionId: resolvedSessionId!,
+            data: {
+              messages: session.messages.map((m) => ({
+                id: m.id,
+                role: m.role,
+                content: m.content,
+                thinking: m.thinking,
+              })),
+              title: session.title,
+              cwd: session.cwd,
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        }
       }
     },
     [addUserMessage, appendChunk, setStreaming, createSession, setAvailableCommands, addTiming],

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -6,6 +6,7 @@ import type {
   StreamEvent,
   TimingEntry,
   SlashCommandInfo,
+  CachedSession,
 } from "../../../../shared/features/agent/types";
 import debug from "debug";
 
@@ -44,6 +45,7 @@ export type ChatSession = {
   promptError: string | null;
   pendingPermission: PendingPermission | null;
   availableCommands: SlashCommandInfo[];
+  sdkReady: boolean;
 };
 
 type AgentState = {
@@ -66,6 +68,8 @@ type AgentState = {
   setPendingPermission: (sessionId: string, perm: PendingPermission | null) => void;
   setAvailableCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
   appendChunk: (sessionId: string, event: StreamEvent) => void;
+  restoreFromCache: (sessionId: string, cached: CachedSession) => void;
+  setSdkReady: (sessionId: string, ready: boolean) => void;
   addTiming: (entry: TimingEntry) => void;
   clearTimings: () => void;
 };
@@ -103,6 +107,7 @@ export const useAgentStore = create<AgentState>()(
           promptError: null,
           pendingPermission: null,
           availableCommands: [],
+          sdkReady: true,
         });
         state.activeSessionId = sessionId;
         storeLog("createSession: totalSessions=%d active=%s", state.sessions.size, sessionId);
@@ -203,6 +208,37 @@ export const useAgentStore = create<AgentState>()(
     },
 
     clearTimings: () => set({ timings: [] }),
+
+    restoreFromCache: (sessionId, cached) => {
+      storeLog(
+        "restoreFromCache: sid=%s msgs=%d title=%s",
+        sessionId,
+        cached.messages.length,
+        cached.title,
+      );
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (!session) {
+          storeLog("restoreFromCache: WARNING session not found sid=%s", sessionId);
+          return;
+        }
+        session.messages = cached.messages.map((m) => {
+          state._nextMessageId += 1;
+          return { ...m, id: String(state._nextMessageId) };
+        });
+        if (cached.title) session.title = cached.title;
+        if (cached.cwd) session.cwd = cached.cwd;
+        session.sdkReady = false;
+      });
+    },
+
+    setSdkReady: (sessionId, ready) => {
+      storeLog("setSdkReady: sid=%s ready=%s", sessionId, ready);
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (session) session.sdkReady = ready;
+      });
+    },
 
     appendChunk: (sessionId, event) => {
       set((state) => {

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -6,6 +6,7 @@ import type {
   LoadSessionResult,
   PromptResult,
   SlashCommandInfo,
+  CachedSession,
 } from "./types";
 
 const promptErrorDataSchema = type<{
@@ -21,8 +22,22 @@ export const agentContract = {
     .output(type<{ sessionId: string; commands?: SlashCommandInfo[] }>()),
 
   loadSession: oc
-    .input(z.object({ sessionId: z.string(), cwd: z.string().optional() }))
+    .input(
+      z.object({
+        sessionId: z.string(),
+        cwd: z.string().optional(),
+        skipReplay: z.boolean().optional(),
+      }),
+    )
     .output(eventIterator(type<StreamEvent>(), type<LoadSessionResult>())),
+
+  getSessionCache: oc
+    .input(z.object({ sessionId: z.string() }))
+    .output(type<CachedSession | null>()),
+
+  saveSessionCache: oc
+    .input(type<{ sessionId: string; data: CachedSession }>())
+    .output(type<void>()),
 
   prompt: oc
     .input(z.object({ sessionId: z.string(), prompt: z.string() }))

--- a/packages/desktop/src/shared/features/agent/types.ts
+++ b/packages/desktop/src/shared/features/agent/types.ts
@@ -39,3 +39,19 @@ export type LoadSessionResult = {
 export type PromptResult = {
   stopReason: string;
 };
+
+/** Cached message for persisted session display */
+export type CachedMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  thinking?: string;
+};
+
+/** Persisted session cache for instant resume */
+export type CachedSession = {
+  messages: CachedMessage[];
+  title?: string;
+  cwd?: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
Added filesystem-backed session caching with new IPC endpoints to read/write cached sessions. The renderer restores messages instantly from cache, skips server-side replay when available, and waits for SDK readiness before sending prompts.