### PR TITLE
fix: use createRequire for SDK cli.js path resolution

### DIFF
--- a/packages/desktop/src/main/features/agent/claude-code-utils.ts
+++ b/packages/desktop/src/main/features/agent/claude-code-utils.ts
@@ -2,7 +2,10 @@ import type { SpawnedProcess, SpawnOptions } from "@anthropic-ai/claude-agent-sd
 
 import { is } from "@electron-toolkit/utils";
 import child_process from "node:child_process";
+import { createRequire } from "node:module";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Resolve the real filesystem path to the SDK's cli.js.


### PR DESCRIPTION
## Summary
- `resolveSDKCliPath()` 中的裸 `require.resolve()` 在 Vite 打包后失去运行时模块解析能力，导致找不到 `@anthropic-ai/claude-agent-sdk`
- 改为使用 `createRequire(import.meta.url)`，与 `search-paths.ts` 保持一致

## Test plan
- [ ] `bun run build` 构建成功
- [ ] 打包后的应用能正常启动 Claude Agent SDK 会话