### PR TITLE
refactor: extract encodeProjectPath to shared utility

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
@@ -3,6 +3,7 @@ import type { ReactElement, ReactNode } from "react";
 import debug from "debug";
 import { MoreHorizontal } from "lucide-react";
 
+import { encodeProjectPath } from "../../../../../shared/claude-code/paths";
 import { Button } from "../../../components/ui/button";
 import {
   ContextMenu,
@@ -50,7 +51,7 @@ export function SessionActionsMenu({
   };
 
   const handleCopyJsonlPath = () => {
-    const encoded = cwd.replaceAll(/[\/.]/g, "-");
+    const encoded = encodeProjectPath(cwd);
     const jsonlPath = `${window.api.homedir}/.claude/projects/${encoded}/${sessionId}.jsonl`;
     log("copyJsonlPath: %s", jsonlPath);
     navigator.clipboard.writeText(jsonlPath);

--- a/packages/desktop/src/shared/claude-code/paths.ts
+++ b/packages/desktop/src/shared/claude-code/paths.ts
@@ -1,0 +1,25 @@
+const MAX_DIR_LENGTH = 200;
+
+/**
+ * Hash a string using the same algorithm as Claude Code (Java's String.hashCode).
+ * Used as a suffix when the encoded path exceeds MAX_DIR_LENGTH.
+ */
+function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+/**
+ * Encode a project path to the directory name used under `~/.claude/projects/`.
+ * Mirrors Claude Code's internal `encodeProjectPath` logic exactly:
+ * 1. Replace all non-alphanumeric characters with `-`
+ * 2. If the result exceeds 200 characters, truncate and append a hash suffix
+ */
+export function encodeProjectPath(cwd: string): string {
+  const encoded = cwd.replace(/[^a-zA-Z0-9]/g, "-");
+  if (encoded.length <= MAX_DIR_LENGTH) return encoded;
+  return `${encoded.slice(0, MAX_DIR_LENGTH)}-${hashString(cwd)}`;
+}


### PR DESCRIPTION
Extracted the encodeProjectPath function into a new shared utility file to mirror Claude Code's internal logic exactly, including proper handling of long paths with hash suffixes.

ref to #122