### PR TITLE
feat: add projectInfo for plugin context

### DIFF
--- a/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
@@ -12,6 +12,7 @@ function createMockApp(): IRendererApp {
     i18nManager: {} as IRendererApp["i18nManager"],
     settings: {} as IRendererApp["settings"],
     workbench: { contentPanel: {} as any },
+    project: {} as any,
   };
 }
 

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -10,6 +10,7 @@ import type { IRendererApp, IWorkbench } from "./types";
 import { ToastProvider } from "../components/ui/toast";
 import { useConfigStore } from "../features/config/store";
 import { ContentPanel } from "../features/content-panel";
+import { useProjectStore } from "../features/project/store";
 import { SettingsService } from "../features/settings/service";
 import { useSettingsStore } from "../features/settings/store";
 import { client } from "../orpc";
@@ -105,6 +106,31 @@ export class RendererApp implements IRendererApp {
   // @ts-expect-error reserved for future use
   readonly #windowId: string;
   readonly subscriptions = new DisposableStore();
+  readonly project = {
+    getActiveProject: () => {
+      const activeProject = useProjectStore.getState().activeProject;
+      if (!activeProject) return activeProject;
+      const { id, name, path } = activeProject;
+      return { id, name, path };
+    },
+    subscribe: (
+      listener: (project: ReturnType<typeof useProjectStore.getState>["activeProject"]) => void,
+    ) =>
+      useProjectStore.subscribe((state, prevState) => {
+        if (state.activeProject === prevState.activeProject) return;
+        listener(state.activeProject);
+      }),
+    refresh: async () => {
+      const [projects, activeProject] = await Promise.all([
+        client.project.list(),
+        client.project.getActive(),
+      ]);
+      const state = useProjectStore.getState();
+      state.setProjects(projects);
+      state.setActiveProject(activeProject);
+      return activeProject;
+    },
+  };
   readonly settings = new SettingsService({
     load: async () => {
       const all = await client.storage.getAll({ namespace: "config" });
@@ -162,6 +188,7 @@ export class RendererApp implements IRendererApp {
     const i18nConfigs = await this.pluginManager.configI18n();
     this.i18nManager.setupLazyNamespaces(i18nConfigs);
     await this.hydrate();
+    await this.project.refresh();
 
     // Collect window contributions — all windows (needed for lookup)
     await this.pluginManager.configWindowContributions();

--- a/packages/desktop/src/renderer/src/core/types.ts
+++ b/packages/desktop/src/renderer/src/core/types.ts
@@ -1,3 +1,4 @@
+import type { Project } from "../../../shared/features/project/types";
 import type { SettingsSchema } from "../../../shared/features/settings/schema";
 import type { ContentPanel } from "../features/content-panel/content-panel";
 import type { SettingsStore } from "../features/settings/store";
@@ -16,6 +17,12 @@ export interface ISettingsService extends Disposable {
   scoped<K extends string & keyof SettingsSchema>(namespace: K): IScopedSettings<SettingsSchema[K]>;
 }
 
+export interface IProjectService {
+  getActiveProject(): Pick<Project, "id" | "name" | "path"> | null;
+  subscribe(listener: (project: Project | null) => void): Unsubscribe;
+  refresh(): Promise<Project | null>;
+}
+
 export interface IWorkbench {
   readonly contentPanel: ContentPanel;
 }
@@ -26,6 +33,7 @@ export interface IRendererApp {
   readonly subscriptions: {
     push(...disposables: (Disposable | Unsubscribe)[]): void;
   };
+  readonly project: IProjectService;
   readonly settings: ISettingsService;
   readonly workbench: IWorkbench;
 }


### PR DESCRIPTION
Add projectInfo in RendererApp, then plugins(NeoDebug) can get it in context