### PR TITLE
feat: add hierarchical model settings with session/project/global scopes

### DIFF
--- a/packages/desktop/src/main/features/agent/claude-settings.ts
+++ b/packages/desktop/src/main/features/agent/claude-settings.ts
@@ -1,0 +1,118 @@
+import debug from "debug";
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { ModelScope } from "../../../shared/features/agent/types";
+
+const log = debug("neovate:claude-settings");
+
+const SESSIONS_DIR = join(homedir(), ".neovate-desktop", "sessions");
+
+function sessionConfigPath(sessionId: string): string {
+  return join(SESSIONS_DIR, `${sessionId}.json`);
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | undefined {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeJsonFile(filePath: string, data: Record<string, unknown>): void {
+  const dir = join(filePath, "..");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Read the effective model for a session.
+ * Priority:
+ *   1. ~/.neovate-desktop/sessions/<sessionId>.json  (session-scoped)
+ *   2. <cwd>/.claude/settings.local.json             (project-scoped)
+ *   3. ~/.claude/settings.json                       (global)
+ */
+export function readModelSetting(
+  sessionId: string,
+  cwd: string,
+): { model: string; scope: ModelScope } | undefined {
+  // 1. Session-scoped
+  const sessionJson = readJsonFile(sessionConfigPath(sessionId));
+  if (typeof sessionJson?.model === "string" && sessionJson.model) {
+    log("readModelSetting: session scope model=%s sid=%s", sessionJson.model, sessionId);
+    return { model: sessionJson.model, scope: "session" };
+  }
+
+  // 2. Project-scoped
+  const projectJson = readJsonFile(join(cwd, ".claude", "settings.local.json"));
+  if (typeof projectJson?.model === "string" && projectJson.model) {
+    log("readModelSetting: project scope model=%s cwd=%s", projectJson.model, cwd);
+    return { model: projectJson.model, scope: "project" };
+  }
+
+  // 3. Global
+  const globalJson = readJsonFile(join(homedir(), ".claude", "settings.json"));
+  if (typeof globalJson?.model === "string" && globalJson.model) {
+    log("readModelSetting: global scope model=%s", globalJson.model);
+    return { model: globalJson.model, scope: "global" };
+  }
+
+  return undefined;
+}
+
+/**
+ * Write (or remove) a model setting at the given scope.
+ * Pass `null` to remove the model key (e.g. "Clear session override").
+ */
+export function writeModelSetting(
+  scope: ModelScope,
+  model: string | null,
+  opts: { sessionId?: string; cwd?: string },
+): void {
+  switch (scope) {
+    case "session": {
+      if (!opts.sessionId) throw new Error("sessionId required for session scope");
+      const filePath = sessionConfigPath(opts.sessionId);
+      if (model === null) {
+        try {
+          unlinkSync(filePath);
+          log("writeModelSetting: removed session config sid=%s", opts.sessionId);
+        } catch {
+          // File didn't exist — no-op
+        }
+        return;
+      }
+      const existing = readJsonFile(filePath) ?? {};
+      writeJsonFile(filePath, { ...existing, model });
+      log("writeModelSetting: session scope model=%s sid=%s", model, opts.sessionId);
+      break;
+    }
+    case "project": {
+      if (!opts.cwd) throw new Error("cwd required for project scope");
+      const filePath = join(opts.cwd, ".claude", "settings.local.json");
+      const existing = readJsonFile(filePath) ?? {};
+      if (model === null) {
+        delete existing.model;
+      } else {
+        existing.model = model;
+      }
+      writeJsonFile(filePath, existing);
+      log("writeModelSetting: project scope model=%s cwd=%s", model, opts.cwd);
+      break;
+    }
+    case "global": {
+      const filePath = join(homedir(), ".claude", "settings.json");
+      const existing = readJsonFile(filePath) ?? {};
+      if (model === null) {
+        delete existing.model;
+      } else {
+        existing.model = model;
+      }
+      writeJsonFile(filePath, existing);
+      log("writeModelSetting: global scope model=%s", model);
+      break;
+    }
+  }
+}

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -4,6 +4,7 @@ import debug from "debug";
 import type { AppContext } from "../../router";
 
 import { agentContract } from "../../../shared/features/agent/contract";
+import { readModelSetting, writeModelSetting } from "./claude-settings";
 
 const agentLog = debug("neovate:agent-router");
 
@@ -61,5 +62,20 @@ export const agentRouter = os.agent.router({
         throw new ORPCError("BAD_GATEWAY", { defined: true, message });
       }
     }),
+  }),
+
+  setModelSetting: os.agent.setModelSetting.handler(({ input, context }) => {
+    const { sessionId, model, scope } = input;
+    const cwd = context.sessionManager.getSessionCwd(sessionId);
+    agentLog(
+      "setModelSetting: sessionId=%s model=%s scope=%s cwd=%s",
+      sessionId,
+      model,
+      scope,
+      cwd,
+    );
+    writeModelSetting(scope, model, { sessionId, cwd });
+    const effective = readModelSetting(sessionId, cwd);
+    return { currentModel: effective?.model, modelScope: effective?.scope };
   }),
 });

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -25,8 +25,9 @@ import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../../shared/claude-code/types";
-import type { SessionInfo } from "../../../shared/features/agent/types";
+import type { ModelScope, SessionInfo } from "../../../shared/features/agent/types";
 
