### PR TITLE
feat: add session completed indicator for background sessions

### DIFF
--- a/docs/designs/2026-03-12-session-completed-indicator.md
+++ b/docs/designs/2026-03-12-session-completed-indicator.md
@@ -1,0 +1,99 @@
+# Session Completed Indicator
+
+## Problem
+
+When a session completes a turn (user sent message -> agent finishes responding) while the user is focused on a different session, there is no visual indication that the background session has finished. The user has to manually check each session.
+
+## Requirements
+
+- **Trigger**: Show indicator when a session's turn completes (streaming/submitted -> ready/error) while the session is NOT the active/focused session
+- **Visual**: A small colored dot replacing the left icon (comment icon) in the session list item — green for success, red for error
+- **Clear**: The indicator disappears when the user clicks on/opens the session (it becomes the active session)
+
+## Approach: Track in Zustand agent store
+
+The agent store already owns `activeSessionId` and session lifecycle, making it the natural place to track "completed but unseen" sessions.
+
+### Data changes — `agent/store.ts`
+
+- Add `unseenTurnResults: Map<string, "success" | "error">` to `AgentState`
+- Add `markTurnCompleted(sessionId: string, result: "success" | "error")` action — sets the entry
+- Add `clearTurnResult(sessionId: string)` action — deletes the entry
+- Modify `setActiveSession(id)` — deletes `id` from `unseenTurnResults` when the user switches to it
+- Modify `removeSession(id)` — deletes `id` from `unseenTurnResults` to prevent stale entries
+- Note: archiving via `ProjectStore.archiveSession` also calls `removeSession` when the session is active, so archived sessions are cleaned up transitively
+- Note: `completedSessions` was renamed to `unseenTurnResults` to avoid confusion with session lifecycle ("session is completed/finished forever" vs "a turn finished and hasn't been seen")
+
+### Status detection — `ClaudeCodeChat` via callback
+
+Detection lives in the chat layer, NOT in React components. This avoids missed transitions if the session-list component unmounts/remounts (e.g. virtualization, sidebar collapse).
+
+`ClaudeCodeChatState` is a generic state container with no `sessionId` — it cannot call into the store directly. Instead, detection is wired through `ClaudeCodeChat` (which owns `this.id`) using a callback pattern to avoid tight coupling between the chat layer and the agent store:
+
+- `ClaudeCodeChatState` tracks `previousStatus` internally. When the `status` setter is called, it stores the old value before updating.
+- `ClaudeCodeChat` constructor accepts an optional callback:
+  ```ts
+  onTurnComplete?: (sessionId: string, result: "success" | "error") => void
+  onTurnStart?: (sessionId: string) => void
+  ```
+- `ClaudeCodeChat` subscribes to its own `store` and checks for qualifying transitions. It tracks `previousStatus` via a closed-over `let prev` variable in the subscription callback (no need to add `previousStatus` to `ClaudeCodeChatStoreState`):
+  - `streaming -> ready` — fires `onTurnComplete` with `"success"`
+  - `streaming -> error` — fires `onTurnComplete` with `"error"`
+  - `submitted -> error` — fires `onTurnComplete` with `"error"` (network failure before streaming started; the user submitted a turn and it failed, they should know)
+  - `* -> submitted` or `* -> streaming` — fires `onTurnStart` (clears any stale unseen result if a new turn begins before the user views the previous one)
+- Explicitly ignored for `onTurnComplete`: `submitted -> ready` (cancelled before streaming), `ready -> ready` (no-op), and other non-streaming/non-submitted transitions
+- `ClaudeCodeChatManager` wires the callbacks when creating/loading a chat:
+  ```ts
+  const chat = new ClaudeCodeChat({
+    id: sessionId,
+    transport: this.transport,
+    onTurnComplete: (id, result) => {
+      const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
+      if (activeSessionId !== id) markTurnCompleted(id, result);
+    },
+    onTurnStart: (id) => {
+      useAgentStore.getState().clearTurnResult(id);
+    },
+  });
+  ```
+
+### Wiring — `unified-session-item.tsx`
+
+- No transition detection needed here (handled in chat layer)
+- Read `turnResult` from `unseenTurnResults` in the agent store and pass it to `SessionItem`
+
+### Visual — `session-item.tsx`
+
+- Add `turnResult?: "success" | "error"` prop
+- In the icon priority chain, insert after processing, before pinned/comment:
+  ```
+  pendingPermission -> processing -> completed (green/red dot) -> pinned -> comment
+  ```
+- Success: small filled circle with `text-green-500` (or `text-success`)
+- Error: small filled circle with `text-destructive`
+
+### Flow
+
+```
+Turn completes (streaming -> ready)
+  -> ClaudeCodeChat store subscription detects streaming -> ready
+  -> onTurnComplete callback checks activeSessionId !== sessionId
+  -> calls markTurnCompleted(sessionId, "success")
+  -> session-item renders green dot instead of comment icon
+
+Turn errors (streaming -> error OR submitted -> error)
+  -> same flow, but markTurnCompleted(sessionId, "error")
+  -> session-item renders red dot
+
+New turn starts (* -> submitted/streaming)
+  -> onTurnStart callback calls clearTurnResult(sessionId)
+  -> stale dot disappears, spinner takes over
+
+User clicks session
+  -> setActiveSession(id) deletes from unseenTurnResults
+  -> dot disappears, shows normal icon
+
+Session removed/archived
+  -> removeSession(id) deletes from unseenTurnResults
+  -> no stale entries
+```

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -4,6 +4,7 @@ import { agentContract } from "../../../../shared/features/agent/contract";
 import { client } from "../../orpc";
 import { ClaudeCodeChat } from "./chat";
 import { ClaudeCodeChatTransport } from "./chat-transport";
