### PR TITLE
fix(content-panel): restore tooltip on orphan tab warning icon

### DIFF
--- a/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { X, TriangleAlert } from "lucide-react";
 import { useRendererApp } from "../../../core";
 import { cn } from "../../../lib/utils";
@@ -9,16 +10,18 @@ function TabButton({
   tab,
   isActive,
   isOrphan,
+  ...rest
 }: {
   tab: Tab;
   isActive: boolean;
   isOrphan: boolean;
-}) {
+} & React.ComponentPropsWithRef<"div">) {
   const app = useRendererApp();
   const contentPanel = app.workbench.contentPanel;
 
   return (
     <div
+      {...rest}
       role="tab"
       aria-selected={isActive}
       className={cn(
@@ -63,7 +66,10 @@ export function TabItem({
   if (isOrphan) {
     return (
       <Tooltip>
-        <TooltipTrigger render={<TabButton tab={tab} isActive={isActive} isOrphan />} delay={0} />
+        <TooltipTrigger
+          delay={0}
+          render={(props) => <TabButton {...props} tab={tab} isActive={isActive} isOrphan />}
+        />
         <TooltipPopup side="bottom">
           &quot;{tab.name}&quot; is unavailable. You can close this tab.
         </TooltipPopup>


### PR DESCRIPTION
## Summary
- Fixed orphan tab tooltip not appearing by forwarding BaseUI trigger props through `TabButton`
- Switched `TooltipTrigger` from JSX element `render` to function form so event handlers and ref reach the DOM
- Corrected `delay={0}` placement on `TooltipTrigger` per BaseUI docs

## Test plan
- [ ] Open a tab whose viewType is no longer registered (orphan tab)
- [ ] Verify the yellow warning icon and tooltip appear on hover
- [ ] Verify tooltip shows immediately (no delay)