### PR TITLE
fix: add wasm-unsafe-eval to CSP for WebAssembly support

### DIFF
--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      content="script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
     />
   </head>
 


### PR DESCRIPTION
Updated Content-Security-Policy to include 'wasm-unsafe-eval' in script-src directive, enabling WebAssembly execution in the Electron renderer.

Fix this.

```
code-block.tsx:220 Failed to highlight code: CompileError: WebAssembly.instantiate(): Compiling or instantiating WebAssembly module violates the following Content Security policy directive because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: 
    at async Promise.all (:5173/index 2)
```