### PR TITLE
fix: resolve duplicate React keys in message list

### DIFF
--- a/packages/desktop/scripts/test-session-transform.ts
+++ b/packages/desktop/scripts/test-session-transform.ts
@@ -1,0 +1,82 @@
+/**
+ * Usage:
+ *   bun scripts/test-session-transform.ts <sessionId>   - test one session
+ *   bun scripts/test-session-transform.ts --all          - test all sessions
+ */
+import { getSessionMessages, listSessions } from "@anthropic-ai/claude-agent-sdk";
+
+import type { ClaudeCodeUIMessage } from "../src/shared/claude-code/types";
+
+import { sessionMessagesToUIMessages } from "../src/main/features/agent/utils/session-messages-to-ui-messages";
+
+function validate(messages: ClaudeCodeUIMessage[]): string[] {
+  const issues: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg.id) issues.push(`[${i}] ${msg.role}: empty ID`);
+    if (seenIds.has(msg.id)) issues.push(`[${i}] ${msg.role}: duplicate ID "${msg.id}"`);
+    seenIds.add(msg.id);
+    if (msg.parts.length === 0) issues.push(`[${i}] ${msg.role}: no parts`);
+  }
+
+  return issues;
+}
+
+async function testSession(
+  sessionId: string,
+): Promise<{ ok: boolean; raw: number; ui: number; issues: string[] }> {
+  const raw = await getSessionMessages(sessionId);
+  const ui = await sessionMessagesToUIMessages(raw);
+  const issues = validate(ui);
+  return { ok: issues.length === 0, raw: raw.length, ui: ui.length, issues };
+}
+
+const arg = process.argv[2];
+
+if (!arg) {
+  console.error(
+    "Usage:\n  bun scripts/test-session-transform.ts <sessionId>\n  bun scripts/test-session-transform.ts --all",
+  );
+  process.exit(1);
+}
+
+if (arg === "--all") {
+  const sessions = await listSessions();
+  let pass = 0,
+    fail = 0,
+    empty = 0;
+
+  for (const s of sessions) {
+    try {
+      const result = await testSession(s.sessionId);
+      if (result.raw === 0) {
+        empty++;
+        continue;
+      }
+      if (result.ok) {
+        pass++;
+      } else {
+        fail++;
+        console.log(`✗ ${s.sessionId} (raw=${result.raw} ui=${result.ui})`);
+        for (const issue of result.issues) console.log(`    ${issue}`);
+      }
+    } catch (e) {
+      fail++;
+      console.log(`✗ ${s.sessionId} ERROR: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+
+  console.log(`\n${pass} pass, ${fail} fail, ${empty} empty (${sessions.length} total)`);
+  process.exit(fail > 0 ? 1 : 0);
+} else {
+  const result = await testSession(arg);
+  console.log(`Raw: ${result.raw}, UI: ${result.ui}`);
+  if (result.ok) {
+    console.log("✓ All checks passed");
+  } else {
+    for (const issue of result.issues) console.log(`✗ ${issue}`);
+    process.exit(1);
+  }
+}

--- a/packages/desktop/src/main/features/agent/__tests__/sdk-message-transformer.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/sdk-message-transformer.test.ts
@@ -51,7 +51,35 @@ describe("SDKMessageTransformer", () => {
     expect(chunks[1].type).toBe("data-system/init");
   });
 
-  it("assistant text → start-step + text-start/delta/end", () => {
+  it("assistant without prior system/init → start + start-step + text", () => {
+    const chunks = collect(
+      t.transform(makeAssistantMsg("msg-A", [{ type: "text", text: "Hello" }]) as any),
+    );
+    expect(chunks.map((c: any) => c.type)).toEqual([
+      "start",
+      "start-step",
+      "text-start",
+      "text-delta",
+      "text-end",
+    ]);
+    expect(chunks[0]).toMatchObject({ type: "start", messageId: "msg-A" });
+    expect(chunks.find((c: any) => c.type === "text-delta").delta).toBe("Hello");
+  });
+
+  it("assistant after system/init → no extra start", () => {
+    const initMsg = {
+      type: "system" as const,
+      subtype: "init" as const,
+      uuid: "uuid-1",
+      session_id: "sess-1",
+      model: "claude-3",
+      tools: [],
+      slash_commands: [],
+      cwd: "/tmp",
+      mcp_servers: [],
+      api_key_source: "env",
+    };
+    collect(t.transform(initMsg as any));
     const chunks = collect(
       t.transform(makeAssistantMsg("msg-A", [{ type: "text", text: "Hello" }]) as any),
     );
@@ -61,7 +89,6 @@ describe("SDKMessageTransformer", () => {
       "text-delta",
       "text-end",
     ]);
-    expect(chunks.find((c: any) => c.type === "text-delta").delta).toBe("Hello");
   });
 
   it("same message.id does not emit start-step again", () => {
@@ -77,9 +104,14 @@ describe("SDKMessageTransformer", () => {
     const second = collect(
       t.transform(makeAssistantMsg("msg-B", [{ type: "text", text: "B" }]) as any),
     );
-    const types = second.map((c: any) => c.type);
-    expect(types[0]).toBe("finish-step");
-    expect(types[1]).toBe("start-step");
+    // no second "start" — already started
+    expect(second.map((c: any) => c.type)).toEqual([
+      "finish-step",
+      "start-step",
+      "text-start",
+      "text-delta",
+      "text-end",
+    ]);
   });
 
   it("result/success → finish-step + finish (no error chunk)", () => {
@@ -179,6 +211,112 @@ describe("SDKMessageTransformer", () => {
     );
     const tool = chunks.find((c: any) => c.type === "tool-input-available");
     expect(tool).toMatchObject({ toolCallId: "tc-1", toolName: "Read", providerExecuted: true });
+  });
+
+  it("assistant with empty content → start + start-step only", () => {
+    const chunks = collect(t.transform(makeAssistantMsg("msg-A", []) as any));
+    expect(chunks.map((c: any) => c.type)).toEqual(["start", "start-step"]);
+  });
+
+  it("multiple tool_use in one message → multiple tool-input-available", () => {
+    const chunks = collect(
+      t.transform(
+        makeAssistantMsg("msg-A", [
+          { type: "tool_use", id: "tc-1", name: "Read", input: { path: "/a" } },
+          { type: "tool_use", id: "tc-2", name: "Write", input: { path: "/b" } },
+        ]) as any,
+      ),
+    );
+    const tools = chunks.filter((c: any) => c.type === "tool-input-available");
+    expect(tools).toHaveLength(2);
+    expect(tools[0].toolCallId).toBe("tc-1");
+    expect(tools[1].toolCallId).toBe("tc-2");
+  });
+
+  it("mixed content: thinking + text + tool_use in one message", () => {
+    const chunks = collect(
+      t.transform(
+        makeAssistantMsg("msg-A", [
+          { type: "thinking", thinking: "hmm" },
+          { type: "text", text: "I will read the file" },
+          { type: "tool_use", id: "tc-1", name: "Read", input: { path: "/tmp" } },
+        ]) as any,
+      ),
+    );
+    const types = chunks.map((c: any) => c.type);
+    expect(types).toEqual([
+      "start",
+      "start-step",
+      "reasoning-start",
+      "reasoning-delta",
+      "reasoning-end",
+      "text-start",
+      "text-delta",
+      "text-end",
+      "tool-input-available",
+    ]);
+  });
+
+  it("multiple tool_results in one user message", () => {
+    const msg = {
+      type: "user" as const,
+      uuid: "u",
+      session_id: "s",
+      parent_tool_use_id: null,
+      message: {
+        role: "user" as const,
+        content: [
+          { type: "tool_result", tool_use_id: "tc-1", content: "ok", is_error: false },
+          { type: "tool_result", tool_use_id: "tc-2", content: "fail", is_error: true },
+        ],
+      },
+    };
+    const chunks = collect(t.transform(msg as any));
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toMatchObject({ type: "tool-output-available", toolCallId: "tc-1" });
+    expect(chunks[1]).toMatchObject({ type: "tool-output-error", toolCallId: "tc-2" });
+  });
+
+  it("compact_boundary does not break step tracking", () => {
+    collect(t.transform(makeAssistantMsg("msg-A", [{ type: "text", text: "A" }]) as any));
+    const compactChunks = collect(
+      t.transform({
+        type: "system" as const,
+        subtype: "compact_boundary" as const,
+        uuid: "cb",
+        session_id: "s",
+      } as any),
+    );
+    expect(compactChunks.map((c: any) => c.type)).toEqual(["data-system/compact_boundary"]);
+    // Next assistant should still detect new step
+    const nextChunks = collect(
+      t.transform(makeAssistantMsg("msg-B", [{ type: "text", text: "B" }]) as any),
+    );
+    expect(nextChunks.map((c: any) => c.type)).toContain("finish-step");
+    expect(nextChunks.map((c: any) => c.type)).toContain("start-step");
+  });
+
+  it("tool_use with parent_tool_use_id passes metadata", () => {
+    const chunks = collect(
+      t.transform({
+        ...makeAssistantMsg("msg-A", [{ type: "tool_use", id: "tc-1", name: "Read", input: {} }]),
+        parent_tool_use_id: "parent-tc",
+      } as any),
+    );
+    const tool = chunks.find((c: any) => c.type === "tool-input-available");
+    expect(tool.providerMetadata).toEqual({ claudeCode: { parentToolUseId: "parent-tc" } });
+  });
+
+  it("tool_use without parent_tool_use_id has no metadata", () => {
+    const chunks = collect(
+      t.transform(
+        makeAssistantMsg("msg-A", [
+          { type: "tool_use", id: "tc-1", name: "Read", input: {} },
+        ]) as any,
+      ),
+    );
+    const tool = chunks.find((c: any) => c.type === "tool-input-available");
+    expect(tool.providerMetadata).toBeUndefined();
   });
 });
 

--- a/packages/desktop/src/main/features/agent/__tests__/session-messages-to-ui-messages.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/session-messages-to-ui-messages.test.ts
@@ -1,0 +1,80 @@
+import { getSessionMessages, listSessions } from "@anthropic-ai/claude-agent-sdk";
+import { describe, it, expect, beforeAll } from "vitest";
+
+import { sessionMessagesToUIMessages } from "../utils/session-messages-to-ui-messages";
+
+function validate(messages: { id: string; role: string; parts: any[] }[]) {
+  const issues: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (!msg.id) {
+      issues.push(`[${i}] ${msg.role}: empty ID`);
+    }
+    if (seenIds.has(msg.id)) {
+      issues.push(`[${i}] ${msg.role}: duplicate ID "${msg.id}"`);
+    }
+    seenIds.add(msg.id);
+
+    if (msg.role === "user" && msg.parts.length === 0) {
+      issues.push(`[${i}] user: no parts`);
+    }
+
+    if (msg.role === "assistant") {
+      for (const part of msg.parts) {
+        if (part.type === "tool-invocation" && !part.toolInvocation?.toolCallId) {
+          issues.push(`[${i}] assistant: tool-invocation missing toolCallId`);
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+describe("sessionMessagesToUIMessages with local sessions", () => {
+  let sessionIds: string[] = [];
+
+  beforeAll(async () => {
+    try {
+      const sessions = await listSessions();
+      sessionIds = sessions.map((s) => s.sessionId);
+    } catch {
+      // no sessions available
+    }
+  });
+
+  it("transforms all local sessions without issues", async () => {
+    if (sessionIds.length === 0) return;
+
+    for (const sessionId of sessionIds) {
+      const raw = await getSessionMessages(sessionId);
+      if (raw.length === 0) continue;
+
+      const messages = await sessionMessagesToUIMessages(raw);
+      const issues = validate(messages);
+
+      if (issues.length > 0) {
+        console.warn(`Issues in ${sessionId}:\n  ${issues.join("\n  ")}`);
+      }
+
+      for (const msg of messages) {
+        expect(msg.id, `${sessionId}: message should have a non-empty id`).toBeTruthy();
+      }
+
+      const ids = messages.map((m) => m.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size, `${sessionId}: should have no duplicate IDs`).toBe(ids.length);
+
+      for (const msg of messages) {
+        if (msg.role === "user") {
+          expect(msg.parts.length, `${sessionId}: user message should have parts`).toBeGreaterThan(
+            0,
+          );
+        }
+      }
+    }
+  });
+});

--- a/packages/desktop/src/main/features/agent/sdk-message-transformer.ts
+++ b/packages/desktop/src/main/features/agent/sdk-message-transformer.ts
@@ -7,6 +7,7 @@ import type {
 
 export class SDKMessageTransformer {
   private inStep = false;
+  private hasStarted = false;
   private currentMessageId: string | null = null;
 
   *transform(msg: SDKMessage): Generator<ClaudeCodeUIMessageChunk> {
@@ -14,6 +15,7 @@ export class SDKMessageTransformer {
       case "system": {
         if (msg.subtype === "init") {
           this.inStep = false;
+          this.hasStarted = true;
           this.currentMessageId = null;
           yield {
             type: "start",
@@ -28,6 +30,10 @@ export class SDKMessageTransformer {
       }
 
       case "assistant": {
+        if (!this.hasStarted) {
+          this.hasStarted = true;
+          yield { type: "start", messageId: msg.message.id };
+        }
         const isNewStep = msg.message.id !== this.currentMessageId;
         if (isNewStep) {
           if (this.inStep) yield { type: "finish-step" };

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -1,10 +1,8 @@
 import type {
   Query,
   Options,
-  SDKMessage,
   SDKUserMessage,
   SDKSessionInfo,
-  SessionMessage,
   PermissionMode as SDKPermissionMode,
 } from "@anthropic-ai/claude-agent-sdk";
 
@@ -14,7 +12,6 @@ import {
   listSessions as sdkListSessions,
 } from "@anthropic-ai/claude-agent-sdk";
 import { EventPublisher } from "@orpc/server";
-import { createUIMessageStream, readUIMessageStream } from "ai";
 import debug from "debug";
 import { randomUUID } from "node:crypto";
 import { globSync, statSync } from "node:fs";
@@ -33,6 +30,7 @@ import type { SessionInfo } from "../../../shared/features/agent/types";
 import { Pushable } from "./pushable";
 import { SDKMessageTransformer, toUIEvent } from "./sdk-message-transformer";
 import { getShellEnvironment } from "./shell-env";
+import { sessionMessagesToUIMessages } from "./utils/session-messages-to-ui-messages";
 
 const log = debug("neovate:session-manager");
 
@@ -146,7 +144,7 @@ export class SessionManager {
     const capabilities = await this.initSession(sessionId, cwd, { resume: sessionId });
 
     const sessionMessages = await getSessionMessages(sessionId);
-    const messages = await this.toUIMessages(sessionMessages);
+    const messages = await sessionMessagesToUIMessages(sessionMessages);
 
     log(
       "loadSession: sessionId=%s raw=%d messages=%d",
@@ -265,84 +263,6 @@ export class SessionManager {
       await this.closeSession(sessionId);
     }
     log("closeAll: DONE");
-  }
-
-  /** Convert SDK SessionMessages to ClaudeCodeUIMessages, split by human prompt boundaries. */
-  private async toUIMessages(sessionMessages: SessionMessage[]): Promise<ClaudeCodeUIMessage[]> {
-    const results: ClaudeCodeUIMessage[] = [];
-    let batch: SessionMessage[] = [];
-
-    const flushBatch = async () => {
-      if (batch.length === 0) return;
-      const batchCopy = batch;
-      batch = [];
-      const transformer = new SDKMessageTransformer();
-
-      const stream = createUIMessageStream<ClaudeCodeUIMessage>({
-        execute({ writer }) {
-          for (const msg of batchCopy) {
-            for (const chunk of transformer.transform(msg as SDKMessage)) {
-              writer.write(chunk);
-            }
-          }
-        },
-      });
-
-      const messageStream = readUIMessageStream<ClaudeCodeUIMessage>({ stream });
-      let last: ClaudeCodeUIMessage | undefined;
-      for await (const msg of messageStream) {
-        last = msg;
-      }
-      if (last) results.push(last);
-    };
-
-    for (const msg of sessionMessages) {
-      const content = (msg as any).message?.content;
-      const isHumanTextPrompt =
-        msg.type === "user" && typeof content === "string" && !content.startsWith("<");
-      const isHumanArrayPrompt =
-        msg.type === "user" &&
-        Array.isArray(content) &&
-        content.some((b: any) => b.type === "text" || b.type === "image");
-
-      if (isHumanTextPrompt || isHumanArrayPrompt) {
-        await flushBatch();
-        const parts: ClaudeCodeUIMessage["parts"] = [];
-
-        if (typeof content === "string") {
-          parts.push({ type: "text", text: content, state: "done" } as any);
-        } else if (Array.isArray(content)) {
-          const textStr = content
-            .filter((b: any) => b.type === "text")
-            .map((b: any) => b.text)
-            .join("");
-          if (textStr) {
-            parts.push({ type: "text", text: textStr, state: "done" } as any);
-          }
-          for (const b of content) {
-            if (b.type === "image" && b.source?.type === "base64") {
-              parts.push({
-                type: "file",
-                mediaType: b.source.media_type ?? "image/png",
-                url: `data:${b.source.media_type ?? "image/png"};base64,${b.source.data}`,
-              } as any);
-            }
-          }
-        }
-
-        results.push({
-          id: (msg as any).uuid ?? crypto.randomUUID(),
-          role: "user",
-          parts,
-          metadata: { sessionId: (msg as any).session_id, parentToolUseId: null },
-        } as ClaudeCodeUIMessage);
-      } else {
-        batch.push(msg);
-      }
-    }
-
-    await flushBatch();
-    return results;
   }
 
   /**

--- a/packages/desktop/src/main/features/agent/utils/session-messages-to-ui-messages.ts
+++ b/packages/desktop/src/main/features/agent/utils/session-messages-to-ui-messages.ts
@@ -1,0 +1,125 @@
+import type { SDKMessage, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+
+import { createUIMessageStream, readUIMessageStream } from "ai";
+
+import type { ClaudeCodeUIMessage } from "../../../../shared/claude-code/types";
+
+import { SDKMessageTransformer } from "../sdk-message-transformer";
+
+/**
+ * Convert raw SDK session messages into UI messages.
+ * Human prompts become user messages; assistant/tool_result batches
+ * are replayed through the AI SDK stream protocol.
+ *
+ * Accepts SessionMessage[] (from getSessionMessages) — cast internally
+ * to SDKMessage[] since the runtime data includes system/result types
+ * that the SessionMessage type declaration doesn't cover.
+ */
+export async function sessionMessagesToUIMessages(
+  sessionMessages: SessionMessage[],
+): Promise<ClaudeCodeUIMessage[]> {
+  const results: ClaudeCodeUIMessage[] = [];
+  let batch: SDKMessage[] = [];
+
+  const flushBatch = async () => {
+    if (batch.length === 0) return;
+    const batchCopy = batch;
+    batch = [];
+    const transformer = new SDKMessageTransformer();
+
+    const stream = createUIMessageStream<ClaudeCodeUIMessage>({
+      execute({ writer }) {
+        for (const msg of batchCopy) {
+          for (const chunk of transformer.transform(msg)) {
+            writer.write(chunk);
+          }
+        }
+      },
+    });
+
+    const messageStream = readUIMessageStream<ClaudeCodeUIMessage>({ stream });
+    let last: ClaudeCodeUIMessage | undefined;
+    for await (const msg of messageStream) {
+      last = msg;
+    }
+    if (last) results.push(last);
+  };
+
+  // SessionMessage type is narrower than runtime data; cast once here.
+  const messages = sessionMessages as unknown as SDKMessage[];
+
+  for (const msg of messages) {
+    // Skip messages that don't contribute to UIMessage content
+    if (msg.type === "system" && msg.subtype !== "init") continue;
+    if (msg.type === "result") continue;
+
+    if (msg.type !== "user" && msg.type !== "assistant" && msg.type !== "system") {
+      continue;
+    }
+
+    if (msg.type !== "user") {
+      batch.push(msg);
+      continue;
+    }
+
+    const content = msg.message.content;
+    const isToolResultMessage =
+      Array.isArray(content) && content.some((p: { type: string }) => p.type === "tool_result");
+    const isHumanTextPrompt = typeof content === "string";
+    const isHumanArrayPrompt =
+      Array.isArray(content) &&
+      content.some((b: { type: string }) => b.type === "text" || b.type === "image");
+    const isHumanPrompt = !isToolResultMessage && (isHumanTextPrompt || isHumanArrayPrompt);
+
+    if (isHumanPrompt) {
+      await flushBatch();
+      const parts: ClaudeCodeUIMessage["parts"] = [];
+
+      if (typeof content === "string") {
+        parts.push({
+          type: "text",
+          text: content,
+          state: "done",
+        } as ClaudeCodeUIMessage["parts"][number]);
+      } else if (Array.isArray(content)) {
+        const textStr = content
+          .filter((b: { type: string }) => b.type === "text")
+          .map((b: { type: string; text?: string }) => b.text ?? "")
+          .join("");
+        if (textStr) {
+          parts.push({
+            type: "text",
+            text: textStr,
+            state: "done",
+          } as ClaudeCodeUIMessage["parts"][number]);
+        }
+        for (const b of content) {
+          const block = b as {
+            type: string;
+            source?: { type: string; media_type?: string; data?: string };
+          };
+          if (block.type === "image" && block.source?.type === "base64") {
+            const mediaType = block.source.media_type ?? "image/png";
+            parts.push({
+              type: "file",
+              mediaType,
+              url: `data:${mediaType};base64,${block.source.data}`,
+            } as ClaudeCodeUIMessage["parts"][number]);
+          }
+        }
+      }
+
+      results.push({
+        id: msg.uuid ?? crypto.randomUUID(),
+        role: "user",
+        parts,
+        metadata: { sessionId: msg.session_id, parentToolUseId: null },
+      } as ClaudeCodeUIMessage);
+    } else {
+      batch.push(msg);
+    }
+  }
+
+  await flushBatch();
+  return results;
+}

--- a/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
@@ -13,13 +13,21 @@ export function MessageParts({ message }: { message: ClaudeCodeUIMessage }) {
           if (part.type === "dynamic-tool") {
             return null;
           }
-          return <ClaudeCodeToolUIPart key={part.toolCallId} message={message} part={part} />;
+          return (
+            <div key={part.toolCallId} data-key={part.toolCallId}>
+              <ClaudeCodeToolUIPart message={message} part={part} />
+            </div>
+          );
         }
 
         switch (part.type) {
           case "text":
             return (
-              <Message key={`${message.id}-${index}`} from={message.role}>
+              <Message
+                key={`${message.id}-${index}`}
+                data-key={`${message.id}-${index}`}
+                from={message.role}
+              >
                 <MessageContent>
                   {message.role === "assistant" ? (
                     <MessageResponse>{part.text}</MessageResponse>
@@ -33,6 +41,7 @@ export function MessageParts({ message }: { message: ClaudeCodeUIMessage }) {
             return (
               <div
                 key={`${message.id}-${index}`}
+                data-key={`${message.id}-${index}`}
                 className="border-b border-border pb-2 text-xs italic text-muted-foreground"
               >
                 {part.text}


### PR DESCRIPTION
## Summary
- Fix empty message IDs causing duplicate React keys when loading sessions
- Add `hasStarted` flag to `SDKMessageTransformer` so `start` chunk always emits a proper `messageId`
- Extract `sessionMessagesToUIMessages` from `session-manager.ts` into `utils/` for reuse and testability
- Skip non-content SDK messages (`compact_boundary`, `result`) during session replay
- Add `data-key` attributes to message parts DOM for debugging

## Test plan
- [x] 27 unit tests for `SDKMessageTransformer` (including new edge cases: empty content, mixed content, multiple tool_use, compact_boundary)
- [x] Integration test validates transformation against all 450 local sessions — no empty IDs, no duplicate IDs
- [x] Typecheck and lint pass