### PR TITLE
feat: support image attachments in agent prompts

### DIFF
--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -130,10 +130,17 @@ export const agentRouter = os.agent.router({
     let eventCount = 0;
     let permissionEventCount = 0;
     agentLog(
-      "prompt: START sessionId=%s promptLen=%d prompt=%s",
+      "prompt: START sessionId=%s promptLen=%d prompt=%s attachments=%d attachmentDetails=%o",
       input.sessionId,
       input.prompt.length,
       input.prompt.slice(0, 100),
+      input.attachments?.length ?? 0,
+      input.attachments?.map((a) => ({
+        id: a.id,
+        filename: a.filename,
+        mediaType: a.mediaType,
+        base64Len: a.base64?.length ?? 0,
+      })),
     );
 
     const pendingPermissionEvents: StreamEvent[] = [];
@@ -147,6 +154,7 @@ export const agentRouter = os.agent.router({
         input.sessionId,
         input.prompt,
         emitter,
+        input.attachments,
       )) {
         eventCount += 1;
         if (!firstEventAt) {

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -18,6 +18,7 @@ import type {
   StreamEvent,
   SessionInfo,
   SlashCommandInfo,
+  ImageAttachment,
 } from "../../../shared/features/agent/types";
 import { getShellEnvironment } from "./shell-env";
 import { Pushable } from "./pushable";
@@ -189,6 +190,7 @@ export class SessionManager {
     sessionId: string,
     text: string,
     emitter: (event: StreamEvent) => void,
+    attachments?: ImageAttachment[],
   ): AsyncGenerator<StreamEvent> {
     const managed = this.sessions.get(sessionId);
     if (!managed) {
@@ -199,7 +201,24 @@ export class SessionManager {
     }
 
     const t0 = performance.now();
-    log("prompt: START sessionId=%s promptLen=%d cwd=%s", sessionId, text.length, managed.cwd);
+    log(
+      "prompt: START sessionId=%s promptLen=%d cwd=%s attachments=%d",
+      sessionId,
+      text.length,
+      managed.cwd,
+      attachments?.length ?? 0,
+    );
+    if (attachments && attachments.length > 0) {
+      log(
+        "prompt: attachment details: %o",
+        attachments.map((a) => ({
+          id: a.id,
+          filename: a.filename,
+          mediaType: a.mediaType,
+          base64Len: a.base64?.length ?? 0,
+        })),
+      );
+    }
 
     // Set permission emitter so canUseTool can forward events
     this.permissionEmitter = emitter;
@@ -207,9 +226,51 @@ export class SessionManager {
     let sdkMsgCount = 0;
 
     try {
+      const content =
+        attachments && attachments.length > 0
+          ? [
+              ...(text ? [{ type: "text" as const, text }] : []),
+              ...attachments.map((att) => ({
+                type: "image" as const,
+                source: {
+                  type: "base64" as const,
+                  media_type: att.mediaType as
+                    | "image/jpeg"
+                    | "image/png"
+                    | "image/gif"
+                    | "image/webp",
+                  data: att.base64,
+                },
+              })),
+            ]
+          : text;
+
+      log(
+        "prompt: content type=%s contentIsArray=%s blockCount=%s",
+        typeof content,
+        Array.isArray(content),
+        Array.isArray(content) ? content.length : "n/a",
+      );
+      if (Array.isArray(content)) {
+        log(
+          "prompt: content blocks: %o",
+          content.map((b) => ({
+            type: b.type,
+            ...(b.type === "text" ? { textLen: b.text.length } : {}),
+            ...(b.type === "image"
+              ? {
+                  sourceType: b.source.type,
+                  mediaType: b.source.media_type,
+                  dataLen: b.source.data?.length ?? 0,
+                }
+              : {}),
+          })),
+        );
+      }
+
       managed.input.push({
         type: "user",
-        message: { role: "user", content: text },
+        message: { role: "user", content },
         parent_tool_use_id: null,
         session_id: sessionId,
       });

--- a/packages/desktop/src/renderer/src/assets/globals.css
+++ b/packages/desktop/src/renderer/src/assets/globals.css
@@ -176,4 +176,14 @@
     font-size: 0.8125rem;
     padding: 0;
   }
+
+  .attachment-thumb {
+    position: relative;
+    border-radius: 0.375rem;
+    overflow: visible;
+  }
+
+  .attachment-thumb img {
+    border: 1px solid var(--border);
+  }
 }

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -3,6 +3,7 @@ import debug from "debug";
 import { client } from "../../../orpc";
 import { useAgentStore } from "../store";
 import { useProjectStore } from "../../project/store";
+import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
 const chatLog = debug("neovate:agent-chat");
 import { usePrompt } from "../hooks/use-prompt";
@@ -97,13 +98,14 @@ export function AgentChat() {
       });
   }, [activeProjectPath, createNewSession]);
 
-  const handleSend = (message: string) => {
+  const handleSend = (message: string, attachments?: ImageAttachment[]) => {
     chatLog(
-      "handleSend: sessionId=%s msgLen=%d",
+      "handleSend: sessionId=%s msgLen=%d attachments=%d",
       activeSession?.sessionId?.slice(0, 8) ?? "new",
       message.length,
+      attachments?.length ?? 0,
     );
-    sendPrompt(activeSession?.sessionId, message);
+    sendPrompt(activeSession?.sessionId, message, attachments);
   };
 
   const handleCancel = () => {

--- a/packages/desktop/src/renderer/src/features/agent/components/image-paste-extension.ts
+++ b/packages/desktop/src/renderer/src/features/agent/components/image-paste-extension.ts
@@ -1,0 +1,141 @@
+import { Extension } from "@tiptap/react";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import debug from "debug";
+import type { ImageAttachment } from "../../../../../shared/features/agent/types";
+
+const log = debug("neovate:image-paste");
+
+type ImagePasteOptions = {
+  onImages: (images: ImageAttachment[]) => void;
+};
+
+function readFileAsAttachment(file: File): Promise<ImageAttachment> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      // strip "data:<mediaType>;base64," prefix
+      const base64 = dataUrl.split(",")[1];
+      log(
+        "readFile: name=%s type=%s size=%d base64Len=%d",
+        file.name,
+        file.type,
+        file.size,
+        base64?.length ?? 0,
+      );
+      resolve({
+        id: crypto.randomUUID(),
+        filename: file.name || "image",
+        mediaType: file.type || "image/png",
+        base64,
+      });
+    };
+    reader.onerror = (err) => {
+      log("readFile: ERROR name=%s error=%o", file.name, err);
+      reject(err);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function extractImageFiles(dataTransfer: DataTransfer): File[] {
+  const files: File[] = [];
+  log(
+    "extractImageFiles: files=%d items=%d types=%o",
+    dataTransfer.files.length,
+    dataTransfer.items?.length ?? 0,
+    dataTransfer.types,
+  );
+  for (let i = 0; i < dataTransfer.files.length; i++) {
+    const file = dataTransfer.files[i];
+    log("extractImageFiles: file[%d] name=%s type=%s size=%d", i, file.name, file.type, file.size);
+    if (file.type.startsWith("image/")) {
+      files.push(file);
+    }
+  }
+  // Also check items for clipboard paste (some browsers put images in items, not files)
+  if (files.length === 0 && dataTransfer.items) {
+    for (let i = 0; i < dataTransfer.items.length; i++) {
+      const item = dataTransfer.items[i];
+      log("extractImageFiles: item[%d] kind=%s type=%s", i, item.kind, item.type);
+      if (item.kind === "file" && item.type.startsWith("image/")) {
+        const file = item.getAsFile();
+        if (file) {
+          log("extractImageFiles: item[%d] -> file name=%s size=%d", i, file.name, file.size);
+          files.push(file);
+        }
+      }
+    }
+  }
+  log("extractImageFiles: result count=%d", files.length);
+  return files;
+}
+
+export function createImagePasteExtension(onImages: (images: ImageAttachment[]) => void) {
+  return Extension.create<ImagePasteOptions>({
+    name: "imagePaste",
+
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("imagePaste"),
+          props: {
+            handlePaste(_view, event) {
+              log("handlePaste: triggered");
+              const clipboardData = event.clipboardData;
+              if (!clipboardData) {
+                log("handlePaste: no clipboardData");
+                return false;
+              }
+
+              const imageFiles = extractImageFiles(clipboardData);
+              if (imageFiles.length === 0) {
+                log("handlePaste: no image files found");
+                return false;
+              }
+
+              log("handlePaste: found %d images, preventing default", imageFiles.length);
+              event.preventDefault();
+              Promise.all(imageFiles.map(readFileAsAttachment)).then((attachments) => {
+                log(
+                  "handlePaste: resolved %d attachments, ids=%o",
+                  attachments.length,
+                  attachments.map((a) => a.id),
+                );
+                onImages(attachments);
+              });
+              return true;
+            },
+
+            handleDrop(_view, event) {
+              log("handleDrop: triggered");
+              const dataTransfer = (event as DragEvent).dataTransfer;
+              if (!dataTransfer) {
+                log("handleDrop: no dataTransfer");
+                return false;
+              }
+
+              const imageFiles = extractImageFiles(dataTransfer);
+              if (imageFiles.length === 0) {
+                log("handleDrop: no image files found");
+                return false;
+              }
+
+              log("handleDrop: found %d images, preventing default", imageFiles.length);
+              event.preventDefault();
+              Promise.all(imageFiles.map(readFileAsAttachment)).then((attachments) => {
+                log(
+                  "handleDrop: resolved %d attachments, ids=%o",
+                  attachments.length,
+                  attachments.map((a) => a.id),
+                );
+                onImages(attachments);
+              });
+              return true;
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -1,20 +1,22 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import debug from "debug";
 import { Extension, useEditor, EditorContent } from "@tiptap/react";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Button } from "../../../components/ui/button";
-import { SendHorizonal, Square, Paperclip } from "lucide-react";
+import { SendHorizonal, Square, Paperclip, X } from "lucide-react";
 import { createSlashCommandsExtension } from "./slash-commands-extension";
 import { createMentionExtension } from "./mention-extension";
+import { createImagePasteExtension } from "./image-paste-extension";
 import { useAgentStore } from "../store";
 import type { JSONContent } from "@tiptap/react";
+import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
 const log = debug("neovate:message-input");
 
 type Props = {
-  onSend: (message: string) => void;
+  onSend: (message: string, attachments?: ImageAttachment[]) => void;
   onCancel: () => void;
   streaming: boolean;
   disabled?: boolean;
@@ -61,6 +63,28 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
   const sendRef = useRef<() => void>(() => {});
   const cwdRef = useRef(cwd);
   cwdRef.current = cwd;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
+
+  const addAttachments = useCallback((images: ImageAttachment[]) => {
+    log(
+      "addAttachments: adding %d images, ids=%o",
+      images.length,
+      images.map((i) => i.id),
+    );
+    setAttachments((prev) => {
+      const next = [...prev, ...images];
+      log("addAttachments: total attachments now=%d", next.length);
+      return next;
+    });
+  }, []);
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
 
   const mentionExtension = useMemo(() => createMentionExtension(() => cwdRef.current), []);
 
@@ -72,6 +96,11 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
         return (sessions.get(activeSessionId)?.availableCommands ?? []).map((c) => c.name);
       }),
     [],
+  );
+
+  const imagePasteExtension = useMemo(
+    () => createImagePasteExtension(addAttachments),
+    [addAttachments],
   );
 
   const send = useCallback(() => {
@@ -91,6 +120,7 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
       }),
       mentionExtension,
       slashCommandsExtension,
+      imagePasteExtension,
       Extension.create({
         name: "chatKeymap",
         addProseMirrorPlugins() {
@@ -137,9 +167,28 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
     sendRef.current = () => {
       if (!editor || streaming) return;
       const text = extractText(editor.getJSON());
-      if (!text) return;
-      onSend(text);
+      const imgs = attachmentsRef.current;
+      log(
+        "send: text=%s attachmentsRef.current.length=%d ids=%o",
+        text.slice(0, 50),
+        imgs.length,
+        imgs.map((i) => i.id),
+      );
+      if (imgs.length > 0) {
+        log(
+          "send: attachment details: %o",
+          imgs.map((i) => ({
+            id: i.id,
+            filename: i.filename,
+            mediaType: i.mediaType,
+            base64Len: i.base64?.length ?? 0,
+          })),
+        );
+      }
+      if (!text && imgs.length === 0) return;
+      onSend(text, imgs.length > 0 ? imgs : undefined);
       editor.commands.clearContent();
+      setAttachments([]);
     };
   }, [editor, onSend, streaming]);
 
@@ -167,12 +216,79 @@ export function MessageInput({ onSend, onCancel, streaming, disabled, cwd }: Pro
     return () => window.removeEventListener("neovate:insert-mention", handler);
   }, [editor]);
 
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      log("handleFileSelect: files=%d", files?.length ?? 0);
+      if (!files || files.length === 0) return;
+      const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+      log("handleFileSelect: imageFiles=%d", imageFiles.length);
+      if (imageFiles.length === 0) return;
+      Promise.all(
+        imageFiles.map(
+          (file) =>
+            new Promise<ImageAttachment>((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onload = () => {
+                const dataUrl = reader.result as string;
+                resolve({
+                  id: crypto.randomUUID(),
+                  filename: file.name,
+                  mediaType: file.type || "image/png",
+                  base64: dataUrl.split(",")[1],
+                });
+              };
+              reader.onerror = reject;
+              reader.readAsDataURL(file);
+            }),
+        ),
+      ).then(addAttachments);
+      e.target.value = "";
+    },
+    [addAttachments],
+  );
+
   return (
     <div className="border-t border-border p-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={handleFileSelect}
+      />
       <div className="rounded-lg border border-input bg-background focus-within:ring-2 focus-within:ring-ring">
         <EditorContent editor={editor} />
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-2 border-t border-border/50 px-3 py-2">
+            {attachments.map((att) => (
+              <div key={att.id} className="attachment-thumb group relative">
+                <img
+                  src={`data:${att.mediaType};base64,${att.base64}`}
+                  alt={att.filename}
+                  className="h-14 w-14 rounded-md object-cover"
+                />
+                <button
+                  type="button"
+                  className="absolute -right-1.5 -top-1.5 hidden h-4 w-4 items-center justify-center rounded-full bg-destructive text-destructive-foreground group-hover:flex"
+                  onClick={() => removeAttachment(att.id)}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="flex items-center gap-1 border-t border-border/50 px-2 py-1">
-          <Button type="button" variant="ghost" size="icon" className="h-7 w-7" title="Attach file">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title="Attach image"
+            onClick={() => fileInputRef.current?.click()}
+          >
             <Paperclip className="h-4 w-4" />
           </Button>
           <div className="flex-1" />

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-prompt.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-prompt.ts
@@ -5,6 +5,7 @@ import { client } from "../../../orpc";
 import { useAgentStore } from "../store";
 import { useProjectStore } from "../../project/store";
 import { useNewSession } from "./use-new-session";
+import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
 const promptLog = debug("neovate:agent-prompt");
 
@@ -25,7 +26,7 @@ export function usePrompt() {
   }, []);
 
   const sendPrompt = useCallback(
-    async (sessionId: string | undefined, prompt: string) => {
+    async (sessionId: string | undefined, prompt: string, attachments?: ImageAttachment[]) => {
       const promptStart = performance.now();
       let resolvedSessionId = sessionId;
       const projectPath = useProjectStore.getState().activeProject?.path;
@@ -55,7 +56,18 @@ export function usePrompt() {
         }
       }
 
-      promptLog("sendPrompt: start sessionId=%s len=%d", resolvedSessionId, prompt.length);
+      promptLog(
+        "sendPrompt: start sessionId=%s len=%d attachments=%d attachmentDetails=%o",
+        resolvedSessionId,
+        prompt.length,
+        attachments?.length ?? 0,
+        attachments?.map((a) => ({
+          id: a.id,
+          filename: a.filename,
+          mediaType: a.mediaType,
+          base64Len: a.base64?.length ?? 0,
+        })),
+      );
       useAgentStore.getState().setPromptError(resolvedSessionId, null);
 
       // Check if this was a new session before sending the first message
@@ -99,8 +111,13 @@ export function usePrompt() {
 
       try {
         const rpcStart = performance.now();
+        promptLog(
+          "sendPrompt: calling oRPC prompt sessionId=%s attachments=%s",
+          resolvedSessionId,
+          attachments ? `${attachments.length} items` : "none",
+        );
         const iterator = await client.agent.prompt(
-          { sessionId: resolvedSessionId, prompt },
+          { sessionId: resolvedSessionId, prompt, attachments },
           { signal: ac.signal },
         );
         const rpcElapsed = Math.round(performance.now() - rpcStart);

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -40,7 +40,22 @@ export const agentContract = {
     .output(type<void>()),
 
   prompt: oc
-    .input(z.object({ sessionId: z.string(), prompt: z.string() }))
+    .input(
+      z.object({
+        sessionId: z.string(),
+        prompt: z.string(),
+        attachments: z
+          .array(
+            z.object({
+              id: z.string(),
+              filename: z.string(),
+              mediaType: z.string(),
+              base64: z.string(),
+            }),
+          )
+          .optional(),
+      }),
+    )
     .errors({
       BAD_GATEWAY: {
         message: "Agent prompt failed",

--- a/packages/desktop/src/shared/features/agent/types.ts
+++ b/packages/desktop/src/shared/features/agent/types.ts
@@ -1,5 +1,13 @@
 export type AgentInfo = { id: string; name: string };
 
+/** Image attachment sent alongside a prompt */
+export type ImageAttachment = {
+  id: string;
+  filename: string;
+  mediaType: string;
+  base64: string;
+};
+
 export type TimingEntry = {
   phase: string;
   label: string;


### PR DESCRIPTION
Added support for sending image attachments with agent prompts, including paste/drag-drop/file attach UI with thumbnails. Updated the shared contract and main session manager to accept attachments and send mixed text+image content to the agent.

<img width="502" height="618" alt="Electron 2026-03-05 18 20 33" src="https://github.com/user-attachments/assets/72536f58-df77-4077-9b02-227f90c20e39" />