+import { useAgentStore } from "./store";
 
 type AgentRpc = ContractRouterClient<{ agent: typeof agentContract }>["agent"];
 
@@ -15,12 +16,23 @@ export class ClaudeCodeChatManager {
     this.transport = new ClaudeCodeChatTransport(rpc);
   }
 
+  #turnCallbacks = {
+    onTurnComplete: (id: string, result: "success" | "error") => {
+      const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
+      if (activeSessionId !== id) markTurnCompleted(id, result);
+    },
+    onTurnStart: (id: string) => {
+      useAgentStore.getState().clearTurnResult(id);
+    },
+  };
+
   async createSession(cwd: string, opts?: { providerId?: string | null }) {
     const { sessionId, currentModel, modelScope, providerId, ...capabilities } =
       await this.rpc.claudeCode.createSession({ cwd, providerId: opts?.providerId });
     const chat = new ClaudeCodeChat({
       id: sessionId,
       transport: this.transport,
+      ...this.#turnCallbacks,
     });
     chat.store.setState({ capabilities });
     this.chats.set(sessionId, chat);
@@ -38,6 +50,7 @@ export class ClaudeCodeChatManager {
       id: sessionId,
       transport: this.transport,
       messages,
+      ...this.#turnCallbacks,
     });
     chat.store.setState({ capabilities });
     this.chats.set(sessionId, chat);

--- a/packages/desktop/src/renderer/src/features/agent/chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat.ts
@@ -18,6 +18,8 @@ import { ClaudeCodeChatState, ClaudeCodeChatStoreState } from "./chat-state";
 export interface ClaudeCodeChatInit extends Omit<ChatInit<ClaudeCodeUIMessage>, "transport"> {
   id: string;
   transport: ClaudeCodeChatTransport;
+  onTurnComplete?: (sessionId: string, result: "success" | "error") => void;
+  onTurnStart?: (sessionId: string) => void;
 }
 
 export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
@@ -26,7 +28,16 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
 
   #unsubscribe?: () => Promise<void>;
 
-  constructor({ id, messages, transport, ...init }: ClaudeCodeChatInit) {
+  #unsubscribeStore?: () => void;
+
+  constructor({
+    id,
+    messages,
+    transport,
+    onTurnComplete,
+    onTurnStart,
+    ...init
+  }: ClaudeCodeChatInit) {
     const state = new ClaudeCodeChatState(messages);
     super({
       id,
@@ -43,6 +54,25 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
         this.store.setState({ eventError: error });
       },
     });
+
+    if (onTurnComplete || onTurnStart) {
+      let prev = this.store.getState().status;
+      this.#unsubscribeStore = this.store.subscribe((cur) => {
+        const status = cur.status;
+        if (status === prev) return;
+
+        if (status === "submitted" || status === "streaming") {
+          onTurnStart?.(id);
+        } else if (
+          (prev === "streaming" && (status === "ready" || status === "error")) ||
+          (prev === "submitted" && status === "error")
+        ) {
+          onTurnComplete?.(id, status === "ready" ? "success" : "error");
+        }
+
+        prev = status;
+      });
+    }
   }
 
   #handleMessage(message: ClaudeCodeUIEvent) {
@@ -109,6 +139,7 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
   };
 
   dispose = async () => {
+    this.#unsubscribeStore?.();
     await this.#unsubscribe?.();
   };
 }

