### PR TITLE
feat: redesign permission dialog with Claude Code UX alignment

### DIFF
--- a/docs/designs/2026-03-12-permission-approve-ux.md
+++ b/docs/designs/2026-03-12-permission-approve-ux.md
@@ -1,0 +1,277 @@
+# Permission Approve UX — Full Alignment with Claude Code
+
+**Date:** 2026-03-12
+**Status:** Implemented
+
+## Problem
+
+The current permission dialog (`permission-request-dialog.tsx`) is minimal:
+
+- Two buttons: Allow / Deny
+- Raw JSON dump of tool input
+- No "always allow" option
+- SDK provides `suggestions` (PermissionUpdate[]) in `options` but they are completely ignored
+- No decision reason shown (why was the user prompted?)
+- No feedback mechanism on deny
+- No keyboard shortcuts
+
+## Target
+
+Align with Claude Code CLI's permission approval UX, which provides:
+
+- Multiple approve options (Yes, Yes + always allow with smart labels)
+- Decision reason display (mode, rule, hook, etc.)
+- Smart suggestion-aware labels from SDK `PermissionUpdate[]`
+- Deny with feedback ("tell Claude what to do differently")
+- Keyboard shortcuts (y/a/n/Escape)
+- Tool-specific input formatting
+
+## Design
+
+### Section 1: Data Flow
+
+The backend (`session-manager.ts` canUseTool callback) already passes the full SDK options through to the frontend via the shared type `Omit<Parameters<CanUseTool>[2], "signal">`. This includes `suggestions`, `blockedPath`, `toolUseID`, `agentID`, and `description`. **No backend changes needed.**
+
+When the user picks "Allow + always allow", the frontend constructs:
+
+```ts
+{
+  behavior: "allow",
+  updatedInput: input,
+  updatedPermissions: options.suggestions, // pass SDK suggestions back
+  toolUseID: options.toolUseID,
+}
+```
+
+The SDK handles writing rules to the appropriate destination (session/project/user settings).
+
+### Section 2: Permission Options
+
+Computed dynamically from `request.options.suggestions`:
+
+| Value           | Label                                                  | When shown                                                |
+| --------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| `"yes"`         | "Allow" (or "Allow once" when always-allow is visible) | Always                                                    |
+| `"yes-always"`  | "Allow, and [smart label]"                             | When `suggestions` exist with `addRules`/`addDirectories` |
+| `"no"`          | "Deny"                                                 | Always                                                    |
+| `"no-feedback"` | "Deny, with feedback..."                               | Always (expands inline text input)                        |
+
+> **Label disambiguation:** When the "yes-always" option is present, the plain "yes" option is labeled "Allow once" to make the distinction clear.
+
+#### Smart Suggestion Labels
+
+A pure function `formatSuggestionLabel(suggestions)` generates contextual text from `PermissionUpdate[]`:
+
+- **addDirectories only**: "always allow access to **dirname/** in this project"
+- **addRules (Read) only**: "allow reading from **dirname/** in this project"
+- **addRules (Bash) only**: "don't ask again for **command** commands this session"
+- **Mixed**: "allow **dirname/** access and **command** commands"
+- **setMode**: shown with warning — "switch to **YOLO** mode for this session"
+- **Fallback**: "always allow for this session"
+
+The destination scope from `PermissionUpdate.destination` is surfaced in the label so the user knows how permanent the rule is:
+
+- `session` -> "this session"
+- `projectSettings` -> "in this project"
+- `userSettings` -> "globally"
+- `localSettings` -> "locally"
+
+#### Persistence Subtitle
+
+When the suggestion destination writes to disk, a small muted subtitle is shown under the "always allow" option so the user understands the side effect:
+
+| Destination       | Subtitle                               | Persistence                            |
+| ----------------- | -------------------------------------- | -------------------------------------- |
+| `session`         | _(none)_                               | In-memory only, gone when session ends |
+| `projectSettings` | "Saves to .claude/settings.json"       | Permanent, committed to git            |
+| `localSettings`   | "Saves to .claude/settings.local.json" | Permanent, not committed to git        |
+| `userSettings`    | "Saves to ~/.claude/settings.json"     | Permanent, global                      |
+
+Example rendering:
+
+```
+○ Allow, always allow access to src/ in this project
+  Saves to .claude/settings.json
+```
+
+#### Keyboard Shortcuts
+
+| Key      | Action                                                                         |
+| -------- | ------------------------------------------------------------------------------ |
+| `y`      | Allow immediately (unless feedback input focused)                              |
+| `a`      | Allow + always allow immediately (if available, unless feedback input focused) |
+| `n`      | Deny immediately (unless feedback input focused)                               |
+| `Escape` | Deny and dismiss (always works)                                                |
+
+When feedback input is focused:
+| `Enter` | Submit deny with feedback text |
+| `Escape` | Collapse feedback input, return to option list |
+
+#### Interaction Model
+
+- **Click** on an option = immediate action (allow/deny/always-allow). No confirm button needed.
+- **Click** on "Deny, with feedback..." = expand inline input (no immediate action)
+- **Arrow keys** = navigate between options (visual focus, no action)
+- **y/a/n** = immediate action (single-key shortcuts, disabled when input focused)
+- **Escape** = deny and dismiss (always works)
+
+Captured via `useEffect` keydown listener on `document`.
+
+### Section 3: Decision Reason & Tool Preview
+
+#### Decision Reason
+
+A muted line above the options showing why the user was prompted:
+
+```
+> Default mode
+```
+
+- Infer from the current permission mode (read from config store): "Default mode", "Auto Edit mode", etc.
+- If `options.blockedPath` exists, append it: "Default mode -- blocked access to /etc/passwd"
+
+> **Note:** The SDK's `CanUseTool` options do NOT include a `description` field. That field exists only on the internal CLI type `SDKControlPermissionRequest`. Decision reason is inferred from the config store's permission mode + `blockedPath`.
+
+#### Tool Input Preview
+
+Replace raw JSON with tool-specific formatting:
+
+| Tool                     | Display                                                                  |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `Bash`                   | Command in code block (bash highlight). `input.description` as subtitle. |
+| `Edit` / `Write`         | File path as title, truncated preview                                    |
+| `Read`                   | File path                                                                |
+| `Glob` / `Grep`          | Pattern + path                                                           |
+| `WebFetch` / `WebSearch` | URL or query                                                             |
+| **Fallback**             | Tool name + truncated JSON (capped ~4 lines)                             |
+
+### Section 4: Component Structure & UI Layout
+
+#### Visual Layout
+
+```
++---------------------------------------------------+
+|  Bash                            (1 of 3)          |  <- Tool icon + name + pending count
+|  +-----------------------------------------------+ |
+|  | $ npm run build                                | |  <- Tool-specific preview
+|  +-----------------------------------------------+ |
+|  > Default mode                                    |  <- Decision reason (muted)
+|                                                     |
+|  * Allow once                                 (y)  |  <- Click = immediate action
+|  o Allow, always allow access to src/         (a)  |  <- Click = immediate action
+|  o Deny                                       (n)  |  <- Click = immediate action
+|  o Deny, with feedback...                           |  <- Click = expand input
+|    +-----------------------------------------------+|
+|    | tell Claude what to do differently...          ||  <- Enter submits, Esc cancels
+|    +-----------------------------------------------+|
+|                                                     |
+|                                               Esc  |  <- Dismiss hint
++---------------------------------------------------+
+```
+
+> **Pending count:** Shown as "(1 of N)" next to the tool name when N > 1. Gives the user awareness of how many approvals remain. Uses `pendingRequests.length` which is already available in the store.
+
+#### Component Tree
+
+```
+PermissionDialog (existing dispatcher -- minor: pass pendingCount prop)
+  PermissionRequestDialog (rewritten)
+    ToolPreview (new -- tool-specific input formatting)
+    PendingCount (new -- "(1 of 3)" badge, hidden when count <= 1)
+    DecisionReason (new -- small muted line)
+    PermissionOptionList (new -- click-to-confirm option list)
+      FeedbackInput (inline, shown when "deny with feedback" selected)
+    Esc hint footer
+```
+
+#### Focus Management
+
+- **On dialog appear**: Auto-focus the dialog container via `ref` + `useEffect` so keyboard shortcuts (`y`/`a`/`n`) work immediately without requiring a click first.
+- **On dialog dismiss** (allow/deny resolved): Return focus to the message input editor. Use a callback or ref forwarded from `AgentChatSession`.
+- **On feedback expand** (click "Deny, with feedback..."): Auto-focus the feedback `<input>` element.
+- **On feedback collapse** (Escape in feedback input): Return focus to the dialog container so shortcuts resume working.
+- **Between consecutive requests**: Focus stays on the dialog container. No focus jump.
+
+#### Transition Between Consecutive Requests
+
+When `key={requestId}` causes a remount on the next pending request:
+
+- **Stable dimensions**: Apply `min-h-[<value>]` on the dialog container so the layout doesn't jump between requests with different content heights.
+- **Crossfade**: Wrap the dialog in a CSS transition (`opacity` + `translate-y`) triggered on mount. Use Tailwind's `animate-in fade-in slide-in-from-bottom-2` utilities (already available via the app's animation setup).
+- **No flicker**: The container element stays mounted (it's the parent `PermissionDialog` div). Only the inner content re-renders with the new request, so the yellow border frame remains stable.
+
+### Section 5: Implementation Details
+
+#### Files Changed/Created
+
+| File                            | Action                                                                                              |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `permission-request-dialog.tsx` | **Rewrite** -- new layout with sub-components inline, focus management, entry animation             |
+| `permission-dialog.tsx`         | **Minor** -- pass `pendingCount` prop to `PermissionRequestDialog`                                  |
+| `permission-utils.ts`           | **New** -- `formatSuggestionLabel()`, `formatToolPreview()`, `inferDecisionReason()` pure functions |
+| `chat.ts`                       | **Minor** -- pass `updatedPermissions` in respondToRequest when behavior is "allow-always"          |
+| `en-US.json` / `zh-CN.json`     | **Add** -- permission dialog strings                                                                |
+| `types.ts` (shared)             | **No change**                                                                                       |
+| `session-manager.ts`            | **No change**                                                                                       |
+
+#### I18n Strings
+
+```json
+{
+  "permission.title": "Permission requested",
+  "permission.allow": "Allow",
+  "permission.allowAlways": "Allow, and {{suggestion}}",
+  "permission.deny": "Deny",
+  "permission.denyFeedback": "Deny, with feedback...",
+  "permission.feedbackPlaceholder": "Tell Claude what to do differently...",
+  "permission.decisionReason.default": "Default mode",
+  "permission.decisionReason.acceptEdits": "Auto Edit mode",
+  "permission.decisionReason.plan": "Plan mode",
+  "permission.escHint": "Esc to dismiss",
+  "permission.allowOnce": "Allow once",
+  "permission.decisionReason.blockedPath": "blocked access to {{path}}",
+  "permission.scope.session": "this session",
+  "permission.scope.projectSettings": "in this project",
+  "permission.scope.userSettings": "globally",
+  "permission.scope.localSettings": "locally",
+  "permission.setModeWarning": "This will switch to {{mode}} mode for this session",
+  "permission.pendingCount": "{{current}} of {{total}}",
+  "permission.savesTo": "Saves to {{path}}"
+}
+```
+
+Plus `zh-CN` equivalents.
+
+#### Edge Cases
+
+- **No suggestions**: "Allow + always" option hidden, only 3 options shown. "Allow" label used instead of "Allow once".
+- **AskUserQuestion tool**: Still routed to `AskUserQuestionRequestDialog` (unchanged)
+- **Multiple pending requests**: Queue behavior unchanged (first shown, rest wait). Pending count "(1 of N)" shown when N > 1.
+- **Feedback on deny**: Enter submits deny with `message` set to feedback text
+- **5-minute timeout**: Unchanged, backend auto-denies
+- **Keyboard guard**: `y`/`a`/`n` shortcuts disabled when feedback `<input>` is focused. Escape still works (collapses input first, then dismisses dialog on second press).
+- **blockedPath**: When present, appended to decision reason line for context
+- **setMode suggestions**: Shown with warning text ("This will switch to YOLO mode for this session"). User sees the consequence before clicking.
+
+#### Future Enhancements (v2)
+
+- **Allow with feedback**: "Yes, and tell Claude what to do next" input mode on the allow side (Claude Code supports this but it's rarely used)
+- **Destructive operation warning**: Show warning badge for tools with `destructive` MCP annotation (requires tool metadata lookup not currently in canUseTool options)
+- **Editable command prefix**: For Bash, allow user to edit the command pattern for "don't ask again" rules (Claude Code supports `yes-prefix-edited`)
+
+#### Styling
+
+- Same yellow border treatment as current dialog
+- Radio-style options using existing `RadioGroup` from `@base-ui/react`
+- `Kbd` component for shortcut hints (y/a/n)
+- Muted text (`text-muted-foreground`) for decision reason
+- `CodeBlock` component for Bash command preview
+- Feedback input: plain `<input>`, auto-focused when expanded
+
+#### Accessibility
+
+- RadioGroup provides built-in ARIA roles and arrow-key navigation
+- Keyboard shortcuts have visible `Kbd` hints
+- Focus is auto-managed: dialog receives focus on appear, returns to input on dismiss
+- Focus is trapped within the dialog while visible
+- Screen reader labels on all interactive elements

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
@@ -7,6 +7,7 @@ import type { PlanApprovalChoice } from "./exit-plan-mode-request-dialog";
 import { AskUserQuestionInputSchema } from "../../../../../shared/claude-code/tools/ask-user-question";
 import { ExitPlanModeInputSchema } from "../../../../../shared/claude-code/tools/exit-plan-mode";
 import { client } from "../../../orpc";
+import { useConfigStore } from "../../config/store";
 import { claudeCodeChatManager } from "../chat-manager";
 import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
 import { useAgentStore } from "../store";
@@ -22,6 +23,9 @@ type Props = {
 
 export function PermissionDialog({ sessionId }: Props) {
   const { pendingRequests, respondToRequest } = useClaudeCodeChat(sessionId);
+  const sessionPermissionMode = useAgentStore((s) => s.sessions.get(sessionId)?.permissionMode);
+  const globalPermissionMode = useConfigStore((s) => s.permissionMode);
+
   const activeRequest = pendingRequests[0];
   if (!activeRequest) return null;
 
@@ -55,6 +59,19 @@ export function PermissionDialog({ sessionId }: Props) {
       result.behavior,
     );
     void respondToRequest(requestId, { type: "permission_request", result });
+
+    // Sync setMode permission updates to agent store so the toolbar reflects the change
+    if (result.behavior === "allow" && result.updatedPermissions) {
+      const setModeUpdate = result.updatedPermissions.find((u) => u.type === "setMode");
+      if (setModeUpdate) {
+        chatLog(
+          "handleResolvePermission: syncing setMode=%s sessionId=%s",
+          setModeUpdate.mode,
+          sessionId.slice(0, 8),
+        );
+        useAgentStore.getState().setPermissionMode(sessionId, setModeUpdate.mode);
+      }
+    }
   };
 
   const handleExitPlanModeChoice = async (choice: PlanApprovalChoice) => {
@@ -119,8 +136,19 @@ export function PermissionDialog({ sessionId }: Props) {
   };
 
   // --- Render ---
+  const pendingCount = pendingRequests.length;
+  const pendingIndex = pendingRequests.findIndex((r) => r.requestId === requestId);
+  const permissionMode = sessionPermissionMode ?? globalPermissionMode ?? "default";
+
   let content = (
-    <PermissionRequestDialog key={requestId} request={request} onResolve={handleResolve} />
+    <PermissionRequestDialog
+      key={requestId}
+      request={request}
+      pendingCount={pendingCount}
+      pendingIndex={pendingIndex >= 0 ? pendingIndex : 0}
+      permissionMode={permissionMode}
+      onResolve={handleResolve}
+    />
   );
 
   if (askUserQuestion?.success) {

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-request-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-request-dialog.tsx
@@ -1,34 +1,276 @@
-import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import type { PermissionResult, PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { ClaudeCodeUIEventRequest } from "../../../../../shared/claude-code/types";
+import type { PermissionMode } from "../../../../../shared/features/agent/types";
 
-import { Button } from "../../../components/ui/button";
+import { CodeBlock } from "../../../components/ai-elements/code-block";
+import { Kbd } from "../../../components/ui/kbd";
+import { cn } from "../../../lib/utils";
+import {
+  formatSuggestionLabel,
+  formatToolPreview,
+  getSuggestionPersistencePath,
+  inferDecisionReason,
+} from "./permission-utils";
 
 type Props = {
   request: ClaudeCodeUIEventRequest;
+  pendingCount: number;
+  pendingIndex: number;
+  permissionMode: PermissionMode;
   onResolve: (result: PermissionResult) => void;
 };
 
-export function PermissionRequestDialog({ request, onResolve }: Props) {
+type OptionValue = "yes" | "yes-always" | "no" | "no-feedback";
+
+export function PermissionRequestDialog({
+  request,
+  pendingCount,
+  pendingIndex,
+  permissionMode,
+  onResolve,
+}: Props) {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const feedbackRef = useRef<HTMLInputElement>(null);
+  const [feedbackExpanded, setFeedbackExpanded] = useState(false);
+  const [feedbackText, setFeedbackText] = useState("");
+  const suggestions = request.options.suggestions;
+  const hasSuggestions = suggestions && suggestions.length > 0;
+
+  // ─── Tool preview ──────────────────────────────────────────────────────
+  const preview = formatToolPreview(request.toolName, request.input as Record<string, unknown>);
+
+  // ─── Decision reason ───────────────────────────────────────────────────
+  const reason = inferDecisionReason(permissionMode, request.options);
+
+  // ─── Suggestion label & persistence ────────────────────────────────────
+  const suggestionLabel = hasSuggestions ? formatSuggestionLabel(suggestions) : null;
+  const persistencePath = hasSuggestions ? getSuggestionPersistencePath(suggestions) : null;
+
+  // ─── Actions ───────────────────────────────────────────────────────────
+  const handleAllow = useCallback(() => {
+    onResolve({ behavior: "allow" });
+  }, [onResolve]);
+
+  const handleAlwaysAllow = useCallback(() => {
+    if (!suggestions) return;
+    onResolve({
+      behavior: "allow",
+      updatedPermissions: suggestions as PermissionUpdate[],
+    });
+  }, [onResolve, suggestions]);
+
+  const handleDeny = useCallback(
+    (message?: string) => {
+      onResolve({
+        behavior: "deny",
+        message: message || "User denied",
+      });
+    },
+    [onResolve],
+  );
+
+  const handleOptionClick = useCallback(
+    (value: OptionValue) => {
+      switch (value) {
+        case "yes":
+          handleAllow();
+          break;
+        case "yes-always":
+          handleAlwaysAllow();
+          break;
+        case "no":
+          handleDeny();
+          break;
+        case "no-feedback":
+          setFeedbackExpanded(true);
+          break;
+      }
+    },
+    [handleAllow, handleAlwaysAllow, handleDeny],
+  );
+
+  const handleFeedbackSubmit = useCallback(() => {
+    const text = feedbackText.trim();
+    handleDeny(text || undefined);
+  }, [feedbackText, handleDeny]);
+
+  // ─── Focus management ─────────────────────────────────────────────────
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (feedbackExpanded) {
+      feedbackRef.current?.focus();
+    }
+  }, [feedbackExpanded]);
+
+  // ─── Keyboard shortcuts ────────────────────────────────────────────────
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInputFocused = target.tagName === "INPUT" || target.tagName === "TEXTAREA";
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        if (feedbackExpanded) {
+          setFeedbackExpanded(false);
+          containerRef.current?.focus();
+        } else {
+          handleDeny();
+        }
+        return;
+      }
+
+      if (isInputFocused) {
+        if (e.key === "Enter" && feedbackExpanded) {
+          e.preventDefault();
+          handleFeedbackSubmit();
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case "y":
+          e.preventDefault();
+          handleAllow();
+          break;
+        case "a":
+          if (hasSuggestions) {
+            e.preventDefault();
+            handleAlwaysAllow();
+          }
+          break;
+        case "n":
+          e.preventDefault();
+          handleDeny();
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [
+    feedbackExpanded,
+    hasSuggestions,
+    handleAllow,
+    handleAlwaysAllow,
+    handleDeny,
+    handleFeedbackSubmit,
+  ]);
+
+  // ─── Build options ─────────────────────────────────────────────────────
+  const allowLabel = hasSuggestions ? t("permission.allowOnce") : t("permission.allow");
+
+  const options: {
+    value: OptionValue;
+    label: string;
+    shortcut?: string;
+    subtitle?: string;
+  }[] = [
+    { value: "yes", label: allowLabel, shortcut: "y" },
+    ...(hasSuggestions && suggestionLabel
+      ? [
+          {
+            value: "yes-always" as const,
+            label: `${t("permission.allow")}, ${suggestionLabel}`,
+            shortcut: "a",
+            subtitle: persistencePath
+              ? t("permission.savesTo", { path: persistencePath })
+              : undefined,
+          },
+        ]
+      : []),
+    { value: "no", label: t("permission.deny"), shortcut: "n" },
+    { value: "no-feedback", label: t("permission.denyFeedback") },
+  ];
+
+  // ─── Render ────────────────────────────────────────────────────────────
   return (
-    <div className="relative rounded-2xl border border-yellow-500/30 bg-white p-4 shadow-[0_16px_40px_-20px_rgba(0,0,0,0.3)]">
-      <p className="mb-1 text-sm font-medium">Permission requested: {request.toolName}</p>
-      {request.input != null && (
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      className="relative animate-in fade-in slide-in-from-bottom-2 duration-200 rounded-2xl border border-yellow-500/30 bg-background p-4 shadow-[0_16px_40px_-20px_rgba(0,0,0,0.3)] outline-none min-h-[120px]"
+    >
+      {/* Header: Tool name + pending count */}
+      <div className="mb-2 flex items-center gap-2">
+        <p className="text-sm font-medium">{preview.title}</p>
+        {pendingCount > 1 && (
+          <span className="text-xs text-muted-foreground">
+            ({t("permission.pendingCount", { current: pendingIndex + 1, total: pendingCount })})
+          </span>
+        )}
+      </div>
+
+      {/* Tool preview */}
+      {preview.code && preview.language && (
+        <div className="mb-2 max-h-24 overflow-auto rounded">
+          <CodeBlock code={preview.code} language={preview.language} className="text-sm" />
+        </div>
+      )}
+      {preview.code && !preview.language && (
         <pre className="mb-2 max-h-24 overflow-auto rounded bg-muted/50 p-2 text-xs">
-          {JSON.stringify(request.input, null, 2)}
+          {preview.code}
         </pre>
       )}
-      <div className="flex gap-2">
-        <Button size="sm" variant="default" onClick={() => onResolve({ behavior: "allow" })}>
-          Allow
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => onResolve({ behavior: "deny", message: "User denied" })}
-        >
-          Deny
-        </Button>
+      {preview.subtitle && !preview.code && (
+        <p className="mb-2 truncate text-sm text-muted-foreground">{preview.subtitle}</p>
+      )}
+
+      {/* Decision reason */}
+      <p className="mb-3 text-xs text-muted-foreground">
+        <span className="mr-1">&#x23BF;</span>
+        {reason}
+      </p>
+
+      {/* Options */}
+      <div className="space-y-1">
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className={cn(
+              "flex w-full items-center justify-between rounded-lg px-3 py-1.5 text-left text-sm transition-colors",
+              "hover:bg-muted/80 active:bg-muted",
+              option.value === "no-feedback" && feedbackExpanded && "bg-muted/50",
+            )}
+            onClick={() => handleOptionClick(option.value)}
+          >
+            <div className="min-w-0">
+              <span className="block truncate">{option.label}</span>
+              {option.subtitle && (
+                <span className="block text-xs text-muted-foreground">{option.subtitle}</span>
+              )}
+            </div>
+            {option.shortcut && <Kbd className="ml-2 shrink-0">{option.shortcut}</Kbd>}
+          </button>
+        ))}
+      </div>
+
+      {/* Feedback input */}
+      {feedbackExpanded && (
+        <div className="mt-2 pl-3">
+          <input
+            ref={feedbackRef}
+            type="text"
+            className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm outline-none ring-ring focus:ring-1"
+            placeholder={t("permission.feedbackPlaceholder")}
+            value={feedbackText}
+            onChange={(e) => setFeedbackText(e.target.value)}
+          />
+        </div>
+      )}
+
+      {/* Footer hint */}
+      <div className="mt-3 flex justify-end">
+        <span className="text-xs text-muted-foreground">
+          <Kbd>Esc</Kbd>
+        </span>
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-utils.ts
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-utils.ts
@@ -1,0 +1,208 @@
+import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
+import type { BundledLanguage } from "shiki";
+
+import type { ClaudeCodeUIEventRequest } from "../../../../../shared/claude-code/types";
+import type { PermissionMode } from "../../../../../shared/features/agent/types";
+
+// ─── Suggestion Label ───────────────────────────────────────────────────────
+
+const DESTINATION_SCOPE: Record<string, string> = {
+  session: "this session",
+  projectSettings: "in this project",
+  userSettings: "globally",
+  localSettings: "locally",
+};
+
+const DESTINATION_FILE: Record<string, string> = {
+  projectSettings: ".claude/settings.json",
+  localSettings: ".claude/settings.local.json",
+  userSettings: "~/.claude/settings.json",
+};
+
+function scopeLabel(destination: string): string {
+  return DESTINATION_SCOPE[destination] ?? "this session";
+}
+
+/**
+ * Build a human-readable label from SDK permission suggestions.
+ * Mirrors Claude Code CLI's contextual "always allow" labels.
+ */
+export function formatSuggestionLabel(suggestions: PermissionUpdate[]): string {
+  const directories: string[] = [];
+  const readPaths: string[] = [];
+  const bashCommands: string[] = [];
+  let modeChange: { mode: string; destination: string } | null = null;
+  let primaryDestination = "session";
+
+  for (const s of suggestions) {
+    if (s.type === "addDirectories") {
+      directories.push(...s.directories.map((d) => d.split("/").pop() || d));
+      primaryDestination = s.destination;
+    } else if (s.type === "addRules" || s.type === "replaceRules") {
+      for (const rule of s.rules) {
+        if (rule.toolName === "Read") {
+          const name = rule.ruleContent?.replace("/**", "").split("/").pop() || rule.ruleContent;
+          if (name) readPaths.push(name);
+        } else if (rule.toolName === "Bash") {
+          if (rule.ruleContent) bashCommands.push(rule.ruleContent);
+        }
+      }
+      primaryDestination = s.destination;
+    } else if (s.type === "setMode") {
+      modeChange = { mode: s.mode, destination: s.destination };
+    }
+  }
+
+  if (modeChange) {
+    const modeLabel =
+      modeChange.mode === "bypassPermissions"
+        ? "YOLO"
+        : modeChange.mode === "acceptEdits"
+          ? "Auto Edit"
+          : modeChange.mode;
+    return `switch to ${modeLabel} mode for ${scopeLabel(modeChange.destination)}`;
+  }
+
+  const scope = scopeLabel(primaryDestination);
+  const hasDirs = directories.length > 0;
+  const hasRead = readPaths.length > 0;
+  const hasBash = bashCommands.length > 0;
+
+  if (hasRead && !hasDirs && !hasBash) {
+    return `allow reading from ${formatNames(readPaths)} ${scope}`;
+  }
+  if (hasDirs && !hasRead && !hasBash) {
+    return `always allow access to ${formatNames(directories)} ${scope}`;
+  }
+  if (hasBash && !hasDirs && !hasRead) {
+    const cmds = bashCommands.length > 2 ? "similar" : formatNames(bashCommands);
+    return `don't ask again for ${cmds} commands ${scope}`;
+  }
+  if ((hasDirs || hasRead) && hasBash) {
+    const paths = [...directories, ...readPaths];
+    return `allow ${formatNames(paths)} access and ${formatNames(bashCommands)} commands`;
+  }
+  if (hasDirs || hasRead) {
+    return `always allow access to ${formatNames([...directories, ...readPaths])} ${scope}`;
+  }
+
+  return `always allow for ${scope}`;
+}
+
+function formatNames(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names.at(-1)}`;
+}
+
+/**
+ * Get the settings file path that a suggestion set will write to.
+ * Returns null for session-only (in-memory) suggestions.
+ */
+export function getSuggestionPersistencePath(suggestions: PermissionUpdate[]): string | null {
+  for (const s of suggestions) {
+    const dest = "destination" in s ? s.destination : undefined;
+    if (dest && dest in DESTINATION_FILE) {
+      return DESTINATION_FILE[dest];
+    }
+  }
+  return null;
+}
+
+// ─── Tool Preview ───────────────────────────────────────────────────────────
+
+export type ToolPreviewInfo = {
+  title: string;
+  subtitle?: string;
+  code?: string;
+  language?: BundledLanguage;
+};
+
+/**
+ * Extract a human-friendly preview from tool input.
+ */
+export function formatToolPreview(
+  toolName: string,
+  input: Record<string, unknown>,
+): ToolPreviewInfo {
+  switch (toolName) {
+    case "Bash": {
+      const command = (input.command as string) ?? "";
+      const description = input.description as string | undefined;
+      return {
+        title: "Bash",
+        subtitle: description,
+        code: `$ ${command}`,
+        language: "bash",
+      };
+    }
+    case "Edit":
+    case "MultiEdit":
+      return {
+        title: toolName,
+        subtitle: (input.file_path as string) ?? (input.filePath as string),
+      };
+    case "Write":
+      return {
+        title: "Write",
+        subtitle: (input.file_path as string) ?? (input.filePath as string),
+      };
+    case "Read":
+      return {
+        title: "Read",
+        subtitle: (input.file_path as string) ?? (input.filePath as string),
+      };
+    case "Glob":
+      return {
+        title: "Glob",
+        subtitle: [input.pattern, input.path].filter(Boolean).join(" in "),
+      };
+    case "Grep":
+      return {
+        title: "Grep",
+        subtitle: [input.pattern, input.path].filter(Boolean).join(" in "),
+      };
+    case "WebFetch":
+      return { title: "WebFetch", subtitle: input.url as string };
+    case "WebSearch":
+      return { title: "WebSearch", subtitle: input.query as string };
+    default:
+      return {
+        title: toolName,
+        subtitle: truncateJSON(input),
+      };
+  }
+}
+
+function truncateJSON(obj: Record<string, unknown>): string {
+  const text = JSON.stringify(obj, null, 2);
+  const lines = text.split("\n");
+  if (lines.length <= 4) return text;
+  return lines.slice(0, 4).join("\n") + "\n...";
+}
+
+// ─── Decision Reason ────────────────────────────────────────────────────────
+
+const MODE_LABELS: Record<PermissionMode, string> = {
+  default: "Default mode",
+  acceptEdits: "Auto Edit mode",
+  plan: "Plan mode",
+  bypassPermissions: "YOLO mode",
+  dontAsk: "Don't Ask mode",
+};
+
+/**
+ * Infer a human-readable decision reason from permission mode and options.
+ */
+export function inferDecisionReason(
+  permissionMode: PermissionMode,
+  options: ClaudeCodeUIEventRequest["options"],
+): string {
+  const mode = MODE_LABELS[permissionMode] ?? "Default mode";
+  const blockedPath = options.blockedPath;
+  if (blockedPath) {
+    return `${mode} — blocked access to ${blockedPath}`;
+  }
+  return mode;
+}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -125,6 +125,14 @@
   "settings.skills.retry": "Retry",
   "settings.skills.removeSkill": "Remove skill",
 
+  "permission.allow": "Allow",
+  "permission.allowOnce": "Allow once",
+  "permission.deny": "Deny",
+  "permission.denyFeedback": "Deny, with feedback...",
+  "permission.feedbackPlaceholder": "Tell Claude what to do differently...",
+  "permission.pendingCount": "{{current}} of {{total}}",
+  "permission.savesTo": "Saves to {{path}}",
+
   "common.cancel": "Cancel",
   "common.delete": "Delete"
 }

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -123,6 +123,14 @@
   "settings.skills.retry": "重试",
   "settings.skills.removeSkill": "移除技能",
 
+  "permission.allow": "允许",
+  "permission.allowOnce": "允许一次",
+  "permission.deny": "拒绝",
+  "permission.denyFeedback": "拒绝并反馈...",
+  "permission.feedbackPlaceholder": "告诉 Claude 应该怎么做...",
+  "permission.pendingCount": "第 {{current}} 个，共 {{total}} 个",
+  "permission.savesTo": "保存到 {{path}}",
+
   "common.cancel": "取消",
   "common.delete": "删除",
   "common.loading": "加载中..."


### PR DESCRIPTION
Redesigned the permission request dialog to align with Claude Code CLI UX, adding smart suggestion-aware labels, keyboard shortcuts (y/a/n), decision reason display, tool-specific input formatting, deny with feedback, and pending request count indicators. Added new permission-utils.ts with pure formatting functions and updated i18n strings for both en-US and zh-CN locales.