### PR TITLE
fix: handle empty message parts by adding default text part

### DIFF
--- a/packages/desktop/src/main/features/agent/utils/session-messages-to-ui-messages.ts
+++ b/packages/desktop/src/main/features/agent/utils/session-messages-to-ui-messages.ts
@@ -109,6 +109,14 @@ export async function sessionMessagesToUIMessages(
         }
       }
 
+      if (parts.length === 0) {
+        parts.push({
+          type: "text",
+          text: typeof content === "string" ? content : "",
+          state: "done",
+        } as ClaudeCodeUIMessage["parts"][number]);
+      }
+
       results.push({
         id: msg.uuid ?? crypto.randomUUID(),
         role: "user",


### PR DESCRIPTION
Added a fallback to push a default text part when no parts are generated from session messages, preventing empty message arrays in the UI.