### PR TITLE
feat: implement plan mode approval flow with context clearing

### DIFF
--- a/docs/designs/2026-03-12-plan-mode-full-flow.md
+++ b/docs/designs/2026-03-12-plan-mode-full-flow.md
@@ -1,0 +1,408 @@
+# Plan Mode Full Flow Design
+
+**Date:** 2026-03-12
+**Status:** Proposed (v4)
+
+## Overview
+
+Implement the full Plan Mode flow for ExitPlanMode, including plan approval dialog via `canUseTool` interception, permission mode switching, context clearing, and plan file persistence.
+
+Currently, `EnterPlanMode` and `ExitPlanMode` exist as basic tool-part renderers. This design adds the interactive approval flow that matches the Claude Code CLI experience.
+
+## Architecture
+
+Follows the same `canUseTool` interception pattern as the AskUserQuestion MVP (see `2026-03-11-ask-user-question-via-can-use-tool-mvp-design.md`):
+
+```
+Claude calls ExitPlanMode({ plan: "..." })
+  |
+SDK calls canUseTool("ExitPlanMode", { plan }, options)
+  |
+session-manager.ts publishes permission_request event
+  |
+PermissionDialog detects toolName === "ExitPlanMode"
+  |
+  +-- ExitPlanMode.inputSchema.safeParse(request.input)
+  |     |
+  |     +-- parse fails → fall through to regular PermissionRequestDialog
+  |     |
+  |     +-- parse succeeds, input.plan is empty/falsy → auto-allow (no dialog)
+  |     |
+  |     +-- parse succeeds, input.plan present → Renders ExitPlanModeRequestDialog
+  |           |
+  |           User picks option (approve with mode / revise / dismiss)
+  |           |
+  |           Returns PlanApprovalChoice to PermissionDialog orchestrator
+```
+
+### Input validation
+
+Like AskUserQuestion, the input is validated with `ExitPlanMode.inputSchema.safeParse(request.input)` before rendering the approval dialog. If validation fails, the request falls through to the generic `PermissionRequestDialog`.
+
+No main-process protocol changes needed. Everything reuses the existing `canUseTool` -> `permission_request` -> `respondToRequest` flow.
+
+### Empty plan handling
+
+If `input.plan` is falsy or whitespace-only, auto-allow without showing the approval dialog. This matches the CLI behavior where an empty plan produces a simple "Exited plan mode" message.
+
+## ExitPlanMode Approval Dialog
+
+### UI Layout
+
+Uses the existing `Plan` component (`components/ai-elements/plan.tsx`) for the plan content display, which provides collapsible card styling with `PlanHeader`, `PlanContent`, `PlanTrigger`.
+
+### Dialog sizing
+
+The approval dialog renders inline (same position as permission dialogs — grid-overlaying the message input in `agent-chat.tsx`). Since the plan content can be large, the plan area is constrained with `max-h-[60vh] overflow-y-auto`. The collapsible `Plan` component allows the user to collapse the plan content to focus on the approval options.
+
+```
++---------------------------------------------+
+| [Plan component - collapsible]               |
+|  Plan to implement                     [v]   |
+| ------------------------------------------- |
+|  [rendered markdown plan content]            |
+|  (scrollable, max-height constrained)        |
++---------------------------------------------+
+|                                              |
+|  Ready to implement?                         |
+|                                              |
+|  o Yes, bypass permissions (YOLO)            |
+|  o Yes, auto-approve edits                   |
+|  * Yes, manually approve edits               |
+|  o Yes, clear context & bypass permissions   |
+|  o Request revision...                       |
+|    +----------------------------------------+|
+|    | [textarea - feedback for Claude]        ||
+|    +----------------------------------------+|
+|                                              |
+|                              [Submit ->]     |
++---------------------------------------------+
+```
+
+### Unified submit flow
+
+All options (approve and reject) share a single submit button. The button label and behavior change based on selection:
+
+- **Approve options (1-4):** Button says "Approve" → returns `approve` choice
+- **Request revision:** Button says "Request Revision" → returns `revise` choice with feedback
+
+The feedback textarea only appears when "Request revision" is selected.
+
+A secondary "Dismiss" text button is always visible. This sends a `dismiss` choice — distinct from "Request revision" (dismiss = user doesn't want to engage, revise = user wants Claude to improve the plan).
+
+### Default selection
+
+"Yes, manually approve edits" (`default` mode) is pre-selected. This is the safest default — the user can submit immediately without changing anything. Opting into YOLO requires an explicit choice.
+
+### Approval Options
+
+| Option                           | Permission Mode     | Clear Context |
+| -------------------------------- | ------------------- | ------------- |
+| Bypass permissions (YOLO)        | `bypassPermissions` | No            |
+| Auto-approve edits               | `acceptEdits`       | No            |
+| Manually approve edits (default) | `default`           | No            |
+| Clear context & bypass           | `bypassPermissions` | Yes           |
+| Request revision                 | n/a                 | No            |
+
+### Component responsibility split
+
+The `ExitPlanModeRequestDialog` is a **pure UI component**. It does NOT call `respondToRequest` or `dispatch`. It returns a structured choice:
+
+```ts
+type PlanApprovalChoice =
+  | { action: "approve"; mode: PermissionMode; clearContext: boolean }
+  | { action: "revise"; feedback: string }
+  | { action: "dismiss" };
+```
+
+All orchestration (respond → store update → dispatch → context clear) lives in `permission-dialog.tsx`, which has access to `sessionId`, the chat instance, and the agent store.
+
+### Response Mapping
+
+#### Approve (no clear context)
+
+```ts
+// permission-dialog.tsx — handleExitPlanModeChoice()
+const handleExitPlanModeChoice = async (choice: PlanApprovalChoice) => {
+  if (choice.action === "revise") {
+    // See "Request revision" below
+    return;
+  }
+
+  // 1. Return allow — SDK runs ExitPlanMode.call() which restores prePlanMode
+  await respondToRequest(requestId, {
+    type: "permission_request",
+    result: { behavior: "allow", updatedInput: { ...input } },
+  });
+
+  // 2. Update agent store (for UI: dropdown, plan mode pill)
+  setPermissionMode(sessionId, choice.mode);
+
+  // 3. Override SDK's prePlanMode restoration with user's chosen mode
+  // Must happen AFTER respondToRequest completes — see ordering rationale below
+  chat.dispatch({
+    kind: "configure",
+    configure: { type: "set_permission_mode", mode: choice.mode },
+  });
+
+  // 4. Save plan to disk (all approvals, not just context clearing)
+  client.agent.savePlan({ sessionId, plan: input.plan });
+
+  // 5. If clear context requested, register pending action
+  if (choice.clearContext) {
+    const cwd = useAgentStore.getState().sessions.get(sessionId)?.cwd;
+    // CWD must be captured BEFORE the session is closed
+    chat.store.setState({
+      pendingContextClear: { plan: input.plan, mode: choice.mode, cwd },
+    });
+  }
+};
+```
+
+**Ordering rationale:** The SDK's ExitPlanMode.call() internally restores `prePlanMode` (the mode active before entering plan mode). Our `set_permission_mode` dispatch must arrive AFTER this to override it with the user's selection. Since `respondToRequest` sends IPC first and the SDK processes it synchronously, dispatching immediately after the await is safe — the SDK will have already finished the ExitPlanMode tool execution.
+
+**Dual update rationale:** Both `setPermissionMode(sessionId, mode)` (Zustand store for UI) and `chat.dispatch(set_permission_mode)` (SDK backend) are required. The store update is synchronous and immediate; the dispatch is async IPC. This matches the existing pattern in `input-toolbar.tsx:127-135`.
+
+#### Approve (with clear context)
+
+Same as above, plus the `pendingContextClear` flag is set on the chat store. Context clearing executes when the turn completes (see Context Clearing Flow below).
+
+#### Request revision (reject with feedback)
+
+```ts
+if (choice.action === "revise") {
+  await respondToRequest(requestId, {
+    type: "permission_request",
+    result: {
+      behavior: "deny",
+      message: choice.feedback || "User requested plan revision",
+    },
+  });
+  // Claude receives rejection and revises the plan. No mode change needed.
+}
+```
+
+#### Dismiss
+
+```ts
+if (choice.action === "dismiss") {
+  await respondToRequest(requestId, {
+    type: "permission_request",
+    result: {
+      behavior: "deny",
+      message: "User dismissed plan approval",
+    },
+  });
+}
+```
+
+## Context Clearing Flow
+
+Context clearing uses a deterministic store-subscription pattern, piggybacking on the existing `onTurnComplete` infrastructure in `ClaudeCodeChat`.
+
+### Mechanism: pendingContextClear in chat store state
+
+Add `pendingContextClear` to `ClaudeCodeChatStoreState`:
+
+```ts
+// chat-state.ts
+export interface ClaudeCodeChatStoreState {
+  // ... existing fields ...
+  pendingContextClear?: {
+    plan: string;
+    mode: PermissionMode;
+    cwd?: string; // captured BEFORE session close
+  };
+}
+```
+
+The existing `onTurnComplete` callback in `ClaudeCodeChatManager` checks for the flag:
+
+```ts
+// chat-manager.ts — #turnCallbacks
+#turnCallbacks = {
+  onTurnComplete: async (id: string, result: "success" | "error") => {
+    const chat = this.chats.get(id);
+    const pending = chat?.store.getState().pendingContextClear;
+
+    if (pending) {
+      chat.store.setState({ pendingContextClear: undefined });
+      const cwd = pending.cwd;
+      if (!cwd) return;
+
+      // 1. Close the old session
+      await this.removeSession(id);
+      useAgentStore.getState().removeSession(id);
+
+      // 2. Create new session
+      const { sessionId, commands, models, ...rest } =
+        await this.createSession(cwd);
+
+      // 3. Register in store and set permission mode
+      registerSessionInStore(sessionId, cwd, { commands, models, ...rest }, true);
+      useAgentStore.getState().setPermissionMode(sessionId, pending.mode);
+      this.getChat(sessionId)?.dispatch({
+        kind: "configure",
+        configure: { type: "set_permission_mode", mode: pending.mode },
+      });
+
+      // 4. Auto-send the plan as the first message
+      useAgentStore.getState().addUserMessage(sessionId, pending.plan);
+      this.getChat(sessionId)?.sendMessage({
+        text: `Implement the following plan:\n\n${pending.plan}`,
+        metadata: { sessionId, parentToolUseId: null },
+      });
+    }
+
+    // Existing background-session notification logic
+    const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
+    if (activeSessionId !== id) markTurnCompleted(id, result);
+  },
+  onTurnStart: (id: string) => {
+    useAgentStore.getState().clearTurnResult(id);
+  },
+};
+```
+
+This is deterministic — the context clear triggers exactly when the turn finishes, via the existing store subscription. No new parallel state mechanism, no timing guesses.
+
+### CWD capture
+
+The CWD must be read from the agent store **before** the session is closed, since closing removes the store entry. This is done in the approval handler (permission-dialog.tsx) and stored in `pendingContextClear.cwd`.
+
+### Error/cleanup paths
+
+If the turn ends with `result === "error"`, the context clear still fires. The plan was approved — the error is unrelated (likely the ExitPlanMode tool had an issue). The user still wants to proceed with the plan.
+
+### Error recovery
+
+If `createSession` fails after `removeSession`, the conversation is lost but the plan is safe (saved via `savePlan` before context clearing triggers). On error:
+
+- Catch the exception in `onTurnComplete`
+- Create a fresh session without injecting the plan
+- Show an error notification with the saved plan file path so the user can manually reference it
+
+## Plan File Persistence
+
+Plans saved to `~/.neovate-desktop/plans/` on **every approval** (not just context clearing). This gives users a history of all approved plans.
+
+Format: `<date>-<slug>.md`
+
+Add a `savePlan` RPC endpoint on the agent router:
+
+```ts
+savePlan: os.input(
+  z.object({
+    sessionId: z.string(),
+    plan: z.string(),
+    title: z.string().optional(),
+  }),
+).handler(async ({ input }) => {
+  const slug = input.title
+    ? input.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .slice(0, 50)
+    : input.sessionId.slice(0, 8);
+  const filename = `${new Date().toISOString().slice(0, 10)}-${slug}.md`;
+  const dir = path.join(homedir(), ".neovate-desktop", "plans");
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, filename), input.plan, "utf8");
+  return { path: path.join(dir, filename) };
+});
+```
+
+## Updated ExitPlanMode Tool Renderer
+
+### No duplicate plan display
+
+While the approval dialog is showing, the tool-part card in the message stream must NOT also show the plan. This follows the same pattern as `AskUserQuestionTool`:
+
+```tsx
+// exit-plan-mode-tool.tsx
+if (
+  !invocation ||
+  invocation.state === "input-streaming" ||
+  invocation.state === "input-available" ||
+  !invocation.output
+) {
+  return null; // hidden while approval dialog is active
+}
+```
+
+The tool-part only renders after the tool completes (with output). This prevents the user from seeing the plan twice (once in the message stream, once in the dialog).
+
+### Post-completion display
+
+After approval, the tool-part renderer shows a compact outcome:
+
+- **Approved:** "Plan approved — implementing with {mode} mode" (collapsed plan content below)
+- **Rejected:** "Plan revision requested" (no plan content — Claude is revising)
+
+Does NOT duplicate the full plan that the approval dialog already showed. Uses a concise status line.
+
+## Context Clearing Loading State
+
+Between approving "clear context" and the new session being ready, the user sees a brief gap (old session closing, new one creating). To avoid a blank/confusing screen, show a transient loading indicator.
+
+The `pendingContextClear` flag in the chat store doubles as the loading signal. In `agent-chat.tsx`, when `pendingContextClear` is set on the current chat, render a "Setting up new session..." overlay or inline message instead of the normal chat content. This state is naturally cleared when the old session is removed and the new session becomes active.
+
+## Implementation Files
+
+| #   | File                                | Action | Description                                                                         |
+| --- | ----------------------------------- | ------ | ----------------------------------------------------------------------------------- |
+| 1   | `exit-plan-mode-request-dialog.tsx` | Create | Pure UI dialog returning `PlanApprovalChoice`                                       |
+| 2   | `permission-dialog.tsx`             | Edit   | Add ExitPlanMode branch, empty plan auto-allow, multi-step resolution orchestration |
+| 3   | `exit-plan-mode-tool.tsx`           | Edit   | Hide while pending + show compact approval outcome                                  |
+| 4   | `agent/router.ts` (main)            | Edit   | Add `savePlan` endpoint                                                             |
+| 5   | `chat-state.ts`                     | Edit   | Add `pendingContextClear` to store state                                            |
+| 6   | `chat-manager.ts`                   | Edit   | Handle `pendingContextClear` in `onTurnComplete` + error recovery                   |
+
+## Constraints
+
+### 1. Follow existing canUseTool semantics
+
+Same as AskUserQuestion MVP — `PermissionResult` only supports `allow + updatedInput` or `deny + message`. All client-side effects (mode switching, session management) happen after the resolve call.
+
+### 2. No new request type
+
+Continue using `permission_request` with tool-name branching. No new protocol types.
+
+### 3. Plan content comes from input
+
+The plan text arrives as `input.plan` from the SDK. We render it as markdown. We do not read plan files from disk (the SDK handles that internally).
+
+### 4. Permission mode: dual update required
+
+Both updates must happen on approve:
+
+- `setPermissionMode(sessionId, mode)` — Zustand store for UI (dropdown, plan mode pill)
+- `chat.dispatch({ kind: "configure", configure: { type: "set_permission_mode", mode } })` — SDK backend
+
+This matches the existing pattern in `input-toolbar.tsx:127-135`.
+
+### 5. Permission mode dispatch ordering
+
+The SDK dispatch MUST happen after `respondToRequest` completes (awaited). The SDK's ExitPlanMode.call() restores `prePlanMode` during tool execution. Our dispatch overrides this with the user's selection. The ordering is guaranteed because the SDK processes the `allow` result synchronously before our dispatch arrives via IPC.
+
+### 6. Dialog is pure UI
+
+`ExitPlanModeRequestDialog` returns a `PlanApprovalChoice` — it has no knowledge of `sessionId`, `respondToRequest`, `dispatch`, or the agent store. All orchestration lives in `permission-dialog.tsx`.
+
+## Risks
+
+### 1. Context clearing: onTurnComplete reliability
+
+The `pendingContextClear` flag fires via `onTurnComplete` (store subscription for `streaming → ready|error`). If the stream is interrupted before transitioning, the pending flag stays orphaned. Mitigation: also clear the flag on session removal or explicit interrupt.
+
+### 2. SDK permission mode race
+
+Although the ordering argument (constraint 5) is sound, edge cases like slow IPC or SDK async internals could cause our dispatch to arrive before ExitPlanMode finishes. Mitigation: if issues arise, add a small safety delay (50-100ms) before the dispatch.
+
+### 3. Plan size
+
+Large plans may make the approval dialog unwieldy. The Plan component's collapsible content and `max-h-[60vh] overflow-y-auto` keep it manageable.
+
+### 4. Session switch during pending dialog
+
+If the user switches to another session while the ExitPlanMode dialog is showing, the dialog disappears (it's per-session `pendingRequests`). When they switch back, it reappears. No special handling needed — this is the existing behavior for all permission requests.

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -1,5 +1,8 @@
 import { ORPCError, implement } from "@orpc/server";
 import debug from "debug";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
 
 import type { AppContext } from "../../router";
 
@@ -76,6 +79,22 @@ export const agentRouter = os.agent.router({
         throw new ORPCError("BAD_GATEWAY", { defined: true, message });
       }
     }),
+  }),
+
+  savePlan: os.agent.savePlan.handler(async ({ input }) => {
+    const slug = input.title
+      ? input.title
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .slice(0, 50)
+      : input.sessionId.slice(0, 8);
+    const filename = `${new Date().toISOString().slice(0, 10)}-${slug}.md`;
+    const dir = path.join(homedir(), ".neovate-desktop", "plans");
+    await mkdir(dir, { recursive: true });
+    const filePath = path.join(dir, filename);
+    await writeFile(filePath, input.plan, "utf8");
+    agentLog("savePlan: saved to %s", filePath);
+    return { path: filePath };
   }),
 
   setModelSetting: os.agent.setModelSetting.handler(({ input, context }) => {

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -1,10 +1,15 @@
 import type { ContractRouterClient } from "@orpc/contract";
 
+import debug from "debug";
+
 import { agentContract } from "../../../../shared/features/agent/contract";
 import { client } from "../../orpc";
 import { ClaudeCodeChat } from "./chat";
 import { ClaudeCodeChatTransport } from "./chat-transport";
+import { registerSessionInStore } from "./session-utils";
 import { useAgentStore } from "./store";
+
+const log = debug("neovate:chat-manager");
 
 type AgentRpc = ContractRouterClient<{ agent: typeof agentContract }>["agent"];
 
@@ -18,6 +23,15 @@ export class ClaudeCodeChatManager {
 
   #turnCallbacks = {
     onTurnComplete: (id: string, result: "success" | "error") => {
+      const chat = this.chats.get(id);
+      const pending = chat?.store.getState().pendingContextClear;
+
+      if (pending) {
+        chat!.store.setState({ pendingContextClear: undefined });
+        log("onTurnComplete: pendingContextClear detected for session=%s", id.slice(0, 8));
+        void this.#handleContextClear(id, pending);
+      }
+
       const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
       if (activeSessionId !== id) markTurnCompleted(id, result);
     },
@@ -65,10 +79,68 @@ export class ClaudeCodeChatManager {
     const chat = this.chats.get(sessionId);
     if (!chat) return;
 
+    // Clear any pending context clear flag to prevent orphaned actions
+    chat.store.setState({ pendingContextClear: undefined });
     await chat.stop();
     await chat.dispose();
     this.chats.delete(sessionId);
     this.rpc.claudeCode.closeSession({ sessionId }).catch(() => {});
+  }
+
+  async #handleContextClear(
+    oldSessionId: string,
+    pending: import("./chat-state").PendingContextClear,
+  ): Promise<void> {
+    const cwd = pending.cwd;
+    if (!cwd) {
+      log("handleContextClear: no cwd, skipping");
+      return;
+    }
+
+    try {
+      // 1. Close old session
+      log("handleContextClear: closing old session=%s", oldSessionId.slice(0, 8));
+      await this.removeSession(oldSessionId);
+      useAgentStore.getState().removeSession(oldSessionId);
+
+      // 2. Create new session
+      log("handleContextClear: creating new session cwd=%s", cwd);
+      const { sessionId, commands, models, currentModel, modelScope, providerId } =
+        await this.createSession(cwd);
+
+      // 3. Register in store and set permission mode
+      registerSessionInStore(
+        sessionId,
+        cwd,
+        { commands, models, currentModel, modelScope, providerId },
+        true,
+      );
+      useAgentStore.getState().setPermissionMode(sessionId, pending.mode);
+      this.getChat(sessionId)?.dispatch({
+        kind: "configure",
+        configure: { type: "set_permission_mode", mode: pending.mode },
+      });
+
+      // 4. Auto-send the plan as first message
+      log("handleContextClear: sending plan to new session=%s", sessionId.slice(0, 8));
+      useAgentStore.getState().addUserMessage(sessionId, pending.plan);
+      this.getChat(sessionId)?.sendMessage({
+        text: `Implement the following plan:\n\n${pending.plan}`,
+        metadata: { sessionId, parentToolUseId: null },
+      });
+    } catch (error) {
+      log(
+        "handleContextClear: FAILED error=%s",
+        error instanceof Error ? error.message : String(error),
+      );
+      // Fallback: create a session without injecting the plan
+      try {
+        const { sessionId } = await this.createSession(cwd);
+        registerSessionInStore(sessionId, cwd, {}, true);
+      } catch {
+        // give up
+      }
+    }
   }
 }
 

--- a/packages/desktop/src/renderer/src/features/agent/chat-state.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-state.ts
@@ -7,8 +7,15 @@ import type {
   ClaudeCodeUIEventRequest,
   ClaudeCodeUIMessage,
 } from "../../../../shared/claude-code/types";
+import type { PermissionMode } from "../../../../shared/features/agent/types";
 
 export type ClaudeCodeChatCapabilities = Awaited<ReturnType<Query["initializationResult"]>>;
+
+export interface PendingContextClear {
+  plan: string;
+  mode: PermissionMode;
+  cwd?: string;
+}
 
 export interface ClaudeCodeChatStoreState {
   messages: ClaudeCodeUIMessage[];
@@ -20,6 +27,7 @@ export interface ClaudeCodeChatStoreState {
     request: ClaudeCodeUIEventRequest;
   }>;
   capabilities: ClaudeCodeChatCapabilities | null;
+  pendingContextClear?: PendingContextClear;
 }
 
 export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {

--- a/packages/desktop/src/renderer/src/features/agent/components/exit-plan-mode-request-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/exit-plan-mode-request-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+
+import type { PermissionMode } from "../../../../../shared/features/agent/types";
+
+import { MessageResponse } from "../../../components/ai-elements/message";
+import {
+  Plan,
+  PlanAction,
+  PlanContent,
+  PlanHeader,
+  PlanTitle,
+  PlanTrigger,
+} from "../../../components/ai-elements/plan";
+import { Button } from "../../../components/ui/button";
+import { Label } from "../../../components/ui/label";
+import { Radio, RadioGroup } from "../../../components/ui/radio-group";
+
+export type PlanApprovalChoice =
+  | { action: "approve"; mode: PermissionMode; clearContext: boolean }
+  | { action: "revise"; feedback: string }
+  | { action: "dismiss" };
+
+type ApprovalOption = {
+  value: string;
+  label: string;
+  description: string;
+  mode: PermissionMode;
+  clearContext: boolean;
+};
+
+const APPROVAL_OPTIONS: ApprovalOption[] = [
+  {
+    value: "bypass",
+    label: "Yes, bypass permissions",
+    description: "YOLO mode — no permission prompts",
+    mode: "bypassPermissions",
+    clearContext: false,
+  },
+  {
+    value: "autoEdit",
+    label: "Yes, auto-approve edits",
+    description: "Auto-approve file edits, prompt for other tools",
+    mode: "acceptEdits",
+    clearContext: false,
+  },
+  {
+    value: "manual",
+    label: "Yes, manually approve edits",
+    description: "Prompt for all tool usage",
+    mode: "default",
+    clearContext: false,
+  },
+  {
+    value: "clearContext",
+    label: "Yes, clear context & bypass",
+    description: "Start fresh session with the plan and bypass permissions",
+    mode: "bypassPermissions",
+    clearContext: true,
+  },
+];
+
+const REVISE_VALUE = "revise";
+
+type Props = {
+  plan: string;
+  onChoice: (choice: PlanApprovalChoice) => void;
+};
+
+export function ExitPlanModeRequestDialog({ plan, onChoice }: Props) {
+  const [selected, setSelected] = useState("manual");
+  const [feedback, setFeedback] = useState("");
+
+  const isRevise = selected === REVISE_VALUE;
+  const buttonLabel = isRevise ? "Request Revision" : "Approve";
+
+  const handleSubmit = () => {
+    if (isRevise) {
+      onChoice({ action: "revise", feedback });
+      return;
+    }
+    const option = APPROVAL_OPTIONS.find((o) => o.value === selected);
+    if (!option) return;
+    onChoice({ action: "approve", mode: option.mode, clearContext: option.clearContext });
+  };
+
+  return (
+    <div className="relative rounded-xl border border-border/80 bg-white dark:bg-background">
+      <Plan defaultOpen>
+        <PlanHeader>
+          <PlanTitle>Plan to implement</PlanTitle>
+          <PlanAction>
+            <PlanTrigger />
+          </PlanAction>
+        </PlanHeader>
+        <PlanContent>
+          <div className="max-h-[40vh] overflow-y-auto px-4 pb-4">
+            <MessageResponse>{plan}</MessageResponse>
+          </div>
+        </PlanContent>
+      </Plan>
+
+      <div className="space-y-3 px-4 py-3">
+        <p className="text-sm font-medium text-foreground">Ready to implement?</p>
+
+        <RadioGroup value={selected} onValueChange={setSelected} className="gap-1">
+          {APPROVAL_OPTIONS.map((option) => (
+            <Label
+              key={option.value}
+              className="flex cursor-pointer items-start gap-2 rounded-lg border border-border/70 p-2.5 hover:bg-accent/50 has-data-checked:border-primary/48 has-data-checked:bg-accent/50"
+            >
+              <Radio value={option.value} />
+              <div className="flex flex-col">
+                <p className="text-sm text-foreground">{option.label}</p>
+                <p className="text-xs text-muted-foreground">{option.description}</p>
+              </div>
+            </Label>
+          ))}
+
+          <Label className="flex cursor-pointer items-start gap-2 rounded-lg border border-border/70 p-2.5 hover:bg-accent/50 has-data-checked:border-primary/48 has-data-checked:bg-accent/50">
+            <Radio value={REVISE_VALUE} />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-col">
+                <p className="text-sm text-foreground">Request revision</p>
+                <p className="text-xs text-muted-foreground">
+                  Send feedback to Claude to revise the plan
+                </p>
+              </div>
+              {isRevise && (
+                <textarea
+                  placeholder="What should Claude change about this plan?"
+                  rows={2}
+                  style={{ resize: "none" }}
+                  className="mt-2 block w-full rounded-md border border-border/70 bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground/70 focus:ring-1 focus:ring-ring"
+                  value={feedback}
+                  onChange={(e) => setFeedback(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  autoFocus
+                />
+              )}
+            </div>
+          </Label>
+        </RadioGroup>
+
+        <div className="flex items-center justify-between">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            onClick={() => onChoice({ action: "dismiss" })}
+          >
+            Dismiss
+          </Button>
+          <Button size="sm" onClick={handleSubmit} disabled={isRevise && !feedback.trim()}>
+            {buttonLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
@@ -2,9 +2,16 @@ import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 
 import debug from "debug";
 
+import type { PlanApprovalChoice } from "./exit-plan-mode-request-dialog";
+
 import { AskUserQuestionInputSchema } from "../../../../../shared/claude-code/tools/ask-user-question";
+import { ExitPlanModeInputSchema } from "../../../../../shared/claude-code/tools/exit-plan-mode";
+import { client } from "../../../orpc";
+import { claudeCodeChatManager } from "../chat-manager";
 import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
+import { useAgentStore } from "../store";
 import { AskUserQuestionRequestDialog } from "./ask-user-question-request-dialog";
+import { ExitPlanModeRequestDialog } from "./exit-plan-mode-request-dialog";
 import { PermissionRequestDialog } from "./permission-request-dialog";
 
 const chatLog = debug("neovate:agent-chat");
@@ -19,10 +26,27 @@ export function PermissionDialog({ sessionId }: Props) {
   if (!activeRequest) return null;
 
   const { requestId, request } = activeRequest;
+
+  // --- AskUserQuestion branch ---
   const askUserQuestion =
     request.toolName === "AskUserQuestion"
       ? AskUserQuestionInputSchema.safeParse(request.input)
       : null;
+
+  // --- ExitPlanMode branch ---
+  const exitPlanMode =
+    request.toolName === "ExitPlanMode" ? ExitPlanModeInputSchema.safeParse(request.input) : null;
+
+  // ExitPlanMode with empty plan: auto-allow without dialog
+  if (exitPlanMode?.success && !exitPlanMode.data.plan?.trim()) {
+    chatLog("ExitPlanMode: empty plan, auto-allowing sessionId=%s", sessionId.slice(0, 8));
+    void respondToRequest(requestId, {
+      type: "permission_request",
+      result: { behavior: "allow", updatedInput: request.input as Record<string, unknown> },
+    });
+    return null;
+  }
+
   const handleResolve = (result: PermissionResult) => {
     chatLog(
       "handleResolvePermission: sessionId=%s requestId=%s behavior=%s",
@@ -33,6 +57,68 @@ export function PermissionDialog({ sessionId }: Props) {
     void respondToRequest(requestId, { type: "permission_request", result });
   };
 
+  const handleExitPlanModeChoice = async (choice: PlanApprovalChoice) => {
+    const input = exitPlanMode?.data;
+    if (!input) return;
+
+    if (choice.action === "dismiss") {
+      chatLog("ExitPlanMode: dismissed sessionId=%s", sessionId.slice(0, 8));
+      await respondToRequest(requestId, {
+        type: "permission_request",
+        result: { behavior: "deny", message: "User dismissed plan approval" },
+      });
+      return;
+    }
+
+    if (choice.action === "revise") {
+      chatLog("ExitPlanMode: revision requested sessionId=%s", sessionId.slice(0, 8));
+      await respondToRequest(requestId, {
+        type: "permission_request",
+        result: {
+          behavior: "deny",
+          message: choice.feedback || "User requested plan revision",
+        },
+      });
+      return;
+    }
+
+    // Approve: respond → store update → SDK dispatch → save plan → context clear
+    chatLog(
+      "ExitPlanMode: approved sessionId=%s mode=%s clearContext=%s",
+      sessionId.slice(0, 8),
+      choice.mode,
+      choice.clearContext,
+    );
+
+    // 1. Return allow — SDK runs ExitPlanMode.call()
+    await respondToRequest(requestId, {
+      type: "permission_request",
+      result: { behavior: "allow", updatedInput: input as Record<string, unknown> },
+    });
+
+    // 2. Update agent store (UI: dropdown, plan mode pill)
+    useAgentStore.getState().setPermissionMode(sessionId, choice.mode);
+
+    // 3. Override SDK's prePlanMode with user's selection
+    const chat = claudeCodeChatManager.getChat(sessionId);
+    chat?.dispatch({
+      kind: "configure",
+      configure: { type: "set_permission_mode", mode: choice.mode },
+    });
+
+    // 4. Save plan to disk
+    client.agent.savePlan({ sessionId, plan: input.plan }).catch(() => {});
+
+    // 5. If clear context, register pending action
+    if (choice.clearContext) {
+      const cwd = useAgentStore.getState().sessions.get(sessionId)?.cwd;
+      chat?.store.setState({
+        pendingContextClear: { plan: input.plan, mode: choice.mode, cwd },
+      });
+    }
+  };
+
+  // --- Render ---
   let content = (
     <PermissionRequestDialog key={requestId} request={request} onResolve={handleResolve} />
   );
@@ -43,6 +129,14 @@ export function PermissionDialog({ sessionId }: Props) {
         key={requestId}
         input={askUserQuestion.data}
         onResolve={handleResolve}
+      />
+    );
+  } else if (exitPlanMode?.success) {
+    content = (
+      <ExitPlanModeRequestDialog
+        key={requestId}
+        plan={exitPlanMode.data.plan}
+        onChoice={handleExitPlanModeChoice}
       />
     );
   }

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/exit-plan-mode-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/exit-plan-mode-tool.tsx
@@ -1,17 +1,24 @@
 import type { ExitPlanModeUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
-import { MessageResponse } from "../../../../components/ai-elements/message";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 
 export function ExitPlanModeTool({ invocation }: { invocation: ExitPlanModeUIToolInvocation }) {
-  if (!invocation || invocation.state === "input-streaming") return null;
-  const { state, input } = invocation;
+  // Hide while approval dialog is active (same pattern as AskUserQuestionTool)
+  if (
+    !invocation ||
+    invocation.state === "input-streaming" ||
+    invocation.state === "input-available" ||
+    !invocation.output
+  ) {
+    return null;
+  }
+  const { state, output } = invocation;
 
   return (
     <Tool>
       <ToolHeader type="tool-ExitPlanMode" state={state} title="Exit Plan Mode" />
       <ToolContent>
-        {input?.plan ? <MessageResponse>{input.plan}</MessageResponse> : null}
+        <p className="text-sm text-muted-foreground">{output}</p>
       </ToolContent>
     </Tool>
   );

--- a/packages/desktop/src/shared/claude-code/tools/exit-plan-mode.ts
+++ b/packages/desktop/src/shared/claude-code/tools/exit-plan-mode.ts
@@ -1,14 +1,16 @@
 import { tool, type UIToolInvocation } from "ai";
 import { z } from "zod";
 
+export const ExitPlanModeInputSchema = z.object({
+  /**
+   * The plan to run by the user for approval
+   */
+  plan: z.string(),
+});
+
 export const ExitPlanMode = tool({
   // Docs: https://docs.claude.com/en/docs/claude-code/sdk/sdk-typescript#exitplanmode
-  inputSchema: z.object({
-    /**
-     * The plan to run by the user for approval
-     */
-    plan: z.string(),
-  }),
+  inputSchema: ExitPlanModeInputSchema,
   // Docs: https://docs.claude.com/en/docs/claude-code/sdk/sdk-typescript#exitplanmode-2
   outputSchema: z.string(),
 });

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -67,6 +67,16 @@ export const agentContract = {
     ),
   },
 
+  savePlan: oc
+    .input(
+      z.object({
+        sessionId: z.string(),
+        plan: z.string(),
+        title: z.string().optional(),
+      }),
+    )
+    .output(type<{ path: string }>()),
+
   setModelSetting: oc
     .input(
       z.object({


### PR DESCRIPTION
Implements the full ExitPlanMode approval flow including plan approval dialog via canUseTool interception, permission mode switching, context clearing with session recreation, and plan file persistence to disk.