### PR TITLE
feat: add drag-to-sort functionality for projects

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,10 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@anthropic-ai/sdk": "~0.78.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@orpc/contract": "^1.13.5",
@@ -207,6 +211,16 @@
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@electron-toolkit/preload": ["@electron-toolkit/preload@3.0.2", "", { "peerDependencies": { "electron": ">=13.0.0" } }, "sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg=="],
 

--- a/docs/designs/2026-03-12-drag-to-sort-projects.md
+++ b/docs/designs/2026-03-12-drag-to-sort-projects.md
@@ -1,0 +1,73 @@
+# Drag-to-Sort Projects
+
+## Goal
+
+Allow users to reorder projects via drag-and-drop in the multi-project accordion view. The new order persists across app restarts and is reflected everywhere projects are listed (accordion view, project selector dropdown).
+
+## Library
+
+`@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` + `@dnd-kit/modifiers`
+
+## Data Layer
+
+No schema changes. The existing `projects: Project[]` array order determines display order. Reordering rewrites the array in place.
+
+### ProjectStore (`project-store.ts`)
+
+Add method:
+
+```ts
+reorder(projectIds: string[]): void {
+  const projects = this.getAll();
+  const map = new Map(projects.map((p) => [p.id, p]));
+  const reordered = projectIds.map((id) => map.get(id)).filter(Boolean);
+  this.store.set("projects", reordered);
+}
+```
+
+### Contract (`project/contract.ts`)
+
+Add `reorderProjects` endpoint:
+
+```ts
+reorderProjects: base.input(z.object({ projectIds: z.array(z.string()) })).handler(...)
+```
+
+### Router (`project/router.ts`)
+
+Add handler that calls `projectStore.reorder(input.projectIds)`.
+
+### Renderer Store (`project/store.ts`)
+
+Add `reorderProjects(projectIds: string[])` action that:
+
+1. Optimistically reorders the local `projects` array
+2. Calls the IPC handler to persist
+
+## UI Layer
+
+### ProjectAccordionList (`project-accordion-list.tsx`)
+
+- Wrap the `Accordion` with `DndContext` + `SortableContext` (vertical list strategy)
+- Each `AccordionItem` becomes a sortable item via `useSortable`
+- The entire accordion header (title bar) acts as the drag handle — no extra grip icon
+- Drag handle element is separate from `AccordionPrimitive.Trigger` to avoid toggling open/close on drag. Use `e.stopPropagation()` on pointer down to prevent conflicts
+- Use `PointerSensor` with `activationConstraint: { distance: 5 }` to avoid accidental drags on click
+- Use `restrictToVerticalAxis` modifier from `@dnd-kit/modifiers` for clean vertical-only dragging
+- On `onDragEnd`: compute new ID order, call `reorderProjects`
+- Use `DragOverlay` for visual feedback during drag
+
+### ProjectSelector (`project-selector.tsx`)
+
+No changes. It reads from the same `projects` array, so it automatically reflects the persisted order.
+
+## Files to Change
+
+| File                                                                    | Change                                                                               |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `package.json`                                                          | Add `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`, `@dnd-kit/modifiers` |
+| `src/main/features/project/project-store.ts`                            | Add `reorder()` method                                                               |
+| `src/shared/features/project/contract.ts`                               | Add `reorderProjects` contract                                                       |
+| `src/main/features/project/router.ts`                                   | Add `reorderProjects` handler                                                        |
+| `src/renderer/src/features/project/store.ts`                            | Add `reorderProjects` action                                                         |
+| `src/renderer/src/features/agent/components/project-accordion-list.tsx` | Add DnD wrapping + drag handle                                                       |

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -27,6 +27,10 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@anthropic-ai/sdk": "~0.78.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@orpc/contract": "^1.13.5",

--- a/packages/desktop/src/main/features/project/project-store.ts
+++ b/packages/desktop/src/main/features/project/project-store.ts
@@ -125,6 +125,16 @@ export class ProjectStore {
     };
   }
 
