### PR TITLE
feat(format): enable import sorting via oxfmt sortImports

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,3 +1,15 @@
 {
-  "ignorePatterns": [".claude/**"]
+  "ignorePatterns": [".claude/**"],
+  "sortImports": {
+    "groups": [
+      "type-import",
+      ["value-builtin", "value-external"],
+      "type-internal",
+      "value-internal",
+      ["type-parent", "type-sibling", "type-index"],
+      ["value-parent", "value-sibling", "value-index"],
+      "unknown"
+    ],
+    "newlinesBetween": true
+  }
 }

--- a/packages/desktop/scripts/test-sdk.ts
+++ b/packages/desktop/scripts/test-sdk.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
-import { resolve } from "node:path";
-import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKUserMessage, SDKMessage, Query } from "@anthropic-ai/claude-agent-sdk";
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { resolve } from "node:path";
 
 // The SDK refuses to run inside a Claude Code session (detects CLAUDECODE env var).
 // Clear it so this script works when invoked from within Claude Code.

--- a/packages/desktop/src/main/__tests__/app.test.ts
+++ b/packages/desktop/src/main/__tests__/app.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import type { MainPlugin } from "../core/plugin/types";
 
 const { mockCreateMainWindow, mockDestroyAll } = vi.hoisted(() => ({

--- a/packages/desktop/src/main/__tests__/router.test.ts
+++ b/packages/desktop/src/main/__tests__/router.test.ts
@@ -1,5 +1,6 @@
 import { call } from "@orpc/server";
 import { describe, expect, it, vi } from "vitest";
+
 import { buildRouter, type AppDependencies } from "../router";
 
 const router = buildRouter(new Map());

--- a/packages/desktop/src/main/app.ts
+++ b/packages/desktop/src/main/app.ts
@@ -1,12 +1,15 @@
-import { os } from "@orpc/server";
 import type { AnyRouter } from "@orpc/server";
-import { PluginManager } from "./core/plugin/plugin-manager";
-import { DisposableStore } from "./core/disposable";
-import type { IBrowserWindowManager, IMainApp } from "./core/types";
+
+import { os } from "@orpc/server";
+
 import type { MainPlugin } from "./core/plugin/types";
-import { buildRouter } from "./router";
+import type { IBrowserWindowManager, IMainApp } from "./core/types";
+
 import { BrowserWindowManager } from "./core";
+import { DisposableStore } from "./core/disposable";
+import { PluginManager } from "./core/plugin/plugin-manager";
 import { StorageService } from "./core/storage-service";
+import { buildRouter } from "./router";
 
 export interface MainAppOptions {
   plugins?: MainPlugin[];

--- a/packages/desktop/src/main/core/__tests__/storage-service.integration.test.ts
+++ b/packages/desktop/src/main/core/__tests__/storage-service.integration.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
 import { StorageService } from "../storage-service";
 
 /**

--- a/packages/desktop/src/main/core/__tests__/storage-service.test.ts
+++ b/packages/desktop/src/main/core/__tests__/storage-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import { StorageService } from "../storage-service";
 
 // Mock electron-store — replicate its dot-path get/set behavior

--- a/packages/desktop/src/main/core/browser-window-manager.ts
+++ b/packages/desktop/src/main/core/browser-window-manager.ts
@@ -1,12 +1,14 @@
+import { is } from "@electron-toolkit/utils";
+import { shell, screen, BrowserWindow } from "electron";
+import Store from "electron-store";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import Store from "electron-store";
 import { join } from "path";
-import { shell, screen, BrowserWindow } from "electron";
-import { is } from "@electron-toolkit/utils";
-import icon from "../../../resources/icon.png?asset";
-import { randomUUID } from "node:crypto";
+
 import type { IBrowserWindowManager, OpenWindowOptions } from "./types";
+
+import icon from "../../../resources/icon.png?asset";
 
 type WindowStore = { bounds: Electron.Rectangle };
 

--- a/packages/desktop/src/main/core/plugin/__tests__/contributions.test.ts
+++ b/packages/desktop/src/main/core/plugin/__tests__/contributions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+
 import { buildContributions, EMPTY_CONTRIBUTIONS } from "../contributions";
 
 describe("buildContributions", () => {

--- a/packages/desktop/src/main/core/plugin/__tests__/plugin-manager.test.ts
+++ b/packages/desktop/src/main/core/plugin/__tests__/plugin-manager.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { PluginManager } from "../plugin-manager";
+
 import type { MainPlugin, PluginContext } from "../types";
+
+import { PluginManager } from "../plugin-manager";
 
 function makeCtx(): PluginContext {
   return {

--- a/packages/desktop/src/main/core/plugin/contributions.ts
+++ b/packages/desktop/src/main/core/plugin/contributions.ts
@@ -1,4 +1,5 @@
 import type { AnyRouter } from "@orpc/server";
+
 import type { PluginContributions } from "./types";
 
 export type Contributions = {

--- a/packages/desktop/src/main/core/plugin/plugin-manager.ts
+++ b/packages/desktop/src/main/core/plugin/plugin-manager.ts
@@ -1,5 +1,6 @@
-import { buildContributions, EMPTY_CONTRIBUTIONS, type Contributions } from "./contributions";
 import type { MainPlugin, PluginContext } from "./types";
+
+import { buildContributions, EMPTY_CONTRIBUTIONS, type Contributions } from "./contributions";
 
 export class PluginManager {
   readonly #plugins: MainPlugin[];

--- a/packages/desktop/src/main/core/plugin/types.ts
+++ b/packages/desktop/src/main/core/plugin/types.ts
@@ -1,5 +1,7 @@
-import { os } from "@orpc/server";
 import type { AnyRouter } from "@orpc/server";
+
+import { os } from "@orpc/server";
+
 import type { IMainApp } from "../types";
 
 export interface PluginContext {

--- a/packages/desktop/src/main/core/storage-service.ts
+++ b/packages/desktop/src/main/core/storage-service.ts
@@ -1,6 +1,6 @@
+import Store from "electron-store";
 import os from "node:os";
 import path from "node:path";
-import Store from "electron-store";
 
 const DEFAULT_BASE_DIR = path.join(os.homedir(), ".neovate-desktop");
 

--- a/packages/desktop/src/main/core/types.ts
+++ b/packages/desktop/src/main/core/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from "electron";
+
 import type { SessionManager } from "../features/agent/session-manager";
 import type { Disposable } from "./disposable";
 

--- a/packages/desktop/src/main/features/agent/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/router.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
 import { call } from "@orpc/server";
-import { agentRouter } from "../router";
-import type { SessionManager } from "../session-manager";
+import { describe, it, expect, vi } from "vitest";
+
 import type { AppContext } from "../../../router";
+import type { SessionManager } from "../session-manager";
+
+import { agentRouter } from "../router";
 
 function makeContext(overrides?: Partial<AppContext>): AppContext {
   return {

--- a/packages/desktop/src/main/features/agent/__tests__/sdk-message-transformer.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/sdk-message-transformer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+
 import { SDKMessageTransformer, toUIEvent } from "../sdk-message-transformer";
 
 function collect(gen: Generator<any>): any[] {

--- a/packages/desktop/src/main/features/agent/__tests__/session-manager.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/session-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+
 import { SessionManager, PERMISSION_TIMEOUT_MS } from "../session-manager";
 
 describe("SessionManager", () => {

--- a/packages/desktop/src/main/features/agent/__tests__/shell-env.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/shell-env.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+
 import { getShellEnvironment, clearShellEnvironmentCache } from "../shell-env";
 
 afterEach(() => {

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -1,7 +1,9 @@
 import { ORPCError, implement } from "@orpc/server";
 import debug from "debug";
-import { agentContract } from "../../../shared/features/agent/contract";
+
 import type { AppContext } from "../../router";
+
+import { agentContract } from "../../../shared/features/agent/contract";
 
 const agentLog = debug("neovate:agent-router");
 

--- a/packages/desktop/src/main/features/agent/sdk-message-transformer.ts
+++ b/packages/desktop/src/main/features/agent/sdk-message-transformer.ts
@@ -1,4 +1,5 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
 import type {
   ClaudeCodeUIMessageChunk,
   ClaudeCodeUIEvent,

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -1,8 +1,3 @@
-import {
-  query,
-  getSessionMessages,
-  listSessions as sdkListSessions,
-} from "@anthropic-ai/claude-agent-sdk";
 import type {
   Query,
   Options,
@@ -12,24 +7,32 @@ import type {
   SessionMessage,
   PermissionMode as SDKPermissionMode,
 } from "@anthropic-ai/claude-agent-sdk";
+
+import {
+  query,
+  getSessionMessages,
+  listSessions as sdkListSessions,
+} from "@anthropic-ai/claude-agent-sdk";
+import { EventPublisher } from "@orpc/server";
+import { createUIMessageStream, readUIMessageStream } from "ai";
+import debug from "debug";
 import { randomUUID } from "node:crypto";
-import { appendFile } from "node:fs/promises";
 import { globSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import debug from "debug";
-import type { SessionInfo } from "../../../shared/features/agent/types";
-import { getShellEnvironment } from "./shell-env";
-import { EventPublisher } from "@orpc/server";
-import { Pushable } from "./pushable";
+
 import type {
   ClaudeCodeUIEvent,
   ClaudeCodeUIMessage,
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../../shared/claude-code/types";
-import { createUIMessageStream, readUIMessageStream } from "ai";
+import type { SessionInfo } from "../../../shared/features/agent/types";
+
+import { Pushable } from "./pushable";
 import { SDKMessageTransformer, toUIEvent } from "./sdk-message-transformer";
+import { getShellEnvironment } from "./shell-env";
 
 const log = debug("neovate:session-manager");
 

--- a/packages/desktop/src/main/features/agent/shell-env.ts
+++ b/packages/desktop/src/main/features/agent/shell-env.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
 import debug from "debug";
+import { spawn } from "node:child_process";
 
 const shellEnvLog = debug("neovate:acp-shell-env");
 

--- a/packages/desktop/src/main/features/config/config-store.ts
+++ b/packages/desktop/src/main/features/config/config-store.ts
@@ -1,6 +1,7 @@
+import Store from "electron-store";
 import os from "node:os";
 import path from "node:path";
-import Store from "electron-store";
+
 import type { AppConfig } from "../../../shared/features/config/types";
 
 const DEFAULT_CONFIG: AppConfig = {

--- a/packages/desktop/src/main/features/config/router.ts
+++ b/packages/desktop/src/main/features/config/router.ts
@@ -1,7 +1,9 @@
 import { implement } from "@orpc/server";
-import { configContract } from "../../../shared/features/config/contract";
+
 import type { AppConfig } from "../../../shared/features/config/types";
 import type { AppContext } from "../../router";
+
+import { configContract } from "../../../shared/features/config/contract";
 
 const os = implement({ config: configContract }).$context<AppContext>();
 

--- a/packages/desktop/src/main/features/project/project-store.ts
+++ b/packages/desktop/src/main/features/project/project-store.ts
@@ -1,6 +1,7 @@
+import Store from "electron-store";
 import os from "node:os";
 import path from "node:path";
-import Store from "electron-store";
+
 import type {
   Project,
   ProjectStore as ProjectStoreSchema,

--- a/packages/desktop/src/main/features/project/router.ts
+++ b/packages/desktop/src/main/features/project/router.ts
@@ -1,9 +1,11 @@
+import { implement } from "@orpc/server";
+import { dialog } from "electron";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { dialog } from "electron";
-import { implement } from "@orpc/server";
-import { projectContract } from "../../../shared/features/project/contract";
+
 import type { AppContext } from "../../router";
+
+import { projectContract } from "../../../shared/features/project/contract";
 
 const os = implement({ project: projectContract }).$context<AppContext>();
 

--- a/packages/desktop/src/main/features/state/router.ts
+++ b/packages/desktop/src/main/features/state/router.ts
@@ -1,6 +1,8 @@
 import { implement } from "@orpc/server";
-import { stateContract } from "../../../shared/features/state/contract";
+
 import type { AppContext } from "../../router";
+
+import { stateContract } from "../../../shared/features/state/contract";
 
 const os = implement({ state: stateContract }).$context<AppContext>();
 

--- a/packages/desktop/src/main/features/storage/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/storage/__tests__/router.test.ts
@@ -1,10 +1,12 @@
+import { call } from "@orpc/server";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { call } from "@orpc/server";
+
+import type { AppContext } from "../../../router";
+
 import { StorageService } from "../../../core/storage-service";
 import { storageRouter } from "../router";
-import type { AppContext } from "../../../router";
 
 /**
  * End-to-end router tests — calls actual ORPC handlers with a real

--- a/packages/desktop/src/main/features/storage/router.ts
+++ b/packages/desktop/src/main/features/storage/router.ts
@@ -1,6 +1,8 @@
 import { implement } from "@orpc/server";
-import { storageContract } from "../../../shared/features/storage/contract";
+
 import type { AppContext } from "../../router";
+
+import { storageContract } from "../../../shared/features/storage/contract";
 
 const os = implement({ storage: storageContract }).$context<AppContext>();
 

--- a/packages/desktop/src/main/features/utils/router.ts
+++ b/packages/desktop/src/main/features/utils/router.ts
@@ -1,14 +1,16 @@
-import { spawn, execSync } from "node:child_process";
-import { existsSync, statSync, rmSync, unlinkSync } from "node:fs";
+import { implement } from "@orpc/server";
 import debug from "debug";
 import { app } from "electron";
-import { implement } from "@orpc/server";
-import { utilsContract } from "../../../shared/features/utils/contract";
+import { spawn, execSync } from "node:child_process";
+import { existsSync, statSync, rmSync, unlinkSync } from "node:fs";
+
 import type { App } from "../../../shared/features/utils/types";
 import type { AppContext } from "../../router";
+
+import { utilsContract } from "../../../shared/features/utils/contract";
 import { getShellEnvironment } from "../agent/shell-env";
-import { searchPaths } from "./search-paths";
 import { searchWithContent } from "./search-content";
+import { searchPaths } from "./search-paths";
 
 const log = debug("neovate:utils-router");
 

--- a/packages/desktop/src/main/features/utils/search-content.ts
+++ b/packages/desktop/src/main/features/utils/search-content.ts
@@ -1,6 +1,7 @@
+import debug from "debug";
 import { execFile } from "node:child_process";
 import { relative, basename, extname } from "node:path";
-import debug from "debug";
+
 import { resolveRgPath } from "./search-paths";
 
 const log = debug("neovate:search-content");

--- a/packages/desktop/src/main/features/utils/search-paths.ts
+++ b/packages/desktop/src/main/features/utils/search-paths.ts
@@ -1,8 +1,8 @@
-import { accessSync, chmodSync, constants } from "node:fs";
+import debug from "debug";
 import { execFile } from "node:child_process";
+import { accessSync, chmodSync, constants } from "node:fs";
 import { createRequire } from "node:module";
 import { join, relative } from "node:path";
-import debug from "debug";
 
 const log = debug("neovate:search-paths");
 const require = createRequire(import.meta.url);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,19 +1,21 @@
-import { app, ipcMain } from "electron";
 import { electronApp, is } from "@electron-toolkit/utils";
 import { RPCHandler } from "@orpc/server/message-port";
 import debug from "debug";
+import { app, ipcMain } from "electron";
+
+import type { AppContext } from "./router";
+
+import { MainApp } from "./app";
+import { setupApplicationMenu } from "./core/menu";
 import { SessionManager } from "./features/agent/session-manager";
 import { getShellEnvironment } from "./features/agent/shell-env";
 import { ConfigStore } from "./features/config/config-store";
 import { ProjectStore } from "./features/project/project-store";
 import { StateStore } from "./features/state/state-store";
-import { MainApp } from "./app";
-import type { AppContext } from "./router";
-import gitPlugin from "./plugins/git";
-import filesPlugin from "./plugins/files";
-import terminalPlugin from "./plugins/terminal";
 import editorPlugin from "./plugins/editor";
-import { setupApplicationMenu } from "./core/menu";
+import filesPlugin from "./plugins/files";
+import gitPlugin from "./plugins/git";
+import terminalPlugin from "./plugins/terminal";
 
 const log = debug("neovate:orpc");
 

--- a/packages/desktop/src/main/plugins/editor/index.ts
+++ b/packages/desktop/src/main/plugins/editor/index.ts
@@ -1,6 +1,7 @@
 import type { MainPlugin } from "../../core/plugin/types";
-import { CodeServerManager } from "./utils";
+
 import { createEditorRouter } from "./router";
+import { CodeServerManager } from "./utils";
 import { ExtensionBridgeServer } from "./utils/bridge";
 
 const codeServerManager = new CodeServerManager();

--- a/packages/desktop/src/main/plugins/editor/router.ts
+++ b/packages/desktop/src/main/plugins/editor/router.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from "../../core/plugin/types";
+
 import { CodeServerManager, ExtensionBridgeServer } from "./utils";
 
 export function createEditorRouter(

--- a/packages/desktop/src/main/plugins/editor/utils/bridge.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/bridge.ts
@@ -1,6 +1,7 @@
+import type { WebContents } from "electron";
+
 import { EventEmitter } from "events";
 import net from "net";
-import type { WebContents } from "electron";
 import { randomUUID } from "node:crypto";
 
 interface IBridgeRequestParams {

--- a/packages/desktop/src/main/plugins/editor/utils/download.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/download.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
 import { extract } from "tar";
+
 import { CODE_SERVER_DIR, getArtifactUrl, getCodeServerBinaryPath } from "./constants";
 
 export class CodeServerDownloadError extends Error {

--- a/packages/desktop/src/main/plugins/editor/utils/extension-path.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/extension-path.ts
@@ -1,6 +1,7 @@
-import path from "path";
-import https from "https";
 import fs from "fs";
+import https from "https";
+import path from "path";
+
 import { EXTENSIONS_DIR } from "./constants";
 
 const RESOURCE_PATH =

--- a/packages/desktop/src/main/plugins/editor/utils/index.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/index.ts
@@ -1,11 +1,12 @@
 import { execSync } from "node:child_process";
+
+import { ExtensionBridgeServer } from "./bridge";
 import { CODE_SERVER_PORT, DATA_DIR, EXTENSION_BRIDGE_PORT, EXTENSIONS_DIR } from "./constants";
 import { downloadCodeServer, isCodeServerInstalled, type ProgressCallback } from "./download";
+import { injectStyle } from "./injector";
 import { installExtension } from "./installer";
 import { overrideCodeServerSettings } from "./settings";
 import { codeServerStarter } from "./starter";
-import { injectStyle } from "./injector";
-import { ExtensionBridgeServer } from "./bridge";
 
 export class CodeServerStartError extends Error {
   constructor(

--- a/packages/desktop/src/main/plugins/editor/utils/injector.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/injector.ts
@@ -1,5 +1,6 @@
-import path from "node:path";
 import fs from "node:fs";
+import path from "node:path";
+
 import { getCodeServerBinaryPath } from "./constants";
 
 /** 通过修改产物的方式实现强制样式修改 */

--- a/packages/desktop/src/main/plugins/editor/utils/installer.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/installer.ts
@@ -1,8 +1,9 @@
+import AdmZip from "adm-zip";
 import fs from "node:fs";
 import path from "node:path";
-import AdmZip from "adm-zip";
-import { ensureExtension } from "./extension-path";
+
 import { EXTENSIONS_DIR } from "./constants";
+import { ensureExtension } from "./extension-path";
 
 interface ExtensionManifest {
   publisher: string;

--- a/packages/desktop/src/main/plugins/editor/utils/settings.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/settings.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+
 import { DATA_DIR } from "./constants";
 
 const OVERRIDE_SETTINGS = {

--- a/packages/desktop/src/main/plugins/editor/utils/starter.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/starter.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+
 import { getCodeServerBinaryPath } from "./constants";
 
 /**

--- a/packages/desktop/src/main/plugins/files/index.ts
+++ b/packages/desktop/src/main/plugins/files/index.ts
@@ -1,4 +1,5 @@
 import type { MainPlugin } from "../../core/plugin/types";
+
 import { createFilesRouter } from "./router";
 
 export default {

--- a/packages/desktop/src/main/plugins/files/router.ts
+++ b/packages/desktop/src/main/plugins/files/router.ts
@@ -1,6 +1,8 @@
-import type { PluginContext } from "../../core/plugin/types";
 import fs from "fs";
 import path from "path";
+
+import type { PluginContext } from "../../core/plugin/types";
+
 import { getFileTree } from "./tree";
 import { unwatchWorkspace, watchWorkspace } from "./watch";
 

--- a/packages/desktop/src/main/plugins/files/tree.ts
+++ b/packages/desktop/src/main/plugins/files/tree.ts
@@ -1,6 +1,6 @@
+import { minimatch } from "minimatch";
 import fs from "node:fs";
 import path from "node:path";
-import { minimatch } from "minimatch";
 
 export interface FileTreeNode {
   fileName: string;

--- a/packages/desktop/src/main/plugins/files/watch.ts
+++ b/packages/desktop/src/main/plugins/files/watch.ts
@@ -1,7 +1,9 @@
-import chokidar from "chokidar";
 import type { FSWatcher } from "chokidar";
-import type { FileWatchEvent } from "../../../shared/plugins/files/contract";
+
 import { EventPublisher } from "@orpc/server";
+import chokidar from "chokidar";
+
+import type { FileWatchEvent } from "../../../shared/plugins/files/contract";
 
 // 防抖函数
 function debounce<T extends (...args: any[]) => any>(

--- a/packages/desktop/src/main/plugins/git/index.ts
+++ b/packages/desktop/src/main/plugins/git/index.ts
@@ -1,4 +1,5 @@
 import type { MainPlugin } from "../../core/plugin/types";
+
 import { createGitRouter } from "./router";
 
 export default {

--- a/packages/desktop/src/main/plugins/git/router.ts
+++ b/packages/desktop/src/main/plugins/git/router.ts
@@ -1,7 +1,8 @@
-import path from "node:path";
 import fs from "node:fs";
-import type { PluginContext } from "../../core/plugin/types";
+import path from "node:path";
 import git from "simple-git";
+
+import type { PluginContext } from "../../core/plugin/types";
 
 function str2file(cwd: string, file: string) {
   return {

--- a/packages/desktop/src/main/plugins/terminal/index.ts
+++ b/packages/desktop/src/main/plugins/terminal/index.ts
@@ -1,4 +1,5 @@
 import type { MainPlugin } from "../../core/plugin/types";
+
 import { PtyManager } from "./pty-manager";
 import { createTerminalRouter } from "./router";
 

--- a/packages/desktop/src/main/plugins/terminal/pty-manager.ts
+++ b/packages/desktop/src/main/plugins/terminal/pty-manager.ts
@@ -1,6 +1,7 @@
+import type { IPty } from "node-pty";
+
 import { EventPublisher } from "@orpc/server";
 import * as pty from "node-pty";
-import type { IPty } from "node-pty";
 
 export interface PtySession {
   pty: IPty;

--- a/packages/desktop/src/main/plugins/terminal/router.ts
+++ b/packages/desktop/src/main/plugins/terminal/router.ts
@@ -1,5 +1,6 @@
 import { eventIterator } from "@orpc/server";
 import { z } from "zod";
+
 import type { PluginContext } from "../../core/plugin/types";
 import type { PtyManager } from "./pty-manager";
 

--- a/packages/desktop/src/main/router.ts
+++ b/packages/desktop/src/main/router.ts
@@ -1,17 +1,20 @@
-import { implement } from "@orpc/server";
 import type { AnyRouter } from "@orpc/server";
+
+import { implement } from "@orpc/server";
+
+import type { StorageService } from "./core/storage-service";
+import type { IMainApp } from "./core/types";
+import type { SessionManager } from "./features/agent/session-manager";
+import type { ConfigStore } from "./features/config/config-store";
+import type { ProjectStore } from "./features/project/project-store";
+import type { StateStore } from "./features/state/state-store";
+
 import { contract } from "../shared/contract";
 import { agentRouter } from "./features/agent/router";
 import { configRouter } from "./features/config/router";
 import { projectRouter } from "./features/project/router";
 import { storageRouter } from "./features/storage/router";
 import { utilsRouter } from "./features/utils/router";
-import type { SessionManager } from "./features/agent/session-manager";
-import type { ConfigStore } from "./features/config/config-store";
-import type { ProjectStore } from "./features/project/project-store";
-import type { StateStore } from "./features/state/state-store";
-import type { IMainApp } from "./core/types";
-import type { StorageService } from "./core/storage-service";
 
 export type AppContext = {
   sessionManager: SessionManager;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
-import { contextBridge, ipcRenderer } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
 import debug from "debug";
+import { contextBridge, ipcRenderer } from "electron";
 
 const log = debug("neovate:orpc:preload");
 

--- a/packages/desktop/src/renderer/src/App.tsx
+++ b/packages/desktop/src/renderer/src/App.tsx
@@ -1,7 +1,3 @@
-import { AgentChat, SessionList } from "./features/agent";
-import { ContentPanelRenderer } from "./features/content-panel";
-import { useSettingsStore } from "./features/settings";
-import { SettingsPage } from "./features/settings/components/settings-page";
 import { lazy, Suspense, useEffect } from "react";
 
 import {
@@ -17,7 +13,11 @@ import {
   AppLayoutTitleBar,
   AppLayoutTrafficLights,
 } from "./components/app-layout";
+import { AgentChat, SessionList } from "./features/agent";
 import { useConfigStore } from "./features/config/store";
+import { ContentPanelRenderer } from "./features/content-panel";
+import { useSettingsStore } from "./features/settings";
+import { SettingsPage } from "./features/settings/components/settings-page";
 import { useGlobalKeybindings } from "./hooks/use-global-keybindings";
 
 const Playground = import.meta.env.DEV ? lazy(() => import("./dev/playground")) : null;

--- a/packages/desktop/src/renderer/src/components/ai-elements/agent.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/agent.tsx
@@ -3,12 +3,12 @@
 import type { Tool } from "ai";
 import type { ComponentProps } from "react";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../ui/accordion";
-import { Badge } from "../ui/badge";
-import { cn } from "../../lib/utils";
 import { BotIcon } from "lucide-react";
 import { memo } from "react";
 
+import { cn } from "../../lib/utils";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../ui/accordion";
+import { Badge } from "../ui/badge";
 import { CodeBlock } from "./code-block";
 
 export type AgentProps = ComponentProps<"div">;

--- a/packages/desktop/src/renderer/src/components/ai-elements/artifact.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/artifact.tsx
@@ -3,10 +3,11 @@
 import type { LucideIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 
+import { XIcon } from "lucide-react";
+
+import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
-import { cn } from "../../lib/utils";
-import { XIcon } from "lucide-react";
 
 export type ArtifactProps = HTMLAttributes<HTMLDivElement>;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/attachments.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/attachments.tsx
@@ -3,9 +3,6 @@
 import type { FileUIPart, SourceDocumentUIPart } from "ai";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 
-import { Button } from "../ui/button";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
-import { cn } from "../../lib/utils";
 import {
   FileTextIcon,
   GlobeIcon,
@@ -16,6 +13,10 @@ import {
   XIcon,
 } from "lucide-react";
 import { createContext, useCallback, useContext, useMemo } from "react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
 
 // ============================================================================
 // Types

--- a/packages/desktop/src/renderer/src/components/ai-elements/chain-of-thought.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/chain-of-thought.tsx
@@ -4,11 +4,12 @@ import type { LucideIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import { Badge } from "../ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
 import { BrainIcon, ChevronDownIcon, DotIcon } from "lucide-react";
 import { createContext, memo, useContext, useMemo } from "react";
+
+import { cn } from "../../lib/utils";
+import { Badge } from "../ui/badge";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 
 interface ChainOfThoughtContextValue {
   isOpen: boolean;

--- a/packages/desktop/src/renderer/src/components/ai-elements/checkpoint.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/checkpoint.tsx
@@ -3,11 +3,12 @@
 import type { LucideProps } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 
+import { BookmarkIcon } from "lucide-react";
+
+import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { cn } from "../../lib/utils";
-import { BookmarkIcon } from "lucide-react";
 
 export type CheckpointProps = HTMLAttributes<HTMLDivElement>;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/code-block.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/code-block.tsx
@@ -3,9 +3,6 @@
 import type { ComponentProps, CSSProperties, FC, HTMLAttributes } from "react";
 import type { BundledLanguage, BundledTheme, HighlighterGeneric, ThemedToken } from "shiki";
 
-import { Button } from "../ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
-import { cn } from "../../lib/utils";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import {
   createContext,
@@ -18,6 +15,10 @@ import {
   useState,
 } from "react";
 import { createHighlighter } from "shiki";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 
 // Shiki uses bitflags for font styles: 1=italic, 2=bold, 4=underline
 // biome-ignore lint/suspicious/noBitwiseOperators: shiki bitflag check

--- a/packages/desktop/src/renderer/src/components/ai-elements/confirmation.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/confirmation.tsx
@@ -3,10 +3,11 @@
 import type { ToolUIPart } from "ai";
 import type { ComponentProps, ReactNode } from "react";
 
+import { createContext, useContext } from "react";
+
+import { cn } from "../../lib/utils";
 import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
-import { cn } from "../../lib/utils";
-import { createContext, useContext } from "react";
 
 type ToolUIPartApproval =
   | {

--- a/packages/desktop/src/renderer/src/components/ai-elements/context.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/context.tsx
@@ -3,12 +3,13 @@
 import type { LanguageModelUsage } from "ai";
 import type { ComponentProps } from "react";
 
+import { createContext, useContext, useMemo } from "react";
+import { getUsage } from "tokenlens";
+
+import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
 import { Progress } from "../ui/progress";
-import { cn } from "../../lib/utils";
-import { createContext, useContext, useMemo } from "react";
-import { getUsage } from "tokenlens";
 
 const PERCENT_MAX = 100;
 const ICON_RADIUS = 10;

--- a/packages/desktop/src/renderer/src/components/ai-elements/conversation.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/conversation.tsx
@@ -2,11 +2,12 @@
 
 import type { ComponentProps } from "react";
 
-import { Button } from "../ui/button";
-import { cn } from "../../lib/utils";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import { useCallback } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/inline-citation.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/inline-citation.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import type { CarouselApi } from "../ui/carousel";
 import type { ComponentProps, FC } from "react";
 
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+import type { CarouselApi } from "../ui/carousel";
+
+import { cn } from "../../lib/utils";
 import { Badge } from "../ui/badge";
 import { Carousel, CarouselContent, CarouselItem } from "../ui/carousel";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
-import { cn } from "../../lib/utils";
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
 export type InlineCitationProps = ComponentProps<"span">;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/message.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/message.tsx
@@ -3,10 +3,6 @@
 import type { UIMessage } from "ai";
 import type { ComponentProps, FC, HTMLAttributes, ReactElement } from "react";
 
-import { Button } from "../ui/button";
-import { ButtonGroup, ButtonGroupText } from "../ui/group";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
-import { cn } from "../../lib/utils";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
@@ -14,6 +10,11 @@ import { mermaid } from "@streamdown/mermaid";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { ButtonGroup, ButtonGroupText } from "../ui/group";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];

--- a/packages/desktop/src/renderer/src/components/ai-elements/plan.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/plan.tsx
@@ -2,6 +2,10 @@
 
 import type { ComponentProps } from "react";
 
+import { ChevronsUpDownIcon } from "lucide-react";
+import { createContext, useContext } from "react";
+
+import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import {
   Card,
@@ -13,10 +17,6 @@ import {
   CardTitle,
 } from "../ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
-import { ChevronsUpDownIcon } from "lucide-react";
-import { createContext, useContext } from "react";
-
 import { Shimmer } from "./shimmer";
 
 interface PlanContextValue {

--- a/packages/desktop/src/renderer/src/components/ai-elements/queue.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/queue.tsx
@@ -2,11 +2,12 @@
 
 import type { ComponentProps } from "react";
 
+import { ChevronDownIcon, PaperclipIcon } from "lucide-react";
+
+import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { ScrollArea } from "../ui/scroll-area";
-import { cn } from "../../lib/utils";
-import { ChevronDownIcon, PaperclipIcon } from "lucide-react";
 
 export interface QueueMessagePart {
   type: string;

--- a/packages/desktop/src/renderer/src/components/ai-elements/reasoning.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/reasoning.tsx
@@ -3,8 +3,6 @@
 import type { ComponentProps, ReactNode } from "react";
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
@@ -22,6 +20,8 @@ import {
 } from "react";
 import { Streamdown } from "streamdown";
 
+import { cn } from "../../lib/utils";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { Shimmer } from "./shimmer";
 
 interface ReasoningContextValue {

--- a/packages/desktop/src/renderer/src/components/ai-elements/shimmer.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/shimmer.tsx
@@ -3,9 +3,10 @@
 import type { MotionProps } from "motion/react";
 import type { CSSProperties, ElementType, JSX } from "react";
 
-import { cn } from "../../lib/utils";
 import { motion } from "motion/react";
 import { memo, useMemo } from "react";
+
+import { cn } from "../../lib/utils";
 
 type MotionHTMLProps = MotionProps & Record<string, unknown>;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/sources.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/sources.tsx
@@ -2,9 +2,10 @@
 
 import type { ComponentProps } from "react";
 
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
 import { BookIcon, ChevronDownIcon } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 
 export type SourcesProps = ComponentProps<"div">;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/task.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/task.tsx
@@ -2,9 +2,10 @@
 
 import type { ComponentProps } from "react";
 
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
 import { ChevronDownIcon, SearchIcon } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 
 export type TaskItemFileProps = ComponentProps<"div">;
 

--- a/packages/desktop/src/renderer/src/components/ai-elements/terminal.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/terminal.tsx
@@ -2,8 +2,6 @@
 
 import type { ComponentProps, HTMLAttributes } from "react";
 
-import { Button } from "../ui/button";
-import { cn } from "../../lib/utils";
 import Ansi from "ansi-to-react";
 import { CheckIcon, CopyIcon, TerminalIcon, Trash2Icon } from "lucide-react";
 import {
@@ -16,6 +14,8 @@ import {
   useState,
 } from "react";
 
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
 import { Shimmer } from "./shimmer";
 
 interface TerminalContextType {

--- a/packages/desktop/src/renderer/src/components/ai-elements/tool.tsx
+++ b/packages/desktop/src/renderer/src/components/ai-elements/tool.tsx
@@ -3,9 +3,6 @@
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import type { ComponentProps, ReactNode } from "react";
 
-import { Badge } from "../ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
-import { cn } from "../../lib/utils";
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -16,6 +13,9 @@ import {
 } from "lucide-react";
 import { isValidElement } from "react";
 
+import { cn } from "../../lib/utils";
+import { Badge } from "../ui/badge";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { CodeBlock } from "./code-block";
 
 export type ToolProps = ComponentProps<typeof Collapsible>;

--- a/packages/desktop/src/renderer/src/components/app-layout/__tests__/behaviors.test.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/__tests__/behaviors.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { open, overflow } from "../behaviors";
+
 import type { LayoutContext } from "../types";
+
+import { open, overflow } from "../behaviors";
 
 function makeCtx(overrides: Partial<LayoutContext> = {}): LayoutContext {
   return {

--- a/packages/desktop/src/renderer/src/components/app-layout/__tests__/integration.test.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/__tests__/integration.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
+
+import type { PanelMap } from "../types";
+
 import {
   shrinkPanelsToFit,
   computeMinWindowWidth,
   applyDelta,
   isSeparatorVisible,
 } from "../layout-coordinator";
-import type { PanelMap } from "../types";
 
 describe("resize flow integration", () => {
   it("opening all panels then fitting to small window shrinks by priority", () => {

--- a/packages/desktop/src/renderer/src/components/app-layout/__tests__/layout-coordinator.test.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/__tests__/layout-coordinator.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+
+import type { PanelMap, LayoutContext } from "../types";
+
 import {
   constrainWidth,
   computeMaxAvailableWidth,
@@ -8,7 +11,6 @@ import {
   isSeparatorVisible,
 } from "../layout-coordinator";
 import { getDescriptor } from "../panel-descriptors";
-import type { PanelMap, LayoutContext } from "../types";
 
 function makePanels(
   overrides: Partial<Record<string, { width: number; collapsed: boolean }>> = {},

--- a/packages/desktop/src/renderer/src/components/app-layout/__tests__/persist-merge.test.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/__tests__/persist-merge.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+
 import type { PanelId, PanelState } from "../types";
 
 // Mock orpc to avoid window dependency

--- a/packages/desktop/src/renderer/src/components/app-layout/activity-bar.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/activity-bar.tsx
@@ -1,6 +1,8 @@
 import { DashboardSquare01FreeIcons } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { ActivityBarItem } from "../../core/plugin/contributions";
+
 import { useRendererApp } from "../../core";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";

--- a/packages/desktop/src/renderer/src/components/app-layout/app-layout.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/app-layout.tsx
@@ -1,4 +1,3 @@
-import { type ReactNode, Suspense, lazy, useRef } from "react";
 import {
   ArrowDown01Icon,
   FolderIcon,
@@ -10,24 +9,27 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
-import { Button } from "../ui/button";
+import { type ReactNode, Suspense, lazy, useRef } from "react";
+
+import type { TitlebarItem } from "../../core/plugin/contributions";
+import type { SeparatorId } from "./types";
+
+import { useRendererApp } from "../../core/app";
+import { SessionInfoBar } from "../../features/agent/components/session-info-bar";
+import { useConfigStore } from "../../features/config/store";
+import { OpenAppButton } from "../../features/open-in";
 import { ProjectSelector } from "../../features/project/components/project-selector";
 import { useProjectStore } from "../../features/project/store";
-import { useConfigStore } from "../../features/config/store";
-import { SessionInfoBar } from "../../features/agent/components/session-info-bar";
-import { OpenAppButton } from "../../features/open-in";
-import { useLayoutStore } from "./store";
-import { ResizeHandle } from "./resize-handle";
-import { usePanelResize } from "./hooks";
+import { useSettingsStore } from "../../features/settings";
+import { Button } from "../ui/button";
 import {
   APP_LAYOUT_COLLAPSED_TITLEBAR_LEFT_MARGIN,
   APP_LAYOUT_GRID,
   APP_LAYOUT_GRID_AREA,
 } from "./constants";
-import type { SeparatorId } from "./types";
-import { useRendererApp } from "../../core/app";
-import type { TitlebarItem } from "../../core/plugin/contributions";
-import { useSettingsStore } from "../../features/settings";
+import { usePanelResize } from "./hooks";
+import { ResizeHandle } from "./resize-handle";
+import { useLayoutStore } from "./store";
 
 function useLazyComponents(items: TitlebarItem[]) {
   const cache = useRef(new Map<string, React.LazyExoticComponent<React.ComponentType>>());

--- a/packages/desktop/src/renderer/src/components/app-layout/behaviors.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/behaviors.ts
@@ -1,4 +1,5 @@
 import type { OpenBehavior, OverflowBehavior } from "./types";
+
 import {
   APP_LAYOUT_ACTIVITY_BAR_WIDTH,
   APP_LAYOUT_EDGE_SPACING,

--- a/packages/desktop/src/renderer/src/components/app-layout/content-panel-tabs.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/content-panel-tabs.tsx
@@ -1,11 +1,13 @@
+import { X, Plus } from "lucide-react";
 import { lazy, Suspense, useEffect, useRef } from "react";
 import { useStore } from "zustand";
-import { X, Plus } from "lucide-react";
-import { useRendererApp } from "../../core";
-import { useProjectStore } from "../../features/project/store";
-import { ContentPanelViewContextProvider } from "../../features/content-panel";
+
 import type { ContentPanelView } from "../../core/plugin/contributions";
 import type { ContentPanelStoreState } from "../../features/content-panel/types";
+
+import { useRendererApp } from "../../core";
+import { ContentPanelViewContextProvider } from "../../features/content-panel";
+import { useProjectStore } from "../../features/project/store";
 
 function useLazyComponents(views: ContentPanelView[]) {
   const cache = useRef(new Map<string, React.LazyExoticComponent<React.ComponentType>>());

--- a/packages/desktop/src/renderer/src/components/app-layout/content-panel.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/content-panel.tsx
@@ -1,5 +1,7 @@
-import { motion } from "motion/react";
 import type { ReactNode } from "react";
+
+import { motion } from "motion/react";
+
 import { cn } from "../../lib/utils";
 import { APP_LAYOUT_GRID_AREA } from "./constants";
 import { usePanelState } from "./store";

--- a/packages/desktop/src/renderer/src/components/app-layout/hooks.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/hooks.ts
@@ -1,8 +1,9 @@
 import { useEffect, useLayoutEffect } from "react";
-import { useLayoutStore, layoutStore } from "./store";
+
+import { client } from "../../orpc";
 import { shrinkPanelsToFit, computeMinWindowWidth, setPanelWidth } from "./layout-coordinator";
 import { applyDelta } from "./layout-coordinator";
-import { client } from "../../orpc";
+import { useLayoutStore, layoutStore } from "./store";
 
 /** Syncs the OS minimum window width via IPC whenever panels change (debounced 100ms). */
 function useSyncWindowMinWidth() {

--- a/packages/desktop/src/renderer/src/components/app-layout/layout-coordinator.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/layout-coordinator.ts
@@ -1,4 +1,5 @@
 import type { PanelDescriptor, PanelId, PanelMap, LayoutContext } from "./types";
+
 import { APP_LAYOUT_FIXED_WIDTH, APP_LAYOUT_RESIZE_HANDLE_WIDTH, PANEL_ORDER } from "./constants";
 import { getDescriptor, PANEL_DESCRIPTORS } from "./panel-descriptors";
 

--- a/packages/desktop/src/renderer/src/components/app-layout/panel-activity.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/panel-activity.tsx
@@ -1,4 +1,5 @@
 import { Activity, type ReactNode, useEffect, useRef, useState } from "react";
+
 import { useLayoutStore } from "./store";
 
 type AppLayoutPanelActivityProps = {

--- a/packages/desktop/src/renderer/src/components/app-layout/panel-descriptors.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/panel-descriptors.ts
@@ -1,4 +1,5 @@
 import type { PanelDescriptor, PanelId } from "./types";
+
 import { open, overflow } from "./behaviors";
 import { APP_LAYOUT_CHAT_PANEL_MIN_WIDTH } from "./constants";
 

--- a/packages/desktop/src/renderer/src/components/app-layout/primary-sidebar.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/primary-sidebar.tsx
@@ -1,8 +1,9 @@
-import { type ReactNode } from "react";
 import { motion } from "motion/react";
+import { type ReactNode } from "react";
+
 import { cn } from "../../lib/utils";
-import { AppLayoutPanelActivity } from "./panel-activity";
 import { APP_LAYOUT_GRID_AREA } from "./constants";
+import { AppLayoutPanelActivity } from "./panel-activity";
 import { usePanelState } from "./store";
 
 const SPRING = { type: "spring" as const, stiffness: 600, damping: 49 };

--- a/packages/desktop/src/renderer/src/components/app-layout/resize-handle.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/resize-handle.tsx
@@ -1,9 +1,11 @@
 import { type CSSProperties, useRef, useCallback } from "react";
-import { cn } from "../../lib/utils";
-import { useLayoutStore } from "./store";
+
 import type { SeparatorId } from "./types";
+
+import { cn } from "../../lib/utils";
 import { separatorIdToIndex } from "./constants";
 import { isSeparatorVisible } from "./layout-coordinator";
+import { useLayoutStore } from "./store";
 
 function useGradientTracker(separatorIndex: number) {
   const ref = useRef<HTMLDivElement>(null);

--- a/packages/desktop/src/renderer/src/components/app-layout/secondary-sidebar.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/secondary-sidebar.tsx
@@ -1,10 +1,12 @@
-import { Activity, lazy, Suspense, useRef } from "react";
 import { motion } from "motion/react";
-import { cn } from "../../lib/utils";
+import { Activity, lazy, Suspense, useRef } from "react";
+
+import type { SecondarySidebarView } from "../../core/plugin/contributions";
+
 import { useRendererApp } from "../../core";
+import { cn } from "../../lib/utils";
 import { APP_LAYOUT_GRID_AREA } from "./constants";
 import { usePanelState, useLayoutStore } from "./store";
-import type { SecondarySidebarView } from "../../core/plugin/contributions";
 
 const SPRING = { type: "spring" as const, stiffness: 600, damping: 49 };
 

--- a/packages/desktop/src/renderer/src/components/app-layout/store.ts
+++ b/packages/desktop/src/renderer/src/components/app-layout/store.ts
@@ -1,15 +1,17 @@
-import { createStore } from "zustand/vanilla";
 import { useStore } from "zustand";
 import { persist, subscribeWithSelector } from "zustand/middleware";
+import { createStore } from "zustand/vanilla";
+
 import type { PanelId, PanelMap, PanelState } from "./types";
-import { PANEL_DESCRIPTORS } from "./panel-descriptors";
+
+import { client } from "../../orpc";
 import {
   openPanel,
   collapsePanel,
   computeMinWindowWidthWithPanel,
   setPanelWidth,
 } from "./layout-coordinator";
-import { client } from "../../orpc";
+import { PANEL_DESCRIPTORS } from "./panel-descriptors";
 
 function isPanelId(id: string, panels: Record<PanelId, PanelState>): id is PanelId {
   return Object.prototype.hasOwnProperty.call(panels, id);

--- a/packages/desktop/src/renderer/src/components/ui/alert.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/alert.tsx
@@ -1,5 +1,6 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/breadcrumb.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/breadcrumb.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { ChevronRight, MoreHorizontal } from "lucide-react";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/button-group.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/button-group.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
 
-import { cn } from "../../lib/utils";
 import { Separator } from "../../components/ui/separator";
+import { cn } from "../../lib/utils";
 
 const groupVariants = cva(
   "flex w-fit *:focus-visible:z-1 has-[>[data-slot=group]]:gap-2 *:has-focus-visible:z-1 dark:*:[[data-slot=separator]:has(~button:hover):not(:has(~[data-slot=separator]~[data-slot]:hover)),[data-slot=separator]:has(~[data-slot][data-pressed]):not(:has(~[data-slot=separator]~[data-slot][data-pressed]))]:before:bg-input/64 dark:*:[button:hover~[data-slot=separator]:not([data-slot]:hover~[data-slot=separator]~[data-slot=separator]),[data-slot][data-pressed]~[data-slot=separator]:not([data-slot][data-pressed]~[data-slot=separator]~[data-slot=separator])]:before:bg-input/64",

--- a/packages/desktop/src/renderer/src/components/ui/button.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/button.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/calendar.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/calendar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ChevronLeftIcon, ChevronRightIcon, ChevronsUpDownIcon } from "lucide-react";
 import type * as React from "react";
+
+import { ChevronLeftIcon, ChevronRightIcon, ChevronsUpDownIcon } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "../../lib/utils";

--- a/packages/desktop/src/renderer/src/components/ui/carousel.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/carousel.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import useEmblaCarousel, { type UseEmblaCarouselType } from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "../../lib/utils";
 import { Button } from "./button";

--- a/packages/desktop/src/renderer/src/components/ui/command.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/command.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { Dialog as CommandDialogPrimitive } from "@base-ui/react/dialog";
 import { SearchIcon } from "lucide-react";
-import type * as React from "react";
+
 import { cn } from "../../lib/utils";
 import {
   Autocomplete,

--- a/packages/desktop/src/renderer/src/components/ui/dialog.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
+
 import { cn } from "../../lib/utils";
 import { Button } from "./button";
 import { ScrollArea } from "./scroll-area";

--- a/packages/desktop/src/renderer/src/components/ui/group.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/group.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 import { Separator } from "./separator";

--- a/packages/desktop/src/renderer/src/components/ui/hover-card.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/hover-card.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+import * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/input-group.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/input-group.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils";
 import { Input, type InputProps } from "./input";

--- a/packages/desktop/src/renderer/src/components/ui/input.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/input.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Input as InputPrimitive } from "@base-ui/react/input";
 import type * as React from "react";
+
+import { Input as InputPrimitive } from "@base-ui/react/input";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/menu.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/menu.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import type * as React from "react";
+
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { ChevronRightIcon } from "lucide-react";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/pagination.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/pagination.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 import { type Button, buttonVariants } from "./button";

--- a/packages/desktop/src/renderer/src/components/ui/select.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/select.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import type * as React from "react";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import { ChevronDownIcon, ChevronsUpDownIcon, ChevronUpIcon } from "lucide-react";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/sheet.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/sheet.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
+
 import { cn } from "../../lib/utils";
 import { Button } from "./button";
 import { ScrollArea } from "./scroll-area";

--- a/packages/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -5,6 +5,7 @@ import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
 import * as React from "react";
+
 import { useIsMobile } from "../../hooks/use-mobile";
 import { cn } from "../../lib/utils";
 import { Button } from "./button";

--- a/packages/desktop/src/renderer/src/components/ui/spinner.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/spinner.tsx
@@ -1,4 +1,5 @@
 import { Loader2Icon } from "lucide-react";
+
 import { cn } from "../../lib/utils";
 
 function Spinner({ className, ...props }: React.ComponentProps<typeof Loader2Icon>) {

--- a/packages/desktop/src/renderer/src/components/ui/textarea.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/textarea.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import type * as React from "react";
+
 import { Field as FieldPrimitive } from "@base-ui/react/field";
 import { mergeProps } from "@base-ui/react/merge-props";
-import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 

--- a/packages/desktop/src/renderer/src/components/ui/toggle-group.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/toggle-group.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
-import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group";
 import type { VariantProps } from "class-variance-authority";
+
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";

--- a/packages/desktop/src/renderer/src/core/__tests__/disposable.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/disposable.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+
 import { DisposableStore, toDisposable } from "../disposable";
 
 describe("toDisposable", () => {

--- a/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { PluginManager } from "../plugin/plugin-manager";
-import type { IRendererApp } from "../types";
+
 import type { RendererPlugin } from "../plugin";
 import type { SecondarySidebarView, ContentPanelView } from "../plugin/contributions";
+import type { IRendererApp } from "../types";
+
+import { PluginManager } from "../plugin/plugin-manager";
 
 function createMockApp(): IRendererApp {
   return {

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -1,27 +1,28 @@
+import { ThemeProvider, useTheme } from "next-themes";
 import { StrictMode, Suspense, createContext, useContext, useEffect, lazy } from "react";
 import ReactDOM from "react-dom/client";
-import { ThemeProvider, useTheme } from "next-themes";
-import { I18nManager } from "./i18n";
-import { useConfigStore } from "../features/config/store";
-import { useSettingsStore } from "../features/settings/store";
-import { DisposableStore } from "./disposable";
-import { ToastProvider } from "../components/ui/toast";
-import type { IRendererApp, IWorkbench } from "./types";
-import type { RendererPlugin, PluginContext } from "./plugin";
-import { PluginManager } from "./plugin";
-import { ContentPanel } from "../features/content-panel";
+
+import type { SettingsSchema } from "../../../shared/features/settings/schema";
 import type { ProjectTabState } from "../features/content-panel";
+import type { RendererPlugin, PluginContext } from "./plugin";
+import type { IRendererApp, IWorkbench } from "./types";
+
+import { ToastProvider } from "../components/ui/toast";
+import { useConfigStore } from "../features/config/store";
+import { ContentPanel } from "../features/content-panel";
+import { SettingsService } from "../features/settings/service";
+import { useSettingsStore } from "../features/settings/store";
+import { client } from "../orpc";
+import editorPlugin from "../plugins/editor";
 import filesPlugin from "../plugins/files";
 import gitPlugin from "../plugins/git";
-import terminalPlugin from "../plugins/terminal";
 import searchPlugin from "../plugins/search";
-import editorPlugin from "../plugins/editor";
+import terminalPlugin from "../plugins/terminal";
 // import contentPanelDemoPlugin from "../plugins/content-panel-demo";
 // import demoWindowPlugin from "../plugins/demo-window";
-
-import { client } from "../orpc";
-import { SettingsService } from "../features/settings/service";
-import type { SettingsSchema } from "../../../shared/features/settings/schema";
+import { DisposableStore } from "./disposable";
+import { I18nManager } from "./i18n";
+import { PluginManager } from "./plugin";
 
 // Preserve context identity across HMR to prevent provider/consumer mismatch
 const RendererAppContext: React.Context<RendererApp | null> =

--- a/packages/desktop/src/renderer/src/core/i18n/manager.ts
+++ b/packages/desktop/src/renderer/src/core/i18n/manager.ts
@@ -1,6 +1,7 @@
 import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
+
 import enUS from "../../locales/en-US.json";
 import zhCN from "../../locales/zh-CN.json";
 import { DEFAULT_LOCALE, normalizeLocale, type Locales } from "./locales";

--- a/packages/desktop/src/renderer/src/core/plugin/plugin-manager.ts
+++ b/packages/desktop/src/renderer/src/core/plugin/plugin-manager.ts
@@ -1,6 +1,7 @@
-import { buildContributions, PluginContributions, type WindowContribution } from "./contributions";
 import type { I18nContributions } from "../i18n";
 import type { PluginContext, RendererPlugin, RendererPluginHooks } from "./types";
+
+import { buildContributions, PluginContributions, type WindowContribution } from "./contributions";
 
 type HookFn = (...args: unknown[]) => unknown;
 

--- a/packages/desktop/src/renderer/src/core/plugin/types.ts
+++ b/packages/desktop/src/renderer/src/core/plugin/types.ts
@@ -1,6 +1,6 @@
-import type { PluginContributions, WindowContribution } from "./contributions";
 import type { I18nContributions } from "../i18n/i18next";
 import type { IRendererApp } from "../types";
+import type { PluginContributions, WindowContribution } from "./contributions";
 
 export interface PluginContext {
   app: IRendererApp;

--- a/packages/desktop/src/renderer/src/core/types.ts
+++ b/packages/desktop/src/renderer/src/core/types.ts
@@ -1,8 +1,8 @@
+import type { SettingsSchema } from "../../../shared/features/settings/schema";
+import type { ContentPanel } from "../features/content-panel/content-panel";
+import type { SettingsStore } from "../features/settings/store";
 import type { Disposable, Unsubscribe } from "./disposable";
 import type { I18nManager } from "./i18n";
-import type { SettingsSchema } from "../../../shared/features/settings/schema";
-import type { SettingsStore } from "../features/settings/store";
-import type { ContentPanel } from "../features/content-panel/content-panel";
 
 export interface IScopedSettings<T extends Record<string, unknown> = Record<string, unknown>> {
   get<K extends string & keyof T>(key: K): T[K] | undefined;

--- a/packages/desktop/src/renderer/src/dev/playground.tsx
+++ b/packages/desktop/src/renderer/src/dev/playground.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useState } from "react";
-import { cn } from "../lib/utils";
+
 import { ErrorBoundary } from "../components/ui/error-boundary";
+import { cn } from "../lib/utils";
 
 const PLAYGROUNDS = [
   {

--- a/packages/desktop/src/renderer/src/dev/playgrounds/ai-elements.tsx
+++ b/packages/desktop/src/renderer/src/dev/playgrounds/ai-elements.tsx
@@ -1,5 +1,5 @@
+import { CheckIcon, CopyIcon, MessageSquareIcon, RefreshCwIcon, XIcon } from "lucide-react";
 import { useState } from "react";
-import { ScrollArea } from "../../components/ui/scroll-area";
 
 import {
   Agent,
@@ -124,9 +124,8 @@ import {
   ToolInput,
   ToolOutput,
 } from "../../components/ai-elements/tool";
-
 import { Button } from "../../components/ui/button";
-import { CheckIcon, CopyIcon, MessageSquareIcon, RefreshCwIcon, XIcon } from "lucide-react";
+import { ScrollArea } from "../../components/ui/scroll-area";
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -1,4 +1,5 @@
 import type { ContractRouterClient } from "@orpc/contract";
+
 import { agentContract } from "../../../../shared/features/agent/contract";
 import { client } from "../../orpc";
 import { ClaudeCodeChat } from "./chat";

--- a/packages/desktop/src/renderer/src/features/agent/chat-state.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-state.ts
@@ -1,10 +1,12 @@
+import type { Query } from "@anthropic-ai/claude-agent-sdk";
 import type { ChatState, ChatStatus } from "ai";
+
 import { createStore, type StoreApi } from "zustand/vanilla";
+
 import type {
   ClaudeCodeUIEventRequest,
   ClaudeCodeUIMessage,
 } from "../../../../shared/claude-code/types";
-import type { Query } from "@anthropic-ai/claude-agent-sdk";
 
 export type ClaudeCodeChatCapabilities = Awaited<ReturnType<Query["initializationResult"]>>;
 

--- a/packages/desktop/src/renderer/src/features/agent/chat-transport.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-transport.ts
@@ -1,12 +1,15 @@
-import { eventIteratorToUnproxiedDataStream } from "@orpc/client";
 import type { ContractRouterClient } from "@orpc/contract";
 import type { ChatRequestOptions, ChatTransport } from "ai";
-import { agentContract } from "../../../../shared/features/agent/contract";
+
+import { eventIteratorToUnproxiedDataStream } from "@orpc/client";
+
 import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
   ClaudeCodeUIMessage,
 } from "../../../../shared/claude-code/types";
+
+import { agentContract } from "../../../../shared/features/agent/contract";
 
 type AgentRpc = ContractRouterClient<{ agent: typeof agentContract }>["agent"];
 

--- a/packages/desktop/src/renderer/src/features/agent/chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat.ts
@@ -1,16 +1,19 @@
-import { consumeEventIterator } from "@orpc/client";
-import type { ChatInit } from "ai";
-import { AbstractChat } from "ai";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import type { ChatInit } from "ai";
+
+import { consumeEventIterator } from "@orpc/client";
+import { AbstractChat } from "ai";
+import { StoreApi } from "zustand";
+
 import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIEvent,
   ClaudeCodeUIEventMessage,
   ClaudeCodeUIMessage,
 } from "../../../../shared/claude-code/types";
-import { ClaudeCodeChatState, ClaudeCodeChatStoreState } from "./chat-state";
 import type { ClaudeCodeChatTransport } from "./chat-transport";
-import { StoreApi } from "zustand";
+
+import { ClaudeCodeChatState, ClaudeCodeChatStoreState } from "./chat-state";
 
 export interface ClaudeCodeChatInit extends Omit<ChatInit<ClaudeCodeUIMessage>, "transport"> {
   id: string;

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -1,26 +1,29 @@
-import { useEffect, useRef, useState } from "react";
-import debug from "debug";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
-import { client } from "../../../orpc";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
-import { useConfigStore } from "../../config/store";
+
+import debug from "debug";
+import { useEffect, useRef, useState } from "react";
+
 import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
+import { client } from "../../../orpc";
+import { useConfigStore } from "../../config/store";
+import { useProjectStore } from "../../project/store";
+import { useAgentStore } from "../store";
+
 const chatLog = debug("neovate:agent-chat");
-import { useNewSession } from "../hooks/use-new-session";
-import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
-import { claudeCodeChatManager } from "../chat-manager";
 import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
 } from "../../../components/ai-elements/conversation";
-import { MessageParts } from "./message-parts";
+import { claudeCodeChatManager } from "../chat-manager";
+import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
+import { useNewSession } from "../hooks/use-new-session";
 import { MessageInput } from "./message-input";
+import { MessageParts } from "./message-parts";
 import { PermissionDialog } from "./permission-dialog";
-import { WelcomePanel } from "./welcome-panel";
 import { TaskProgress } from "./task-progress";
+import { WelcomePanel } from "./welcome-panel";
 
 export function AgentChat() {
   const multiProjectSupport = useConfigStore((s) => s.multiProjectSupport);

--- a/packages/desktop/src/renderer/src/features/agent/components/attachment-preview.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/attachment-preview.tsx
@@ -1,4 +1,5 @@
 import { X } from "lucide-react";
+
 import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
 type Props = {

--- a/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
@@ -1,8 +1,9 @@
 import debug from "debug";
 import { memo, useState } from "react";
-import { useAgentStore } from "../store";
+
 import { useLoadSession } from "../hooks/use-load-session";
 import { useFilteredSessions } from "../hooks/use-unified-sessions";
+import { useAgentStore } from "../store";
 import { UnifiedSessionItem } from "./unified-session-item";
 
 const log = debug("neovate:chronological-list");

--- a/packages/desktop/src/renderer/src/features/agent/components/image-paste-extension.ts
+++ b/packages/desktop/src/renderer/src/features/agent/components/image-paste-extension.ts
@@ -1,8 +1,10 @@
-import { Extension } from "@tiptap/react";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Extension } from "@tiptap/react";
 import debug from "debug";
-import { readFileAsAttachment } from "../utils/read-file-as-attachment";
+
 import type { ImageAttachment } from "../../../../../shared/features/agent/types";
+
+import { readFileAsAttachment } from "../utils/read-file-as-attachment";
 
 const log = debug("neovate:image-paste");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -1,12 +1,15 @@
-import { useCallback } from "react";
-import debug from "debug";
 import type { StoreApi } from "zustand";
-import { useStore } from "zustand";
-import { Button } from "../../../components/ui/button";
+
+import debug from "debug";
 import { SendHorizonal, Square, Paperclip } from "lucide-react";
-import { useAgentStore } from "../store";
-import { claudeCodeChatManager } from "../chat-manager";
+import { useCallback } from "react";
+import { useStore } from "zustand";
+
 import type { ClaudeCodeChatStoreState } from "../chat-state";
+
+import { Button } from "../../../components/ui/button";
+import { claudeCodeChatManager } from "../chat-manager";
+import { useAgentStore } from "../store";
 
 const log = debug("neovate:input-toolbar");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/markdown-content.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/markdown-content.tsx
@@ -1,5 +1,5 @@
-import { Streamdown } from "streamdown";
 import { code } from "@streamdown/code";
+import { Streamdown } from "streamdown";
 
 type Props = { content: string; streaming?: boolean };
 

--- a/packages/desktop/src/renderer/src/features/agent/components/mention-extension.ts
+++ b/packages/desktop/src/renderer/src/features/agent/components/mention-extension.ts
@@ -1,10 +1,12 @@
-import Mention from "@tiptap/extension-mention";
 import type { SuggestionProps } from "@tiptap/suggestion";
-import { createRoot } from "react-dom/client";
-import { createElement, createRef } from "react";
+
+import Mention from "@tiptap/extension-mention";
 import { File } from "lucide-react";
-import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
+import { createElement, createRef } from "react";
+import { createRoot } from "react-dom/client";
+
 import { client } from "../../../orpc";
+import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
 import { positionAboveInput } from "./suggestion-position";
 
 function fileName(p: string): string {

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -1,21 +1,23 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import debug from "debug";
-import { Extension, useEditor, EditorContent } from "@tiptap/react";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
-import { createSlashCommandsExtension } from "./slash-commands-extension";
-import { createMentionExtension } from "./mention-extension";
-import { createImagePasteExtension } from "./image-paste-extension";
-import { AttachmentPreview } from "./attachment-preview";
-import { InputToolbar } from "./input-toolbar";
-import { useAgentStore } from "../store";
-import { useNewSession } from "../hooks/use-new-session";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Extension, useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import debug from "debug";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { ImageAttachment } from "../../../../../shared/features/agent/types";
+
 import { useEventCallback } from "../../../hooks/use-event-callback";
 import { useLatestRef } from "../../../hooks/use-latest-ref";
+import { useNewSession } from "../hooks/use-new-session";
+import { useAgentStore } from "../store";
 import { extractText } from "../utils/extract-text";
 import { readFileAsAttachment } from "../utils/read-file-as-attachment";
-import type { ImageAttachment } from "../../../../../shared/features/agent/types";
+import { AttachmentPreview } from "./attachment-preview";
+import { createImagePasteExtension } from "./image-paste-extension";
+import { InputToolbar } from "./input-toolbar";
+import { createMentionExtension } from "./mention-extension";
+import { createSlashCommandsExtension } from "./slash-commands-extension";
 
 const log = debug("neovate:message-input");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
@@ -1,7 +1,9 @@
-import type { ClaudeCodeUIMessage } from "../../../../../shared/claude-code/types";
 import { isToolUIPart } from "ai";
-import { ClaudeCodeToolUIPart } from "./tool-parts";
+
+import type { ClaudeCodeUIMessage } from "../../../../../shared/claude-code/types";
+
 import { Message, MessageContent, MessageResponse } from "../../../components/ai-elements/message";
+import { ClaudeCodeToolUIPart } from "./tool-parts";
 
 export function MessageParts({ message }: { message: ClaudeCodeUIMessage }) {
   return (

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
@@ -1,6 +1,8 @@
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
-import { Button } from "../../../components/ui/button";
+
 import type { ClaudeCodeUIEventRequest } from "../../../../../shared/claude-code/types";
+
+import { Button } from "../../../components/ui/button";
 
 type Props = {
   requestId: string;

--- a/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
@@ -1,8 +1,9 @@
 import debug from "debug";
 import { memo, useState } from "react";
-import { useAgentStore } from "../store";
+
 import { useLoadSession } from "../hooks/use-load-session";
 import { useFilteredSessions } from "../hooks/use-unified-sessions";
+import { useAgentStore } from "../store";
 import { UnifiedSessionItem } from "./unified-session-item";
 
 const log = debug("neovate:pinned-session-list");

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -1,19 +1,21 @@
-import debug from "debug";
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
 import { FolderIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import debug from "debug";
 import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
-import { useConfigStore } from "../../config/store";
-import { useNewSession } from "../hooks/use-new-session";
-import { useLoadSession } from "../hooks/use-load-session";
-import { useProject } from "../../project/hooks/use-project";
-import { useFilteredSessions } from "../hooks/use-unified-sessions";
-import { UnifiedSessionItem } from "./unified-session-item";
-import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
-import { Accordion, AccordionItem, AccordionPanel } from "../../../components/ui/accordion";
+
 import type { Project } from "../../../../../shared/features/project/types";
+
+import { Accordion, AccordionItem, AccordionPanel } from "../../../components/ui/accordion";
+import { useConfigStore } from "../../config/store";
+import { useProject } from "../../project/hooks/use-project";
+import { useProjectStore } from "../../project/store";
+import { useLoadSession } from "../hooks/use-load-session";
+import { useNewSession } from "../hooks/use-new-session";
+import { useFilteredSessions } from "../hooks/use-unified-sessions";
+import { useAgentStore } from "../store";
+import { UnifiedSessionItem } from "./unified-session-item";
 
 const log = debug("neovate:project-accordion");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
@@ -1,10 +1,9 @@
+import type { ReactElement, ReactNode } from "react";
+
 import debug from "debug";
 import { MoreHorizontal } from "lucide-react";
-import type { ReactElement, ReactNode } from "react";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
+
 import { Button } from "../../../components/ui/button";
-import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "../../../components/ui/menu";
 import {
   ContextMenu,
   ContextMenuItem,
@@ -12,6 +11,9 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "../../../components/ui/context-menu";
+import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "../../../components/ui/menu";
+import { useProjectStore } from "../../project/store";
+import { useAgentStore } from "../store";
 
 const log = debug("neovate:session-actions-menu");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/session-info-bar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-info-bar.tsx
@@ -1,9 +1,10 @@
 import debug from "debug";
 import { FolderOpen } from "lucide-react";
 import { useState } from "react";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
+
 import { client } from "../../../orpc";
+import { useProjectStore } from "../../project/store";
+import { useAgentStore } from "../store";
 import { SessionActionsMenu } from "./session-actions-menu";
 
 const log = debug("neovate:session-info-bar");

--- a/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
@@ -3,11 +3,12 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { Archive, Pin, PinOff } from "lucide-react";
 import { memo, useState } from "react";
-import { cn } from "../../../lib/utils";
+
 import { Spinner } from "../../../components/ui/spinner";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
+import { cn } from "../../../lib/utils";
 import { useConfigStore } from "../../config/store";
+import { useProjectStore } from "../../project/store";
+import { useAgentStore } from "../store";
 import { SessionActionsMenu } from "./session-actions-menu";
 
 function formatRelativeTime(iso: string): string {

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -1,20 +1,22 @@
-import { useEffect, useMemo, useState } from "react";
 import debug from "debug";
 import { Plus } from "lucide-react";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
-import { useConfigStore } from "../../config/store";
-import { Button } from "../../../components/ui/button";
-import { useNewSession } from "../hooks/use-new-session";
-import { useLoadSession } from "../hooks/use-load-session";
-import { UnifiedSessionItem } from "./unified-session-item";
-import { SidebarTitleBar } from "./sidebar-title-bar";
-import { PinnedSessionList } from "./pinned-session-list";
-import { ProjectAccordionList } from "./project-accordion-list";
-import { ChronologicalList } from "./chronological-list";
+import { useEffect, useMemo, useState } from "react";
+
+import type { SessionInfo } from "../../../../../shared/features/agent/types";
 import type { UnifiedItem } from "../hooks/use-unified-sessions";
 import type { ChatSession } from "../store";
-import type { SessionInfo } from "../../../../../shared/features/agent/types";
+
+import { Button } from "../../../components/ui/button";
+import { useConfigStore } from "../../config/store";
+import { useProjectStore } from "../../project/store";
+import { useLoadSession } from "../hooks/use-load-session";
+import { useNewSession } from "../hooks/use-new-session";
+import { useAgentStore } from "../store";
+import { ChronologicalList } from "./chronological-list";
+import { PinnedSessionList } from "./pinned-session-list";
+import { ProjectAccordionList } from "./project-accordion-list";
+import { SidebarTitleBar } from "./sidebar-title-bar";
+import { UnifiedSessionItem } from "./unified-session-item";
 
 const log = debug("neovate:session-list");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/sidebar-title-bar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/sidebar-title-bar.tsx
@@ -1,12 +1,11 @@
-import debug from "debug";
 import { FolderAddIcon, FilterIcon, FolderIcon, Clock01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import debug from "debug";
 import { CheckIcon, Plus } from "lucide-react";
 import { memo } from "react";
-import { useConfigStore } from "../../config/store";
-import { useProjectStore } from "../../project/store";
-import { useProject } from "../../project/hooks/use-project";
-import { useNewSession } from "../hooks/use-new-session";
+
+import type { SidebarOrganize, SidebarSortBy } from "../../../../../shared/features/config/types";
+
 import { Button } from "../../../components/ui/button";
 import {
   Menu,
@@ -17,7 +16,10 @@ import {
   MenuSeparator,
   MenuTrigger,
 } from "../../../components/ui/menu";
-import type { SidebarOrganize, SidebarSortBy } from "../../../../../shared/features/config/types";
+import { useConfigStore } from "../../config/store";
+import { useProject } from "../../project/hooks/use-project";
+import { useProjectStore } from "../../project/store";
+import { useNewSession } from "../hooks/use-new-session";
 
 const log = debug("neovate:sidebar-title-bar");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/slash-commands-extension.ts
+++ b/packages/desktop/src/renderer/src/features/agent/components/slash-commands-extension.ts
@@ -1,12 +1,14 @@
 import { Node, type Editor, mergeAttributes } from "@tiptap/react";
 import Suggestion, { type SuggestionProps } from "@tiptap/suggestion";
-import { createRoot } from "react-dom/client";
-import { createElement, createRef } from "react";
+import debug from "debug";
 import { Terminal } from "lucide-react";
+import { createElement, createRef } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { SlashCommandInfo } from "../../../../../shared/features/agent/types";
+
 import { SuggestionList, type SuggestionItem, type SuggestionListHandle } from "./suggestion-list";
 import { positionAboveInput } from "./suggestion-position";
-import type { SlashCommandInfo } from "../../../../../shared/features/agent/types";
-import debug from "debug";
 
 const slashLog = debug("neovate:slash-commands");
 

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-actions-group.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-actions-group.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
 import { ChevronDown, FileText, Pencil, Terminal, Search, Wrench } from "lucide-react";
-import { cn } from "../../../lib/utils";
+import { useState } from "react";
+
+import type { ToolCallState } from "../store";
+
 import {
   Collapsible,
   CollapsibleTrigger,
   CollapsiblePanel,
 } from "../../../components/ui/collapsible";
-import type { ToolCallState } from "../store";
+import { cn } from "../../../lib/utils";
 
 function categorize(name: string): "read" | "write" | "bash" | "search" | "other" {
   if (/read|glob|grep/i.test(name)) return "read";

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/ask-user-question-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/ask-user-question-tool.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useState } from "react";
+
 import type { AskUserQuestionUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import { useState } from "react";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
-import { RadioGroup, RadioGroupItem } from "../../../../components/ui/radio-group";
-import { Checkbox } from "../../../../components/ui/checkbox";
 import { Button } from "../../../../components/ui/button";
+import { Checkbox } from "../../../../components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "../../../../components/ui/radio-group";
 import { useAgentStore } from "../../store";
 
 type Props = {

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/edit-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/edit-tool.tsx
@@ -1,6 +1,7 @@
+import type { BundledLanguage } from "shiki";
+
 import type { EditUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import type { BundledLanguage } from "shiki";
 import { CodeBlock } from "../../../../components/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/index.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/index.tsx
@@ -1,4 +1,5 @@
 import type { ToolUIPart } from "ai";
+
 import type {
   ClaudeCodeUIMessage,
   ClaudeCodeUITools,

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/multi-edit-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/multi-edit-tool.tsx
@@ -1,6 +1,7 @@
+import type { BundledLanguage } from "shiki";
+
 import type { MultiEditUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import type { BundledLanguage } from "shiki";
 import { CodeBlock } from "../../../../components/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/read-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/read-tool.tsx
@@ -1,6 +1,7 @@
+import type { BundledLanguage } from "shiki";
+
 import type { ReadUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import type { BundledLanguage } from "shiki";
 import { CodeBlock, CodeBlockCopyButton } from "../../../../components/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/task-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/task-tool.tsx
@@ -1,11 +1,12 @@
+import { isToolUIPart, type ToolUIPart } from "ai";
+import { type ReactNode, useMemo } from "react";
+
 import type {
   ClaudeCodeUIMessage,
   ClaudeCodeUITools,
   TaskUIToolInvocation,
 } from "../../../../../../shared/claude-code/types";
 
-import { isToolUIPart, type ToolUIPart } from "ai";
-import { type ReactNode, useMemo } from "react";
 import { MessageResponse } from "../../../../components/ai-elements/message";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/todo-write-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/todo-write-tool.tsx
@@ -1,8 +1,9 @@
+import { SquareCheckIcon, SquareDotIcon, SquareIcon } from "lucide-react";
+
 import type { TodoWriteUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import { cn } from "../../../../lib/utils";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
-import { SquareCheckIcon, SquareDotIcon, SquareIcon } from "lucide-react";
+import { cn } from "../../../../lib/utils";
 
 export function TodoWriteTool({ invocation }: { invocation: TodoWriteUIToolInvocation }) {
   if (!invocation || invocation.state === "input-streaming") return null;

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/write-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/write-tool.tsx
@@ -1,6 +1,7 @@
+import type { BundledLanguage } from "shiki";
+
 import type { WriteUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import type { BundledLanguage } from "shiki";
 import { CodeBlock } from "../../../../components/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 

--- a/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
@@ -1,7 +1,9 @@
 import { memo } from "react";
-import { SessionItem } from "./session-item";
+
 import type { UnifiedItem } from "../hooks/use-unified-sessions";
+
 import { useSessionChatStatus } from "../hooks/use-session-chat-status";
+import { SessionItem } from "./session-item";
 
 interface UnifiedSessionItemProps {
   item: UnifiedItem;

--- a/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
@@ -1,4 +1,5 @@
 import { MessageCircle } from "lucide-react";
+
 import { ProjectSelector } from "../../project/components/project-selector";
 
 export function WelcomePanel() {

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-claude-code-chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-claude-code-chat.ts
@@ -1,4 +1,5 @@
 import { useStore } from "zustand";
+
 import { claudeCodeChatManager } from "../chat-manager";
 
 export function useClaudeCodeChat(sessionId: string) {

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-load-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-load-session.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef } from "react";
 import debug from "debug";
-import { useAgentStore } from "../store";
+import { useCallback, useEffect, useRef } from "react";
+
 import { claudeCodeChatManager } from "../chat-manager";
+import { useAgentStore } from "../store";
 
 const loadLog = debug("neovate:agent-load-session");
 

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
@@ -1,8 +1,9 @@
-import { useCallback } from "react";
 import debug from "debug";
-import { useAgentStore } from "../store";
+import { useCallback } from "react";
+
 import { useProjectStore } from "../../project/store";
 import { claudeCodeChatManager } from "../chat-manager";
+import { useAgentStore } from "../store";
 
 const newSessionLog = debug("neovate:agent-new-session");
 

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-session-chat-status.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-session-chat-status.ts
@@ -1,4 +1,5 @@
 import { useCallback, useSyncExternalStore } from "react";
+
 import { claudeCodeChatManager } from "../chat-manager";
 
 const noop = () => () => {};

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
@@ -1,9 +1,11 @@
 import { useMemo } from "react";
-import { useAgentStore } from "../store";
-import { useProjectStore } from "../../project/store";
-import { useConfigStore } from "../../config/store";
-import type { ChatSession } from "../store";
+
 import type { SessionInfo } from "../../../../../shared/features/agent/types";
+import type { ChatSession } from "../store";
+
+import { useConfigStore } from "../../config/store";
+import { useProjectStore } from "../../project/store";
+import { useAgentStore } from "../store";
 
 export type UnifiedItem =
   | { kind: "memory"; session: ChatSession; projectPath: string }

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -1,13 +1,15 @@
+import debug from "debug";
+import { enableMapSet } from "immer";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-import { enableMapSet } from "immer";
+
 import type {
   SessionInfo,
   SlashCommandInfo,
   ModelInfo,
 } from "../../../../shared/features/agent/types";
+
 import { client } from "../../orpc";
-import debug from "debug";
 
 const storeLog = debug("neovate:agent-store");
 

--- a/packages/desktop/src/renderer/src/features/config/store.ts
+++ b/packages/desktop/src/renderer/src/features/config/store.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+
 import type { AppConfig } from "../../../../shared/features/config/types";
-import { client } from "../../orpc";
+
 import { DEFAULT_KEYBINDINGS, type KeybindingAction } from "../../lib/keybindings";
+import { client } from "../../orpc";
 
 type KeybindingsConfig = Record<KeybindingAction, string>;
 

--- a/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ContentPanel } from "../content-panel";
-import type { ContentPanelOptions } from "../content-panel";
+
 import type { ContentPanelView } from "../../../core/plugin/contributions";
+import type { ContentPanelOptions } from "../content-panel";
+
+import { ContentPanel } from "../content-panel";
 
 const PROJECT = "/test/project";
 

--- a/packages/desktop/src/renderer/src/features/content-panel/__tests__/view-context.test.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/__tests__/view-context.test.tsx
@@ -1,13 +1,15 @@
-// @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { type ReactNode } from "react";
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import type { ContentPanelView } from "../../../core/plugin/contributions";
+
 import {
   ContentPanelViewContextProvider,
   useContentPanelViewContext,
 } from "../components/view-context";
 import { ContentPanel } from "../content-panel";
-import type { ContentPanelView } from "../../../core/plugin/contributions";
 
 // Mock useRendererApp to return our test contentPanel
 let panel: ContentPanel;

--- a/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
@@ -1,12 +1,14 @@
 import { Activity, lazy, Suspense, useEffect, useRef } from "react";
 import { useStore } from "zustand";
-import { useRendererApp } from "../../../core";
-import { useProjectStore } from "../../project/store";
-import { cn } from "../../../lib/utils";
-import { ContentPanelViewContextProvider } from "./view-context";
-import { TabBar } from "./tab-bar";
+
 import type { ContentPanelView } from "../../../core/plugin/contributions";
 import type { ContentPanelStoreState } from "../types";
+
+import { useRendererApp } from "../../../core";
+import { cn } from "../../../lib/utils";
+import { useProjectStore } from "../../project/store";
+import { TabBar } from "./tab-bar";
+import { ContentPanelViewContextProvider } from "./view-context";
 
 function useLazyComponents(views: ContentPanelView[]) {
   const cache = useRef(new Map<string, React.LazyExoticComponent<React.ComponentType>>());

--- a/packages/desktop/src/renderer/src/features/content-panel/components/new-tab-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/new-tab-menu.tsx
@@ -1,11 +1,13 @@
-import { useMemo } from "react";
 import { Plus } from "lucide-react";
+import { useMemo } from "react";
 import { useStore } from "zustand";
+
+import type { ContentPanelStoreState, Tab } from "../types";
+
+import { Button } from "../../../components/ui/button";
+import { Menu, MenuTrigger, MenuPopup, MenuItem } from "../../../components/ui/menu";
 import { useRendererApp } from "../../../core";
 import { useProjectStore } from "../../project/store";
-import { Menu, MenuTrigger, MenuPopup, MenuItem } from "../../../components/ui/menu";
-import { Button } from "../../../components/ui/button";
-import type { ContentPanelStoreState, Tab } from "../types";
 
 const EMPTY_TABS: Tab[] = [];
 

--- a/packages/desktop/src/renderer/src/features/content-panel/components/tab-bar.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/tab-bar.tsx
@@ -1,7 +1,8 @@
-import { ScrollArea } from "../../../components/ui/scroll-area";
 import type { Tab } from "../types";
-import { TabItem } from "./tab-item";
+
+import { ScrollArea } from "../../../components/ui/scroll-area";
 import { NewTabMenu } from "./new-tab-menu";
+import { TabItem } from "./tab-item";
 
 export function TabBar({
   tabs,

--- a/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
@@ -1,10 +1,13 @@
 import type React from "react";
+
 import { X, TriangleAlert } from "lucide-react";
-import { useRendererApp } from "../../../core";
-import { cn } from "../../../lib/utils";
+
+import type { Tab } from "../types";
+
 import { Button } from "../../../components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipPopup } from "../../../components/ui/tooltip";
-import type { Tab } from "../types";
+import { useRendererApp } from "../../../core";
+import { cn } from "../../../lib/utils";
 
 function TabButton({
   tab,

--- a/packages/desktop/src/renderer/src/features/content-panel/components/view-context.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/view-context.tsx
@@ -1,7 +1,9 @@
 import { createContext, useContext, type ReactNode } from "react";
 import { useStore } from "zustand";
-import { useRendererApp } from "../../../core";
+
 import type { ContentPanelStoreState } from "../types";
+
+import { useRendererApp } from "../../../core";
 
 const ViewIdContext = createContext<string | null>(null);
 

--- a/packages/desktop/src/renderer/src/features/content-panel/content-panel.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/content-panel.ts
@@ -1,6 +1,8 @@
 import type { StoreApi } from "zustand/vanilla";
+
 import type { ContentPanelView } from "../../core/plugin/contributions";
 import type { Tab, ContentPanelStoreState, ProjectTabState } from "./types";
+
 import { createContentPanelStore } from "./store";
 
 export interface ContentPanelOptions {

--- a/packages/desktop/src/renderer/src/features/content-panel/store.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/store.ts
@@ -1,5 +1,6 @@
-import { createStore } from "zustand/vanilla";
 import { immer } from "zustand/middleware/immer";
+import { createStore } from "zustand/vanilla";
+
 import type { ProjectTabState, ContentPanelStoreState } from "./types";
 
 const EMPTY_PROJECT: ProjectTabState = { tabs: [], activeTabId: null };

--- a/packages/desktop/src/renderer/src/features/open-in/components/open-app-button.tsx
+++ b/packages/desktop/src/renderer/src/features/open-in/components/open-app-button.tsx
@@ -1,5 +1,19 @@
 import { ChevronDown, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
+
+import type { App } from "../../../../../shared/features/utils/types";
+
+import antigravityIcon from "../../../assets/icons/antigravity.png";
+import cursorIcon from "../../../assets/icons/cursor.png";
+import finderIcon from "../../../assets/icons/finder.png";
+import itermIcon from "../../../assets/icons/iterm.png";
+import sourcetreeIcon from "../../../assets/icons/sourcetree.png";
+import terminalIcon from "../../../assets/icons/terminal.png";
+import vscodeInsidersIcon from "../../../assets/icons/vscode-insiders.png";
+import vscodeIcon from "../../../assets/icons/vscode.png";
+import warpIcon from "../../../assets/icons/warp.png";
+import windsurfIcon from "../../../assets/icons/windsurf.png";
+import zedIcon from "../../../assets/icons/zed.png";
 import { Button } from "../../../components/ui/button";
 import {
   DropdownMenu,
@@ -8,21 +22,9 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "../../../components/ui/menu";
+import { DEFAULT_KEYBINDINGS, formatKeyForDisplay } from "../../../lib/keybindings";
 import { client } from "../../../orpc";
 import { useConfigStore } from "../../config/store";
-import { DEFAULT_KEYBINDINGS, formatKeyForDisplay } from "../../../lib/keybindings";
-import type { App } from "../../../../../shared/features/utils/types";
-import antigravityIcon from "../../../assets/icons/antigravity.png";
-import cursorIcon from "../../../assets/icons/cursor.png";
-import finderIcon from "../../../assets/icons/finder.png";
-import itermIcon from "../../../assets/icons/iterm.png";
-import sourcetreeIcon from "../../../assets/icons/sourcetree.png";
-import terminalIcon from "../../../assets/icons/terminal.png";
-import vscodeIcon from "../../../assets/icons/vscode.png";
-import vscodeInsidersIcon from "../../../assets/icons/vscode-insiders.png";
-import warpIcon from "../../../assets/icons/warp.png";
-import windsurfIcon from "../../../assets/icons/windsurf.png";
-import zedIcon from "../../../assets/icons/zed.png";
 
 const APP_NAMES: Record<App, string> = {
   cursor: "Cursor",

--- a/packages/desktop/src/renderer/src/features/project/components/project-selector.tsx
+++ b/packages/desktop/src/renderer/src/features/project/components/project-selector.tsx
@@ -1,7 +1,9 @@
+import type React from "react";
+
 import { Delete02Icon, FolderIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
-import type React from "react";
+
 import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "../../../components/ui/menu";
 import { useProject } from "../hooks/use-project";
 

--- a/packages/desktop/src/renderer/src/features/project/hooks/use-project.ts
+++ b/packages/desktop/src/renderer/src/features/project/hooks/use-project.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+
 import { client } from "../../../orpc";
 import { useProjectStore } from "../store";
 

--- a/packages/desktop/src/renderer/src/features/project/store.ts
+++ b/packages/desktop/src/renderer/src/features/project/store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+
 import type { Project } from "../../../../shared/features/project/types";
+
 import { client } from "../../orpc";
 
 type ProjectState = {

--- a/packages/desktop/src/renderer/src/features/settings/__tests__/service.test.ts
+++ b/packages/desktop/src/renderer/src/features/settings/__tests__/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SettingsService, type SettingsServiceOptions } from "../service";
+
 import { DEFAULT_SETTINGS } from "../../../../../shared/features/settings/schema";
+import { SettingsService, type SettingsServiceOptions } from "../service";
 
 describe("SettingsService", () => {
   let load: ReturnType<typeof vi.fn<SettingsServiceOptions["load"]>>;

--- a/packages/desktop/src/renderer/src/features/settings/__tests__/types.test-d.ts
+++ b/packages/desktop/src/renderer/src/features/settings/__tests__/types.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest";
-import type { ISettingsService, IScopedSettings } from "../../../core/types";
+
 import type { Preferences } from "../../../../../shared/features/settings/schema";
+import type { ISettingsService, IScopedSettings } from "../../../core/types";
 
 declare const service: ISettingsService;
 

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/about-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/about-panel.tsx
@@ -1,6 +1,7 @@
 import { HelpCircle, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+
 import { Button } from "../../../../components/ui/button";
 import { Spinner } from "../../../../components/ui/spinner";
 import { SettingsRow } from "../settings-row";

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -1,12 +1,13 @@
 import { MessageSquare } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useConfigStore } from "../../../config/store";
+
 import type {
   ApprovalMode,
   NotificationSound,
   AgentLanguage,
   SendMessageWith,
 } from "../../../../../../shared/features/config/types";
+
 import {
   Select,
   SelectItem,
@@ -16,6 +17,7 @@ import {
 } from "../../../../components/ui/select";
 import { Spinner } from "../../../../components/ui/spinner";
 import { ToggleOptions } from "../../../../components/ui/toggle-options";
+import { useConfigStore } from "../../../config/store";
 import { SettingsRow } from "../settings-row";
 
 // Translation key mappings

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
@@ -1,13 +1,14 @@
 import { Settings } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { localeOptions, type Locales } from "../../../../core/i18n";
-import { useRendererApp } from "../../../../core";
-import { useConfigStore } from "../../../config/store";
-import { client } from "../../../../orpc";
+
 import { Input } from "../../../../components/ui/input";
 import { Spinner } from "../../../../components/ui/spinner";
 import { Switch } from "../../../../components/ui/switch";
 import { ToggleOptions } from "../../../../components/ui/toggle-options";
+import { useRendererApp } from "../../../../core";
+import { localeOptions, type Locales } from "../../../../core/i18n";
+import { client } from "../../../../orpc";
+import { useConfigStore } from "../../../config/store";
 import { SettingsRow } from "../settings-row";
 
 export const GeneralPanel = () => {

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/keybindings-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/keybindings-panel.tsx
@@ -1,6 +1,8 @@
 import { Keyboard, Lock } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import { Button } from "../../../../components/ui/button";
 import {
   captureKeybinding,
   DEFAULT_KEYBINDINGS,
@@ -11,7 +13,6 @@ import {
 } from "../../../../lib/keybindings";
 import { cn } from "../../../../lib/utils";
 import { useConfigStore } from "../../../config/store";
-import { Button } from "../../../../components/ui/button";
 
 const KEYBINDING_ACTIONS: KeybindingAction[] = [
   "openSettings",

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/rules-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/rules-panel.tsx
@@ -1,5 +1,6 @@
 import { BookOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
+
 import { Button } from "../../../../components/ui/button";
 import { SettingsRow } from "../settings-row";
 

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/skills-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/skills-panel.tsx
@@ -1,11 +1,12 @@
 import { Loader2, Plus, Trash2, Wand2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { cn } from "../../../../lib/utils";
-import { useConfigStore } from "../../../config/store";
+
 import { Button } from "../../../../components/ui/button";
 import { Checkbox } from "../../../../components/ui/checkbox";
 import { Input } from "../../../../components/ui/input";
+import { cn } from "../../../../lib/utils";
+import { useConfigStore } from "../../../config/store";
 
 // Types
 interface Skill {

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-menu.tsx
@@ -8,8 +8,10 @@ import {
   Wand2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { cn } from "../../../lib/utils";
+
 import type { SettingsMenuId } from "../store";
+
+import { cn } from "../../../lib/utils";
 import { useSettingsStore } from "../store";
 
 interface MenuItem {

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-page.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
+
 import { matchesBinding } from "../../../lib/keybindings";
-import { useSettingsStore } from "../store";
 import { useConfigStore } from "../../config/store";
-import { SettingsMenu } from "./settings-menu";
+import { useSettingsStore } from "../store";
 import { AboutPanel } from "./panels/about-panel";
 import { ChatPanel } from "./panels/chat-panel";
 import { GeneralPanel } from "./panels/general-panel";
@@ -10,6 +10,7 @@ import { KeybindingsPanel } from "./panels/keybindings-panel";
 import { MCPPanel } from "./panels/mcp-panel";
 import { RulesPanel } from "./panels/rules-panel";
 import { SkillsPanel } from "./panels/skills-panel";
+import { SettingsMenu } from "./settings-menu";
 
 export const SettingsPage = () => {
   // UI state from useSettingsStore

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-row.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-row.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+
 import { cn } from "../../../lib/utils";
 
 interface SettingsRowProps {

--- a/packages/desktop/src/renderer/src/features/settings/hooks.ts
+++ b/packages/desktop/src/renderer/src/features/settings/hooks.ts
@@ -1,6 +1,8 @@
 import { useStore } from "zustand";
-import { useRendererApp } from "../../core";
+
 import type { SettingsState } from "./store";
+
+import { useRendererApp } from "../../core";
 
 export function useSettings<T>(selector: (state: SettingsState) => T): T {
   const { settings } = useRendererApp();

--- a/packages/desktop/src/renderer/src/features/settings/service.ts
+++ b/packages/desktop/src/renderer/src/features/settings/service.ts
@@ -1,10 +1,12 @@
 import { shallow } from "zustand/shallow";
+
+import type { ISettingsService, IScopedSettings } from "../../core/types";
+
 import {
   settingsSchema,
   DEFAULT_SETTINGS,
   type SettingsSchema,
 } from "../../../../shared/features/settings/schema";
-import type { ISettingsService, IScopedSettings } from "../../core/types";
 import { createSettingsStore, type SettingsStore, type SettingsState } from "./store";
 
 const FLUSH_DELAY = 500;

--- a/packages/desktop/src/renderer/src/features/settings/store.ts
+++ b/packages/desktop/src/renderer/src/features/settings/store.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
-import { createStore } from "zustand/vanilla";
-import { immer } from "zustand/middleware/immer";
 import { subscribeWithSelector } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+import { createStore } from "zustand/vanilla";
+
 import type { SettingsSchema } from "../../../../shared/features/settings/schema";
 
 // --- UI State (settings modal) ---

--- a/packages/desktop/src/renderer/src/hooks/use-global-keybindings.ts
+++ b/packages/desktop/src/renderer/src/hooks/use-global-keybindings.ts
@@ -1,11 +1,12 @@
+import { useTheme } from "next-themes";
 import { useEffect } from "react";
-import { matchesBinding, DEFAULT_KEYBINDINGS } from "../lib/keybindings";
-import { useSettingsStore } from "../features/settings/store";
+
+import { toastManager } from "../components/ui/toast";
+import { useNewSession } from "../features/agent/hooks/use-new-session";
 import { useConfigStore } from "../features/config/store";
 import { useProjectStore } from "../features/project/store";
-import { useNewSession } from "../features/agent/hooks/use-new-session";
-import { useTheme } from "next-themes";
-import { toastManager } from "../components/ui/toast";
+import { useSettingsStore } from "../features/settings/store";
+import { matchesBinding, DEFAULT_KEYBINDINGS } from "../lib/keybindings";
 
 /**
  * Global keybinding handler for app-wide shortcuts.

--- a/packages/desktop/src/renderer/src/orpc.ts
+++ b/packages/desktop/src/renderer/src/orpc.ts
@@ -1,6 +1,8 @@
+import type { ContractRouterClient } from "@orpc/contract";
+
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/message-port";
-import type { ContractRouterClient } from "@orpc/contract";
+
 import { contract } from "../../shared/contract";
 
 const { port1: clientPort, port2: serverPort } = new MessageChannel();

--- a/packages/desktop/src/renderer/src/plugins/content-panel-demo/demo-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/content-panel-demo/demo-view.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { useStore } from "zustand";
-import { useContentPanelViewContext } from "../../features/content-panel";
+
 import type { ContentPanelStoreState } from "../../features/content-panel";
-import { useRendererApp } from "../../core/app";
+
 import { Button } from "../../components/ui/button";
 import { ScrollArea } from "../../components/ui/scroll-area";
+import { useRendererApp } from "../../core/app";
+import { useContentPanelViewContext } from "../../features/content-panel";
 
 export default function DemoView() {
   const { viewId, viewState: state } = useContentPanelViewContext();

--- a/packages/desktop/src/renderer/src/plugins/content-panel-demo/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/content-panel-demo/index.tsx
@@ -1,5 +1,6 @@
 import { SquareLock01Icon, Copy01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { RendererPlugin } from "../../core/plugin";
 
 const SingletonIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/demo-window/open-demo-window-button.tsx
+++ b/packages/desktop/src/renderer/src/plugins/demo-window/open-demo-window-button.tsx
@@ -1,5 +1,6 @@
 import { CursorInWindowIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import { Button } from "../../components/ui/button";
 import { client } from "../../orpc";
 

--- a/packages/desktop/src/renderer/src/plugins/editor/editor-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/editor/editor-view.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from "react";
-import { usePluginContext } from "../../core/app";
 import { ContractRouterClient } from "@orpc/contract";
+import { useEffect, useRef, useState } from "react";
+
 import { editorContract } from "../../../../shared/plugins/editor/contract";
+import { usePluginContext } from "../../core/app";
 import { useProjectStore } from "../../features/project/store";
-import { EditorStatus } from "./type";
 import { ErrorState, LoadingState } from "./status";
+import { EditorStatus } from "./type";
 
 type EditorClient = ContractRouterClient<{ editor: typeof editorContract }>;
 

--- a/packages/desktop/src/renderer/src/plugins/editor/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/editor/index.tsx
@@ -1,7 +1,9 @@
 import { FileEditIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { RendererPlugin } from "../../core/plugin";
 import { ContractRouterClient } from "@orpc/contract";
+
+import type { RendererPlugin } from "../../core/plugin";
+
 import { editorContract } from "../../../../shared/plugins/editor/contract";
 
 const EditorIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
@@ -1,15 +1,17 @@
-import { useEffect, useState } from "react";
 import type { ContractRouterClient } from "@orpc/contract";
+
 import { consumeEventIterator } from "@orpc/client";
 import debug from "debug";
+import { useEffect, useState } from "react";
+
+import type { Project } from "../../../../shared/features/project/types";
 
 import { FileTreeItem } from "../../../../shared/plugins/files/contract";
 import { filesContract } from "../../../../shared/plugins/files/contract";
-import type { Project } from "../../../../shared/features/project/types";
 import { usePluginContext } from "../../core/app";
-import { TreeNode } from "./tree-node";
 import { useProjectStore } from "../../features/project/store";
 import { useFilesTranslation } from "./i18n";
+import { TreeNode } from "./tree-node";
 
 const log = debug("neovate:files-view");
 

--- a/packages/desktop/src/renderer/src/plugins/files/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/index.tsx
@@ -1,5 +1,6 @@
 import { FolderIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { RendererPlugin } from "../../core/plugin";
 
 const FilesIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/files/tree-node.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/tree-node.tsx
@@ -1,10 +1,10 @@
-import { HugeiconsIcon } from "@hugeicons/react";
 import { File02Icon, Folder02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronRight, ChevronDown, FilePlus, FolderPlus, Edit, Trash2, Plus } from "lucide-react";
 import { useState } from "react";
-import { useFilesTranslation } from "./i18n";
-import { cn } from "../../lib/utils";
+
 import type { FileTreeItem } from "../../../../shared/plugins/files/contract";
+
 import {
   ContextMenu,
   ContextMenuTrigger,
@@ -12,6 +12,8 @@ import {
   ContextMenuItem,
   ContextMenuSeparator,
 } from "../../components/ui/context-menu";
+import { cn } from "../../lib/utils";
+import { useFilesTranslation } from "./i18n";
 
 interface TreeNodeProps {
   item: FileTreeItem;

--- a/packages/desktop/src/renderer/src/plugins/git/git-diff-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/git/git-diff-view.tsx
@@ -1,11 +1,12 @@
-import { memo, useEffect, useState } from "react";
 import { MultiFileDiff } from "@pierre/diffs/react";
-import { Client } from "./hooks/useGit";
-import { useProjectStore } from "../../features/project/store";
-import { useGitTranslation } from "./i18n";
-import { useTheme } from "next-themes";
 import { File, GitBranch } from "lucide-react";
+import { useTheme } from "next-themes";
+import { memo, useEffect, useState } from "react";
+
 import { usePluginContext } from "../../core/app";
+import { useProjectStore } from "../../features/project/store";
+import { Client } from "./hooks/useGit";
+import { useGitTranslation } from "./i18n";
 
 interface DiffData {
   oldContent: string;

--- a/packages/desktop/src/renderer/src/plugins/git/git-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/git/git-view.tsx
@@ -1,10 +1,11 @@
-import { memo, useEffect, useState } from "react";
 import { ChevronDown, ChevronRight, ArrowUp, ArrowDown, RefreshCw, Undo2 } from "lucide-react";
+import { memo, useEffect, useState } from "react";
+
 import { type GitFile } from "../../../../shared/plugins/git/contract";
+import { usePluginContext } from "../../core/app";
+import { useProjectStore } from "../../features/project/store";
 import { useGit } from "./hooks/useGit";
 import { useGitTranslation } from "./i18n";
-import { useProjectStore } from "../../features/project/store";
-import { usePluginContext } from "../../core/app";
 
 export default memo(function GitView() {
   const { t } = useGitTranslation();

--- a/packages/desktop/src/renderer/src/plugins/git/hooks/useGit.ts
+++ b/packages/desktop/src/renderer/src/plugins/git/hooks/useGit.ts
@@ -1,8 +1,11 @@
 import type { ContractRouterClient } from "@orpc/contract";
+
 import { useState } from "react";
+
 import type { GitFile } from "../../../../../shared/plugins/git/contract";
-import { gitContract } from "../../../../../shared/plugins/git/contract";
+
 import { utilsContract } from "../../../../../shared/features/utils/contract";
+import { gitContract } from "../../../../../shared/plugins/git/contract";
 import { usePluginContext } from "../../../core/app";
 
 export type Client = ContractRouterClient<{

--- a/packages/desktop/src/renderer/src/plugins/git/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/git/index.tsx
@@ -1,5 +1,6 @@
 import { GitBranchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { RendererPlugin } from "../../core/plugin";
 
 const GitIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/search/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/search/index.tsx
@@ -1,5 +1,6 @@
 import { Search02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { RendererPlugin } from "../../core/plugin";
 
 const SearchIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/search/search-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/search/search-view.tsx
@@ -1,13 +1,16 @@
-import { useState, useEffect, useRef } from "react";
 import type { ContractRouterClient } from "@orpc/contract";
+
 import { Search, FileText, Loader2, ChevronRight, CaseSensitive, WholeWord } from "lucide-react";
-import { utilsContract } from "../../../../shared/features/utils/contract";
+import { useState, useEffect, useRef } from "react";
+
 import type { Project } from "../../../../shared/features/project/types";
+
+import { utilsContract } from "../../../../shared/features/utils/contract";
+import { Input } from "../../components/ui/input";
 import { usePluginContext } from "../../core/app";
 import { useProjectStore } from "../../features/project/store";
-import { useSearchTranslation } from "./i18n";
-import { Input } from "../../components/ui/input";
 import { cn } from "../../lib/utils";
+import { useSearchTranslation } from "./i18n";
 
 // File icon component
 function FileLangIcon({ path, size = 14 }: { path: string; size?: number }) {

--- a/packages/desktop/src/renderer/src/plugins/terminal/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/terminal/index.tsx
@@ -1,5 +1,6 @@
 import { ComputerTerminal01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+
 import type { RendererPlugin } from "../../core/plugin";
 
 const TerminalIcon = ({ className }: { className?: string }) => (

--- a/packages/desktop/src/renderer/src/plugins/terminal/terminal-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/terminal/terminal-view.tsx
@@ -1,14 +1,15 @@
 import type { ContractRouterClient } from "@orpc/contract";
-import { useEffect, useRef } from "react";
-import { useTheme } from "next-themes";
-import { Terminal } from "@xterm/xterm";
+
 import { FitAddon } from "@xterm/addon-fit";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
+import { Terminal } from "@xterm/xterm";
+import { useTheme } from "next-themes";
+import { useEffect, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
+import { terminalContract } from "../../../../shared/plugins/terminal/contract";
 import { usePluginContext } from "../../core/app";
 import { useProjectStore } from "../../features/project/store";
-import { terminalContract } from "../../../../shared/plugins/terminal/contract";
 
 type TerminalClient = ContractRouterClient<{ terminal: typeof terminalContract }>;
 

--- a/packages/desktop/src/shared/claude-code/tools/index.ts
+++ b/packages/desktop/src/shared/claude-code/tools/index.ts
@@ -23,29 +23,29 @@ export { Skill, type SkillUIToolInvocation } from "./skill";
 export { EnterPlanMode, type EnterPlanModeUIToolInvocation } from "./enter-plan-mode";
 export { EnterWorktree, type EnterWorktreeUIToolInvocation } from "./enter-worktree";
 
+import { Agent } from "./agent";
+import { AskUserQuestion } from "./ask-user-question";
 // Re-import for registry object
 import { Bash } from "./bash";
-import { Agent } from "./agent";
+import { BashOutput } from "./bash-output";
+import { Edit } from "./edit";
+import { EnterPlanMode } from "./enter-plan-mode";
+import { EnterWorktree } from "./enter-worktree";
+import { ExitPlanMode } from "./exit-plan-mode";
+import { Glob } from "./glob";
+import { Grep } from "./grep";
+import { MultiEdit } from "./multi-edit";
+import { NotebookEdit } from "./notebook-edit";
+import { Read } from "./read";
+import { Skill } from "./skill";
+import { SlashCommand } from "./slash-command";
 import { Task } from "./task";
 import { TaskOutput } from "./task-output";
 import { TaskStop } from "./task-stop";
-import { Read } from "./read";
-import { Edit } from "./edit";
-import { MultiEdit } from "./multi-edit";
-import { Write } from "./write";
-import { Glob } from "./glob";
-import { Grep } from "./grep";
+import { TodoWrite } from "./todo-write";
 import { WebFetch } from "./web-fetch";
 import { WebSearch } from "./web-search";
-import { TodoWrite } from "./todo-write";
-import { BashOutput } from "./bash-output";
-import { SlashCommand } from "./slash-command";
-import { ExitPlanMode } from "./exit-plan-mode";
-import { NotebookEdit } from "./notebook-edit";
-import { AskUserQuestion } from "./ask-user-question";
-import { Skill } from "./skill";
-import { EnterPlanMode } from "./enter-plan-mode";
-import { EnterWorktree } from "./enter-worktree";
+import { Write } from "./write";
 
 /**
  * Registry of all Claude Code tools with Zod schemas.

--- a/packages/desktop/src/shared/claude-code/types.ts
+++ b/packages/desktop/src/shared/claude-code/types.ts
@@ -22,6 +22,7 @@ import type {
   SDKPromptSuggestionMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { InferUIMessageChunk, UIMessage } from "ai";
+
 import type { ClaudeCodeUITools } from "./tools";
 
 // ─── Stream (message) ────────────────────────────────────────────────────────

--- a/packages/desktop/src/shared/contract.ts
+++ b/packages/desktop/src/shared/contract.ts
@@ -1,5 +1,6 @@
 import { oc, type } from "@orpc/contract";
 import { z } from "zod";
+
 import { agentContract } from "./features/agent/contract";
 import { configContract } from "./features/config/contract";
 import { projectContract } from "./features/project/contract";

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -1,6 +1,8 @@
+import type { Query } from "@anthropic-ai/claude-agent-sdk";
+
 import { oc, type, eventIterator } from "@orpc/contract";
 import { z } from "zod";
-import type { SessionInfo } from "./types";
+
 import type {
   ClaudeCodeUIMessage,
   ClaudeCodeUIMessageChunk,
@@ -8,7 +10,7 @@ import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../claude-code/types";
-import type { Query } from "@anthropic-ai/claude-agent-sdk";
+import type { SessionInfo } from "./types";
 
 export const agentContract = {
   listSessions: oc.input(z.object({ cwd: z.string().optional() })).output(type<SessionInfo[]>()),

--- a/packages/desktop/src/shared/features/config/contract.ts
+++ b/packages/desktop/src/shared/features/config/contract.ts
@@ -1,5 +1,6 @@
 import { oc, type } from "@orpc/contract";
 import { z } from "zod";
+
 import type { AppConfig } from "./types";
 
 // Value schemas for each key

--- a/packages/desktop/src/shared/features/project/contract.ts
+++ b/packages/desktop/src/shared/features/project/contract.ts
@@ -1,5 +1,6 @@
 import { oc, type } from "@orpc/contract";
 import { z } from "zod";
+
 import type { Project } from "./types";
 
 export const projectContract = {

--- a/packages/desktop/src/shared/features/utils/contract.ts
+++ b/packages/desktop/src/shared/features/utils/contract.ts
@@ -1,5 +1,6 @@
 import { oc, type } from "@orpc/contract";
 import { z } from "zod";
+
 import type { App } from "./types";
 
 const appSchema = z.enum([


### PR DESCRIPTION
## Summary

- Configure oxfmt's built-in `sortImports` in `.oxfmtrc.json` to enforce consistent import ordering across the codebase
- Groups: type imports → builtins/externals → internal types → internal values → relative types → relative values → unknown, separated by blank lines
- Run `bun run format` to apply sorting to all 213 existing files — no changes to `package.json` or git hooks needed

Closes #67

## Test plan

- [x] `bun run lint:format` passes
- [ ] Verify imports are correctly grouped in a few files
- [ ] Confirm pre-commit hook enforces sorting on new changes