### PR TITLE
feat: auto-switch project when activating or loading sessions

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
@@ -1,6 +1,7 @@
 import debug from "debug";
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 
+import { useProjectStore } from "../../project/store";
 import { useLoadSession } from "../hooks/use-load-session";
 import { useFilteredSessions } from "../hooks/use-unified-sessions";
 import { useAgentStore } from "../store";
@@ -24,14 +25,28 @@ export const ChronologicalList = memo(function ChronologicalList() {
   const visibleItems = showAll ? items : items.slice(0, CHRONOLOGICAL_SESSION_LIMIT);
   const hiddenCount = items.length - CHRONOLOGICAL_SESSION_LIMIT;
 
-  const handleLoad = async (sessionId: string) => {
-    setRestoring(sessionId);
-    try {
-      await loadSession(sessionId);
-    } finally {
-      setRestoring((prev) => (prev === sessionId ? null : prev));
-    }
-  };
+  const switchToProjectByPath = useProjectStore((s) => s.switchToProjectByPath);
+
+  const handleActivate = useCallback(
+    (sessionId: string, projectPath: string) => {
+      switchToProjectByPath(projectPath);
+      setActiveSession(sessionId);
+    },
+    [switchToProjectByPath, setActiveSession],
+  );
+
+  const handleLoad = useCallback(
+    async (sessionId: string, projectPath: string) => {
+      setRestoring(sessionId);
+      try {
+        switchToProjectByPath(projectPath);
+        await loadSession(sessionId);
+      } finally {
+        setRestoring((prev) => (prev === sessionId ? null : prev));
+      }
+    },
+    [switchToProjectByPath, loadSession],
+  );
 
   return (
     <ul className="flex flex-col gap-0.5">
@@ -44,8 +59,8 @@ export const ChronologicalList = memo(function ChronologicalList() {
             activeSessionId={activeSessionId}
             isPinned={false}
             restoring={restoring}
-            onActivate={setActiveSession}
-            onLoad={handleLoad}
+            onActivate={(sid) => handleActivate(sid, item.projectPath)}
+            onLoad={(sid) => handleLoad(sid, item.projectPath)}
           />
         );
       })}

--- a/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
@@ -1,6 +1,7 @@
 import debug from "debug";
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 
+import { useProjectStore } from "../../project/store";
 import { useLoadSession } from "../hooks/use-load-session";
 import { useFilteredSessions } from "../hooks/use-unified-sessions";
 import { useAgentStore } from "../store";
@@ -14,20 +15,33 @@ export const PinnedSessionList = memo(function PinnedSessionList() {
   const loadSession = useLoadSession();
   const [restoring, setRestoring] = useState<string | null>(null);
 
+  const switchToProjectByPath = useProjectStore((s) => s.switchToProjectByPath);
   const items = useFilteredSessions({ filter: "pinned" });
+
+  const handleActivate = useCallback(
+    (sessionId: string, projectPath: string) => {
+      switchToProjectByPath(projectPath);
+      setActiveSession(sessionId);
+    },
+    [switchToProjectByPath, setActiveSession],
+  );
+
+  const handleLoad = useCallback(
+    async (sessionId: string, projectPath: string) => {
+      setRestoring(sessionId);
+      try {
+        switchToProjectByPath(projectPath);
+        await loadSession(sessionId);
+      } finally {
+        setRestoring((prev) => (prev === sessionId ? null : prev));
+      }
+    },
+    [switchToProjectByPath, loadSession],
+  );
 
   log("render: pinnedCount=%d", items.length);
 
   if (items.length === 0) return null;
-
-  const handleLoad = async (sessionId: string) => {
-    setRestoring(sessionId);
-    try {
-      await loadSession(sessionId);
-    } finally {
-      setRestoring((prev) => (prev === sessionId ? null : prev));
-    }
-  };
 
   return (
     <div className="pb-2">
@@ -41,8 +55,8 @@ export const PinnedSessionList = memo(function PinnedSessionList() {
               activeSessionId={activeSessionId}
               isPinned
               restoring={restoring}
-              onActivate={setActiveSession}
-              onLoad={handleLoad}
+              onActivate={(sid) => handleActivate(sid, item.projectPath)}
+              onLoad={(sid) => handleLoad(sid, item.projectPath)}
             />
           );
         })}

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -35,14 +35,28 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
   const visibleItems = expanded ? items : items.slice(0, DEFAULT_SESSION_LIMIT);
   const hiddenCount = items.length - DEFAULT_SESSION_LIMIT;
 
-  const handleLoad = async (sessionId: string) => {
-    setRestoring(sessionId);
-    try {
-      await loadSession(sessionId);
-    } finally {
-      setRestoring((prev) => (prev === sessionId ? null : prev));
-    }
-  };
+  const switchToProjectByPath = useProjectStore((s) => s.switchToProjectByPath);
+
+  const handleActivate = useCallback(
+    (sessionId: string) => {
+      switchToProjectByPath(project.path);
+      setActiveSession(sessionId);
+    },
+    [switchToProjectByPath, project.path, setActiveSession],
+  );
+
+  const handleLoad = useCallback(
+    async (sessionId: string) => {
+      setRestoring(sessionId);
+      try {
+        switchToProjectByPath(project.path);
+        await loadSession(sessionId);
+      } finally {
+        setRestoring((prev) => (prev === sessionId ? null : prev));
+      }
+    },
+    [switchToProjectByPath, project.path, loadSession],
+  );
 
   return (
     <ul className="flex flex-col gap-0.5">
@@ -55,7 +69,7 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
             activeSessionId={activeSessionId}
             isPinned={false}
             restoring={restoring}
-            onActivate={setActiveSession}
+            onActivate={handleActivate}
             onLoad={handleLoad}
           />
         );

--- a/packages/desktop/src/renderer/src/features/project/store.ts
+++ b/packages/desktop/src/renderer/src/features/project/store.ts
@@ -17,6 +17,7 @@ type ProjectState = {
   setProjects: (projects: Project[]) => void;
   setActiveProject: (project: Project | null) => void;
   setLoading: (loading: boolean) => void;
+  switchToProjectByPath: (projectPath: string) => void;
   archiveSession: (projectPath: string, sessionId: string) => void;
   togglePinSession: (projectPath: string, sessionId: string) => void;
   loadSessionPreferences: (projectPath: string) => Promise<void>;
@@ -33,6 +34,15 @@ export const useProjectStore = create<ProjectState>()(
     setProjects: (projects) => set({ projects }),
     setActiveProject: (activeProject) => set({ activeProject }),
     setLoading: (loading) => set({ loading }),
+    switchToProjectByPath: (projectPath) => {
+      const { activeProject, projects } = useProjectStore.getState();
+      if (activeProject?.path === projectPath) return;
+      const project = projects.find((p) => p.path === projectPath);
+      if (project) {
+        client.project.setActive({ id: project.id }).catch(() => {});
+        set({ activeProject: project });
+      }
+    },
     archiveSession: (projectPath, sessionId) => {
       client.project.archiveSession({ projectPath, sessionId }).catch(() => {});
       set((state) => {


### PR DESCRIPTION
Added automatic project switching when users activate or load sessions from different projects. Introduced `switchToProjectByPath` action in project store and updated chronological, pinned, and accordion session lists to use it.