+  reorder(projectIds: string[]): void {
+    const projects = this.getAll();
+    const map = new Map(projects.map((p) => [p.id, p]));
+    const reordered = projectIds.flatMap((id) => {
+      const p = map.get(id);
+      return p ? [p] : [];
+    });
+    this.store.set("projects", reordered);
+  }
+
   setProjectSelection(cwd: string, provider?: string | null, model?: string | null): void {
     const selections = this.store.get("providerSelections") ?? {};
     const existing = selections[cwd] ?? {};

--- a/packages/desktop/src/main/features/project/router.ts
+++ b/packages/desktop/src/main/features/project/router.ts
@@ -95,4 +95,8 @@ export const projectRouter = os.project.router({
   setClosedAccordions: os.project.setClosedAccordions.handler(({ input, context }) => {
     context.projectStore.setClosedProjectAccordions(input.ids);
   }),
+
+  reorderProjects: os.project.reorderProjects.handler(({ input, context }) => {
+    context.projectStore.reorder(input.projectIds);
+  }),
 });

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -1,4 +1,16 @@
 import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
+import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { FolderIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import debug from "debug";
@@ -92,14 +104,93 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
 
 // --- ProjectAccordionList ---
 
+// --- SortableProjectItem ---
+
+const SortableProjectItem = memo(function SortableProjectItem({
+  project,
+  closedSet,
+  onRemove,
+  onCreateSession,
+}: {
+  project: Project;
+  closedSet: Set<string>;
+  onRemove: (id: string) => void;
+  onCreateSession: (project: Project) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: project.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <AccordionItem ref={setNodeRef} style={style} value={project.id} className="border-b-0">
+      <AccordionPrimitive.Header className="group flex items-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
+        <div
+          className="flex flex-1 cursor-grab items-center gap-2 px-3 py-1.5 active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <AccordionPrimitive.Trigger className="flex flex-1 cursor-pointer items-center gap-2 text-left">
+            <div className="flex-shrink-0 group-hover:hidden">
+              <HugeiconsIcon icon={FolderIcon} size={16} strokeWidth={1.5} />
+            </div>
+            <div className="hidden flex-shrink-0 group-hover:block">
+              {!closedSet.has(project.id) ? (
+                <ChevronDown size={16} strokeWidth={1.5} />
+              ) : (
+                <ChevronRight size={16} strokeWidth={1.5} />
+              )}
+            </div>
+            <span className="flex-1 truncate text-sm font-medium">{project.name}</span>
+          </AccordionPrimitive.Trigger>
+        </div>
+        <button
+          className="rounded p-1 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(project.id);
+          }}
+        >
+          <Trash2 size={14} strokeWidth={1.5} />
+        </button>
+        <button
+          className="mr-1 rounded p-1 opacity-0 transition-opacity hover:bg-accent group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            onCreateSession(project);
+          }}
+        >
+          <Plus size={14} strokeWidth={1.5} />
+        </button>
+      </AccordionPrimitive.Header>
+      <AccordionPanel className="pb-1 pt-0">
+        <ProjectSessions project={project} />
+      </AccordionPanel>
+    </AccordionItem>
+  );
+});
+
+// --- ProjectAccordionList ---
+
 export const ProjectAccordionList = memo(function ProjectAccordionList() {
   const projects = useProjectStore((s) => s.projects);
   const closedProjectAccordions = useProjectStore((s) => s.closedProjectAccordions);
   const setClosedProjectAccordions = useProjectStore((s) => s.setClosedProjectAccordions);
+  const reorderProjects = useProjectStore((s) => s.reorderProjects);
   const { removeProject, switchProject } = useProject();
   const { createNewSession } = useNewSession();
+  const [activeId, setActiveId] = useState<string | null>(null);
 
   const closedSet = useMemo(() => new Set(closedProjectAccordions), [closedProjectAccordions]);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
 
   const handleCreateSession = useCallback(
     async (project: Project) => {
@@ -130,6 +221,35 @@ export const ProjectAccordionList = memo(function ProjectAccordionList() {
     [projects, setClosedProjectAccordions],
   );
 
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = projectIds.indexOf(active.id as string);
+      const newIndex = projectIds.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const newIds = [...projectIds];
+      newIds.splice(oldIndex, 1);
+      newIds.splice(newIndex, 0, active.id as string);
+      reorderProjects(newIds);
+    },
+    [projectIds, reorderProjects],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
+  const activeProject = useMemo(
+    () => projects.find((p) => p.id === activeId) ?? null,
+    [projects, activeId],
+  );
+
   if (projects.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center p-4">
@@ -150,47 +270,34 @@ export const ProjectAccordionList = memo(function ProjectAccordionList() {
   }
 
   return (
-    <Accordion value={openAccordions} onValueChange={handleAccordionChange} multiple>
-      {projects.map((project) => (
-        <AccordionItem key={project.id} value={project.id} className="border-b-0">
-          <AccordionPrimitive.Header className="group flex items-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
-            <AccordionPrimitive.Trigger className="flex flex-1 cursor-pointer items-center gap-2 px-3 py-1.5 text-left">
-              <div className="flex-shrink-0 group-hover:hidden">
-                <HugeiconsIcon icon={FolderIcon} size={16} strokeWidth={1.5} />
-              </div>
-              <div className="hidden flex-shrink-0 group-hover:block">
-                {!closedSet.has(project.id) ? (
-                  <ChevronDown size={16} strokeWidth={1.5} />
-                ) : (
-                  <ChevronRight size={16} strokeWidth={1.5} />
-                )}
-              </div>
-              <span className="flex-1 truncate text-sm font-medium">{project.name}</span>
-            </AccordionPrimitive.Trigger>
-            <button
-              className="rounded p-1 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                removeProject(project.id);
-              }}
-            >
-              <Trash2 size={14} strokeWidth={1.5} />
-            </button>
-            <button
-              className="mr-1 rounded p-1 opacity-0 transition-opacity hover:bg-accent group-hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleCreateSession(project);
-              }}
-            >
-              <Plus size={14} strokeWidth={1.5} />
-            </button>
-          </AccordionPrimitive.Header>
-          <AccordionPanel className="pb-1 pt-0">
-            <ProjectSessions project={project} />
-          </AccordionPanel>
-        </AccordionItem>
-      ))}
-    </Accordion>
+    <DndContext
+      sensors={sensors}
+      modifiers={[restrictToVerticalAxis]}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext items={projectIds} strategy={verticalListSortingStrategy}>
+        <Accordion value={openAccordions} onValueChange={handleAccordionChange} multiple>
+          {projects.map((project) => (
+            <SortableProjectItem
+              key={project.id}
+              project={project}
+              closedSet={closedSet}
+              onRemove={removeProject}
+              onCreateSession={handleCreateSession}
+            />
+          ))}
+        </Accordion>
+      </SortableContext>
+      <DragOverlay>
+        {activeProject ? (
+          <div className="flex items-center gap-2 rounded bg-accent px-3 py-1.5 text-sm font-medium shadow-md">
+            <HugeiconsIcon icon={FolderIcon} size={16} strokeWidth={1.5} />
+            <span className="truncate">{activeProject.name}</span>
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 });

--- a/packages/desktop/src/renderer/src/features/project/store.ts
+++ b/packages/desktop/src/renderer/src/features/project/store.ts
@@ -25,6 +25,7 @@ type ProjectState = {
   archiveSession: (projectPath: string, sessionId: string, isActive?: boolean) => void;
   togglePinSession: (projectPath: string, sessionId: string) => void;
   setClosedProjectAccordions: (ids: string[]) => void;
+  reorderProjects: (projectIds: string[]) => void;
   loadSessionPreferences: (projectPath: string) => Promise<void>;
 };
 
@@ -101,6 +102,16 @@ export const useProjectStore = create<ProjectState>()(
     setClosedProjectAccordions: (ids) => {
       client.project.setClosedAccordions({ ids }).catch(() => {});
       set({ closedProjectAccordions: ids });
+    },
+    reorderProjects: (projectIds) => {
+      const { projects } = useProjectStore.getState();
+      const map = new Map(projects.map((p) => [p.id, p]));
+      const reordered = projectIds.flatMap((id) => {
+        const p = map.get(id);
+        return p ? [p] : [];
+      });
+      set({ projects: reordered });
+      client.project.reorderProjects({ projectIds }).catch(() => {});
     },
     loadSessionPreferences: async (_projectPath) => {
       const [archived, pinned, closedAccordions] = await Promise.all([

--- a/packages/desktop/src/shared/features/project/contract.ts
+++ b/packages/desktop/src/shared/features/project/contract.ts
@@ -35,4 +35,6 @@ export const projectContract = {
   getClosedAccordions: oc.output(type<string[]>()),
 
   setClosedAccordions: oc.input(z.object({ ids: z.array(z.string()) })).output(type<void>()),
+
+  reorderProjects: oc.input(z.object({ projectIds: z.array(z.string()) })).output(type<void>()),
 };


### PR DESCRIPTION
Implemented drag-and-drop project reordering using @dnd-kit. Added reorder method to ProjectStore, new IPC endpoint, and updated the project accordion list UI with sortable items and drag overlay.