+import { readModelSetting } from "./claude-settings";
 import { Pushable } from "./pushable";
 import { SDKMessageTransformer, toUIEvent } from "./sdk-message-transformer";
 import { getShellEnvironment } from "./shell-env";
@@ -153,10 +154,23 @@ export class SessionManager {
   async createSession(
     cwd: string,
     model?: string,
-  ): Promise<{ sessionId: string } & Awaited<ReturnType<Query["initializationResult"]>>> {
+  ): Promise<
+    { sessionId: string; currentModel?: string; modelScope?: ModelScope } & Awaited<
+      ReturnType<Query["initializationResult"]>
+    >
+  > {
     const sessionId = randomUUID();
-    const initResult = await this.initSession(sessionId, cwd, { model });
-    return { ...initResult, sessionId };
+    // Resolve model: explicit param > project/global settings
+    const modelSetting = model
+      ? { model, scope: "session" as const }
+      : readModelSetting(sessionId, cwd);
+    const initResult = await this.initSession(sessionId, cwd, { model: modelSetting?.model });
+    return {
+      ...initResult,
+      sessionId,
+      currentModel: modelSetting?.model,
+      modelScope: modelSetting?.scope,
+    };
   }
 
   /** Resume an existing session, returning converted historical messages. */
@@ -167,20 +181,35 @@ export class SessionManager {
     sessionId: string;
     capabilities: Awaited<ReturnType<Query["initializationResult"]>>;
     messages: ClaudeCodeUIMessage[];
+    currentModel?: string;
+    modelScope?: ModelScope;
   }> {
-    const capabilities = await this.initSession(sessionId, cwd, { resume: sessionId });
+    // Read persisted model setting before initializing SDK query
+    const modelSetting = readModelSetting(sessionId, cwd);
+    const capabilities = await this.initSession(sessionId, cwd, {
+      model: modelSetting?.model,
+      resume: sessionId,
+    });
 
     const sessionMessages = await getSessionMessages(sessionId);
     const messages = await sessionMessagesToUIMessages(sessionMessages);
 
     log(
-      "loadSession: sessionId=%s raw=%d messages=%d",
+      "loadSession: sessionId=%s raw=%d messages=%d currentModel=%s modelScope=%s",
       sessionId,
       sessionMessages.length,
       messages.length,
+      modelSetting?.model ?? "(default)",
+      modelSetting?.scope ?? "(none)",
     );
 
-    return { sessionId, capabilities, messages };
+    return {
+      sessionId,
+      capabilities,
+      messages,
+      currentModel: modelSetting?.model,
+      modelScope: modelSetting?.scope,
+    };
   }
 
   /** Shared session initialization: shell env, query, canUseTool wiring. */
@@ -206,7 +235,7 @@ export class SessionManager {
       ...(mergedPath ? { PATH: mergedPath } : {}),
     };
 
-    const queryOpts = this.queryOptions({ sessionId, cwd, model: opts?.model ?? "sonnet" });
+    const queryOpts = this.queryOptions({ sessionId, cwd, model: opts?.model });
     const options: Options = {
       ...queryOpts,
       env,
@@ -265,6 +294,12 @@ export class SessionManager {
     const entry = JSON.stringify({ type: "custom-title", customTitle: title, sessionId });
     await appendFile(matches[0], entry + "\n");
     log("renameSession: DONE sessionId=%s", sessionId);
+  }
+
+  getSessionCwd(sessionId: string): string {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown session: ${sessionId}`);
+    return session.cwd;
   }
 
   async closeSession(sessionId: string): Promise<void> {

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -16,21 +16,23 @@ export class ClaudeCodeChatManager {
   }
 
   async createSession(cwd: string) {
-    const { sessionId, ...capabilities } = await this.rpc.claudeCode.createSession({ cwd });
+    const { sessionId, currentModel, modelScope, ...capabilities } =
+      await this.rpc.claudeCode.createSession({ cwd });
     const chat = new ClaudeCodeChat({
       id: sessionId,
       transport: this.transport,
     });
     chat.store.setState({ capabilities });
     this.chats.set(sessionId, chat);
-    return { sessionId, ...capabilities };
+    return { sessionId, currentModel, modelScope, ...capabilities };
   }
 
   async loadSession(sessionId: string, cwd: string) {
-    const { capabilities, messages } = await this.rpc.claudeCode.loadSession({
-      sessionId,
-      cwd,
-    });
+    const { capabilities, messages, currentModel, modelScope } =
+      await this.rpc.claudeCode.loadSession({
+        sessionId,
+        cwd,
+      });
 
     const chat = new ClaudeCodeChat({
       id: sessionId,
@@ -39,7 +41,7 @@ export class ClaudeCodeChatManager {
     });
     chat.store.setState({ capabilities });
     this.chats.set(sessionId, chat);
-    return { sessionId, ...capabilities };
+    return { sessionId, currentModel, modelScope, ...capabilities };
   }
 
   getChat(sessionId: string) {

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -1,13 +1,29 @@
 import type { StoreApi } from "zustand";
 
 import debug from "debug";
-import { SendHorizonal, Square, Paperclip } from "lucide-react";
+import { ChevronDown, FolderOpen, Globe, Paperclip, SendHorizonal, Square } from "lucide-react";
 import { useCallback } from "react";
 import { useStore } from "zustand";
 
+import type { ModelScope } from "../../../../../shared/features/agent/types";
 import type { ClaudeCodeChatStoreState } from "../chat-state";
 
 import { Button } from "../../../components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuPopup,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from "../../../components/ui/context-menu";
+import {
+  Menu,
+  MenuTrigger,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+} from "../../../components/ui/menu";
+import { client } from "../../../orpc";
 import { claudeCodeChatManager } from "../chat-manager";
 import { useAgentStore } from "../store";
 
@@ -63,6 +79,12 @@ export function InputToolbar({
   );
 }
 
+function ScopeBadge({ scope }: { scope?: ModelScope }) {
+  if (scope === "project") return <FolderOpen className="h-3 w-3 text-muted-foreground" />;
+  if (scope === "global") return <Globe className="h-3 w-3 text-muted-foreground" />;
+  return null;
+}
+
 function ModelSelect({
   activeSessionId,
   disabled,
@@ -92,37 +114,95 @@ function ConnectedModelSelect({
   disabled: boolean;
 }) {
   const setCurrentModel = useAgentStore((s) => s.setCurrentModel);
+  const setModelScope = useAgentStore((s) => s.setModelScope);
   const currentModel = useAgentStore((s) => s.sessions.get(activeSessionId)?.currentModel);
+  const modelScope = useAgentStore((s) => s.sessions.get(activeSessionId)?.modelScope);
   const availableModels = useStore(chatStore, (state) => state.capabilities?.models);
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const model = e.target.value;
-      log("handleModelChange: model=%s sessionId=%s", model, activeSessionId);
+  const handleModelSelect = useCallback(
+    (value: unknown) => {
+      const model = value as string;
+      log("handleModelSelect: model=%s sessionId=%s", model, activeSessionId);
       setCurrentModel(activeSessionId, model);
+      setModelScope(activeSessionId, "session");
       claudeCodeChatManager.getChat(activeSessionId)?.dispatch({
         kind: "configure",
         configure: { type: "set_model", model },
       });
+      client.agent.setModelSetting({ sessionId: activeSessionId, model, scope: "session" });
     },
-    [activeSessionId, setCurrentModel],
+    [activeSessionId, setCurrentModel, setModelScope],
+  );
+
+  const handleScopeAction = useCallback(
+    (scope: ModelScope | "clear") => {
+      if (scope === "clear") {
+        log("clearSessionOverride: sessionId=%s", activeSessionId);
+        client.agent
+          .setModelSetting({ sessionId: activeSessionId, model: null, scope: "session" })
+          .then((result) => {
+            if (result.currentModel) {
+              setCurrentModel(activeSessionId, result.currentModel);
+            }
+            setModelScope(activeSessionId, result.modelScope);
+          });
+        return;
+      }
+      const model = currentModel;
+      if (!model) return;
+      log("setModelSetting: scope=%s model=%s sessionId=%s", scope, model, activeSessionId);
+      client.agent.setModelSetting({ sessionId: activeSessionId, model, scope });
+    },
+    [activeSessionId, currentModel, setCurrentModel, setModelScope],
   );
 
   if (!availableModels || availableModels.length === 0) return null;
 
+  const displayModel =
+    availableModels.find((m) => m.value === currentModel)?.displayName ??
+    currentModel ??
+    availableModels[0]?.displayName;
+
   return (
-    <select
-      value={currentModel ?? availableModels[0]?.value ?? ""}
-      onChange={handleChange}
-      disabled={disabled}
-      className="h-7 rounded-md border border-input bg-background px-2 text-xs text-muted-foreground outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-      title="Select model"
-    >
-      {availableModels.map((m) => (
-        <option key={m.value} value={m.value}>
-          {m.displayName}
-        </option>
-      ))}
-    </select>
+    <ContextMenu>
+      <ContextMenuTrigger className="inline-flex">
+        <Menu>
+          <MenuTrigger
+            disabled={disabled}
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-input bg-background px-2 text-xs text-muted-foreground outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          >
+            <ScopeBadge scope={modelScope} />
+            <span>{displayModel}</span>
+            <ChevronDown className="h-3 w-3 opacity-50" />
+          </MenuTrigger>
+          <MenuPopup side="top" align="start">
+            <MenuRadioGroup
+              value={currentModel ?? availableModels[0]?.value ?? ""}
+              onValueChange={handleModelSelect}
+            >
+              {availableModels.map((m) => (
+                <MenuRadioItem key={m.value} value={m.value}>
+                  {m.displayName}
+                </MenuRadioItem>
+              ))}
+            </MenuRadioGroup>
+          </MenuPopup>
+        </Menu>
+      </ContextMenuTrigger>
+      <ContextMenuPopup>
+        <ContextMenuItem onClick={() => handleScopeAction("project")}>
+          <FolderOpen className="h-4 w-4" />
+          Set as project default
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => handleScopeAction("global")}>
+          <Globe className="h-4 w-4" />
+          Set as global default
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => handleScopeAction("clear")}>
+          Clear session override
+        </ContextMenuItem>
+      </ContextMenuPopup>
+    </ContextMenu>
   );
 }

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-load-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-load-session.ts
@@ -12,6 +12,8 @@ export function useLoadSession(fallbackCwd?: string) {
   const removeSession = useAgentStore((s) => s.removeSession);
   const setAvailableCommands = useAgentStore((s) => s.setAvailableCommands);
   const setAvailableModels = useAgentStore((s) => s.setAvailableModels);
+  const setCurrentModel = useAgentStore((s) => s.setCurrentModel);
+  const setModelScope = useAgentStore((s) => s.setModelScope);
 
   const loadAbortRef = useRef<AbortController | null>(null);
 
@@ -51,7 +53,8 @@ export function useLoadSession(fallbackCwd?: string) {
       );
 
       try {
-        const { commands, models } = await claudeCodeChatManager.loadSession(sessionId, cwd);
+        const { commands, models, currentModel, modelScope } =
+          await claudeCodeChatManager.loadSession(sessionId, cwd);
 
         // Register in old store AFTER chat is created in manager,
         // so React render finds getChat() ready before useClaudeCodeChat runs
@@ -65,6 +68,12 @@ export function useLoadSession(fallbackCwd?: string) {
         }
         if (models?.length) {
           setAvailableModels(sessionId, models);
+        }
+        if (currentModel) {
+          setCurrentModel(sessionId, currentModel);
+        }
+        if (modelScope) {
+          setModelScope(sessionId, modelScope);
         }
 
         loadLog("DONE sid=%s in %dms", sessionId.slice(0, 8), Math.round(performance.now() - t0));
@@ -89,6 +98,8 @@ export function useLoadSession(fallbackCwd?: string) {
       removeSession,
       setAvailableCommands,
       setAvailableModels,
+      setCurrentModel,
+      setModelScope,
       fallbackCwd,
     ],
   );

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
@@ -24,6 +24,8 @@ export function useNewSession() {
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
   const setAvailableCommands = useAgentStore((s) => s.setAvailableCommands);
   const setAvailableModels = useAgentStore((s) => s.setAvailableModels);
+  const setCurrentModel = useAgentStore((s) => s.setCurrentModel);
+  const setModelScope = useAgentStore((s) => s.setModelScope);
 
   const createNewSession = useCallback(
     async (cwd: string) => {
@@ -39,8 +41,9 @@ export function useNewSession() {
 
       const startActiveId = useAgentStore.getState().activeSessionId;
       newSessionLog("createNewSession: creating session cwd=%s", cwd);
-      const { sessionId, commands, models } = await claudeCodeChatManager.createSession(cwd);
-      newSessionLog("createNewSession: created %s", sessionId);
+      const { sessionId, commands, models, currentModel, modelScope } =
+        await claudeCodeChatManager.createSession(cwd);
+      newSessionLog("createNewSession: created %s currentModel=%s", sessionId, currentModel);
 
       // Guard: if user navigated to another session during the async gap, don't steal focus
       const currentActiveId = useAgentStore.getState().activeSessionId;
@@ -64,10 +67,23 @@ export function useNewSession() {
       if (models?.length) {
         setAvailableModels(sessionId, models);
       }
+      if (currentModel) {
+        setCurrentModel(sessionId, currentModel);
+      }
+      if (modelScope) {
+        setModelScope(sessionId, modelScope);
+      }
 
       return sessionId;
     },
-    [createSession, setActiveSession, setAvailableCommands, setAvailableModels],
+    [
+      createSession,
+      setActiveSession,
+      setAvailableCommands,
+      setAvailableModels,
+      setCurrentModel,
+      setModelScope,
+    ],
   );
 
   /** Pre-warm a new empty session in the background (no activation). */
@@ -83,8 +99,9 @@ export function useNewSession() {
       }
 
       newSessionLog("preWarmSession: creating background session cwd=%s", cwd);
-      const { sessionId, commands, models } = await claudeCodeChatManager.createSession(cwd);
-      newSessionLog("preWarmSession: created %s", sessionId);
+      const { sessionId, commands, models, currentModel, modelScope } =
+        await claudeCodeChatManager.createSession(cwd);
+      newSessionLog("preWarmSession: created %s currentModel=%s", sessionId, currentModel);
 
       createBackgroundSession(sessionId, {
         cwd: projectPath,
@@ -97,8 +114,20 @@ export function useNewSession() {
       if (models?.length) {
         setAvailableModels(sessionId, models);
       }
+      if (currentModel) {
+        setCurrentModel(sessionId, currentModel);
+      }
+      if (modelScope) {
+        setModelScope(sessionId, modelScope);
+      }
     },
-    [createBackgroundSession, setAvailableCommands, setAvailableModels],
+    [
+      createBackgroundSession,
+      setAvailableCommands,
+      setAvailableModels,
+      setCurrentModel,
+      setModelScope,
+    ],
   );
 
   return { createNewSession, preWarmSession };

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -7,6 +7,7 @@ import type {
   SessionInfo,
   SlashCommandInfo,
   ModelInfo,
+  ModelScope,
 } from "../../../../shared/features/agent/types";
 
 import { client } from "../../orpc";
@@ -58,6 +59,7 @@ export type ChatSession = {
   availableCommands: SlashCommandInfo[];
   availableModels: ModelInfo[];
   currentModel?: string;
+  modelScope?: ModelScope;
   usage?: SessionUsage;
   tasks: Map<string, TaskState>;
 };
@@ -83,6 +85,7 @@ type AgentState = {
   setAvailableCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
   setAvailableModels: (sessionId: string, models: ModelInfo[]) => void;
   setCurrentModel: (sessionId: string, model: string) => void;
+  setModelScope: (sessionId: string, scope: ModelScope | undefined) => void;
   renameSession: (sessionId: string, title: string) => Promise<void>;
 };
 
@@ -210,6 +213,14 @@ export const useAgentStore = create<AgentState>()(
       set((state) => {
         const session = state.sessions.get(sessionId);
         if (session) session.currentModel = model;
+      });
+    },
+
+    setModelScope: (sessionId, scope) => {
+      storeLog("setModelScope: sid=%s scope=%s", sessionId, scope);
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (session) session.modelScope = scope;
       });
     },
 

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -10,7 +10,7 @@ import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../claude-code/types";
-import type { SessionInfo } from "./types";
+import type { ModelScope, SessionInfo } from "./types";
 
 export const agentContract = {
   listSessions: oc.input(z.object({ cwd: z.string().optional() })).output(type<SessionInfo[]>()),
@@ -22,7 +22,13 @@ export const agentContract = {
   claudeCode: {
     createSession: oc
       .input(z.object({ cwd: z.string(), model: z.string().optional() }))
-      .output(type<{ sessionId: string } & Awaited<ReturnType<Query["initializationResult"]>>>()),
+      .output(
+        type<
+          { sessionId: string; currentModel?: string; modelScope?: ModelScope } & Awaited<
+            ReturnType<Query["initializationResult"]>
+          >
+        >(),
+      ),
 
     stream: oc
       .input(type<{ sessionId: string; message: ClaudeCodeUIMessage }>())
@@ -41,7 +47,19 @@ export const agentContract = {
         sessionId: string;
         capabilities: Awaited<ReturnType<Query["initializationResult"]>>;
         messages: ClaudeCodeUIMessage[];
+        currentModel?: string;
+        modelScope?: ModelScope;
       }>(),
     ),
   },
+
+  setModelSetting: oc
+    .input(
+      z.object({
+        sessionId: z.string(),
+        model: z.string().nullable(),
+        scope: z.enum(["session", "project", "global"]),
+      }),
+    )
+    .output(type<{ currentModel?: string; modelScope?: ModelScope }>()),
 };

--- a/packages/desktop/src/shared/features/agent/types.ts
+++ b/packages/desktop/src/shared/features/agent/types.ts
@@ -16,6 +16,8 @@ export type AccountInfo = {
   apiKeySource?: string;
 };
 
+export type ModelScope = "session" | "project" | "global";
+
 export type FastModeState = "off" | "cooldown" | "on";
 
 export type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk";


### PR DESCRIPTION
Implemented a three-tier model configuration system allowing users to set models at session, project, or global scope. Added new claude-settings.ts module to manage settings persistence, updated UI with context menu for scope selection, and integrated scope resolution into session creation and loading flows.