### PR TITLE
fix: add settingSources to Claude Code session config

### DIFF
--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -141,6 +141,13 @@ export class SessionManager {
       env,
       canUseTool,
       permissionMode: "default",
+      settings: {
+        attribution: {
+          commit: "",
+          pr: "",
+        },
+      },
+      settingSources: ["user", "project", "local"],
     };
   }
 


### PR DESCRIPTION
## Summary
- Add empty `attribution` settings (`commit`, `pr`) to Claude Code session config to prevent annotation in commits and PRs
- Add `settingSources` to respect user/project/local setting hierarchy

## Test plan
- [ ] Verify Claude Code sessions start without errors
- [ ] Confirm commit messages don't include Claude-related attribution