--- a/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
@@ -1,8 +1,10 @@
 import { Comment01Icon, HelpCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { formatDistanceToNowStrict } from "date-fns";
-import { Archive, Pin, PinOff } from "lucide-react";
+import { Archive, Circle, Pin, PinOff } from "lucide-react";
 import { memo, useState } from "react";
+
+import type { TurnResult } from "../store";
 
 import { Spinner } from "../../../components/ui/spinner";
 import { cn } from "../../../lib/utils";
@@ -31,6 +33,7 @@ interface SessionItemProps {
   isRestoring: boolean;
   isStreaming?: boolean;
   hasPendingPermission?: boolean;
+  turnResult?: TurnResult;
   onClick: () => void;
   projectPath: string;
 }
@@ -44,6 +47,7 @@ export const SessionItem = memo(function SessionItem({
   isRestoring,
   isStreaming = false,
   hasPendingPermission = false,
+  turnResult,
   onClick,
   projectPath,
 }: SessionItemProps) {
@@ -136,6 +140,13 @@ export const SessionItem = memo(function SessionItem({
               />
             ) : isProcessing ? (
               <Spinner className="size-3.5" />
+            ) : turnResult ? (
+              <Circle
+                size={8}
+                strokeWidth={0}
+                fill="currentColor"
+                className={turnResult === "success" ? "text-green-500" : "text-destructive"}
+              />
             ) : isPinned ? (
               <Pin size={14} strokeWidth={1.5} />
             ) : (

--- a/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
@@ -1,8 +1,10 @@
 import { memo } from "react";
 
 import type { UnifiedItem } from "../hooks/use-unified-sessions";
+import type { TurnResult } from "../store";
 
 import { useSessionChatStatus } from "../hooks/use-session-chat-status";
+import { useAgentStore } from "../store";
 import { SessionItem } from "./session-item";
 
 interface UnifiedSessionItemProps {
@@ -24,6 +26,9 @@ export const UnifiedSessionItem = memo(function UnifiedSessionItem({
 }: UnifiedSessionItemProps) {
   const sessionId = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
   const { isStreaming, hasPendingRequests } = useSessionChatStatus(sessionId);
+  const turnResult = useAgentStore((s) => s.unseenTurnResults.get(sessionId)) as
+    | TurnResult
+    | undefined;
 
   if (item.kind === "memory") {
     const s = item.session;
@@ -37,6 +42,7 @@ export const UnifiedSessionItem = memo(function UnifiedSessionItem({
         isRestoring={false}
         isStreaming={isStreaming}
         hasPendingPermission={hasPendingRequests}
+        turnResult={turnResult}
         onClick={() => onActivate(s.sessionId)}
         projectPath={item.projectPath}
       />
@@ -53,6 +59,7 @@ export const UnifiedSessionItem = memo(function UnifiedSessionItem({
       isRestoring={restoring === info.sessionId}
       isStreaming={isStreaming}
       hasPendingPermission={hasPendingRequests}
+      turnResult={turnResult}
       onClick={() => onLoad(info.sessionId)}
       projectPath={item.projectPath}
     />

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -67,14 +67,19 @@ export type ChatSession = {
   tasks: Map<string, TaskState>;
 };
 
+export type TurnResult = "success" | "error";
+
 type AgentState = {
   sessions: Map<string, ChatSession>;
   activeSessionId: string | null;
   agentSessions: SessionInfo[];
+  unseenTurnResults: Map<string, TurnResult>;
   _nextMessageId: number;
 
   setActiveSession: (sessionId: string | null) => void;
   setAgentSessions: (sessions: SessionInfo[]) => void;
+  markTurnCompleted: (sessionId: string, result: TurnResult) => void;
+  clearTurnResult: (sessionId: string) => void;
   createSession: (
     sessionId: string,
     meta?: { title?: string; createdAt?: string; cwd?: string; isNew?: boolean },
@@ -99,11 +104,29 @@ export const useAgentStore = create<AgentState>()(
     sessions: new Map(),
     activeSessionId: null,
     agentSessions: [],
+    unseenTurnResults: new Map(),
     _nextMessageId: 0,
 
     setActiveSession: (sessionId) => {
       storeLog("setActiveSession: %s", sessionId);
-      set({ activeSessionId: sessionId });
+      set((state) => {
+        state.activeSessionId = sessionId;
+        if (sessionId) state.unseenTurnResults.delete(sessionId);
+      });
+    },
+
+    markTurnCompleted: (sessionId, result) => {
+      storeLog("markTurnCompleted: sid=%s result=%s", sessionId, result);
+      set((state) => {
+        state.unseenTurnResults.set(sessionId, result);
+      });
+    },
+
+    clearTurnResult: (sessionId) => {
+      storeLog("clearTurnResult: sid=%s", sessionId);
+      set((state) => {
+        state.unseenTurnResults.delete(sessionId);
+      });
     },
 
     setAgentSessions: (agentSessions) => {
@@ -152,6 +175,7 @@ export const useAgentStore = create<AgentState>()(
       storeLog("removeSession: sid=%s", sessionId);
       set((state) => {
         state.sessions.delete(sessionId);
+        state.unseenTurnResults.delete(sessionId);
         if (state.activeSessionId === sessionId) {
           state.activeSessionId = null;
         }


### PR DESCRIPTION
Implemented visual indicators (green/red dots) for background sessions that complete a turn while not focused. Added unseenTurnResults tracking in Zustand store with callbacks from ClaudeCodeChat to detect turn completion transitions.