### PR TITLE
fix: clear pending permission requests on chat interrupt

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat.ts
@@ -103,6 +103,7 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
 
   interrupt = async () => {
     await this.dispatch({ kind: "interrupt" });
+    // Clear pending permission requests so dialogs don't stay stuck after interrupt
     this.store.setState({ pendingRequests: [] });
     await this.stop();
   };


### PR DESCRIPTION
## Summary

- When a user interrupts a chat while a permission request dialog is pending, the `pendingRequests` array in the store was never cleared
- This caused the permission dialog to remain stuck and unclickable in subsequent interactions, since the old unresolved request was still in state
- Fix: clear `pendingRequests` in the `interrupt()` method before calling `stop()`

## Changes

- `packages/desktop/src/renderer/src/features/agent/chat.ts`: Added `this.store.setState({ pendingRequests: [] })` in the `interrupt` method

## Test plan

- [ ] Start a chat session that triggers a permission request dialog
- [ ] Interrupt the chat while the dialog is pending
- [ ] Verify the permission dialog is cleared
- [ ] Send a new message and verify permission dialogs work normally