### PR TITLE
feat: add built-in provider templates with OpenRouter support

### DIFF
--- a/docs/designs/2026-03-12-built-in-providers.md
+++ b/docs/designs/2026-03-12-built-in-providers.md
@@ -1,0 +1,130 @@
+# Built-in Provider Templates
+
+## Overview
+
+Add built-in provider templates so users can quickly configure known providers (starting with OpenRouter) without manually entering baseURL, models, and modelMap. Users just need to provide their API key.
+
+## UX Flow
+
+1. User clicks "Add Provider"
+2. **Template picker step** appears showing available templates + "Custom" option
+3. Selecting a template pre-fills the form (name, baseURL, models, modelMap)
+4. Selecting "Custom" opens the current blank form
+5. User enters API key, optionally tweaks pre-filled values, clicks Create
+6. Normal `addProvider()` flow — no backend changes
+
+### Duplicate Prevention
+
+Each built-in provider can only be added once. Detection uses a `builtInId` field stored on the `Provider` type (see Architecture). Templates whose `builtInId` already exists in the current `providers` array are filtered out of the picker. This is robust against user renames — even if the user changes the provider name from "OpenRouter" to "My Router", the `builtInId` still tracks the origin.
+
+If all built-in templates are already added, skip the picker entirely and go straight to the blank form (no point showing a picker with only "Custom").
+
+## Built-in Templates
+
+### OpenRouter
+
+| Field     | Value                                                                                                 |
+| --------- | ----------------------------------------------------------------------------------------------------- |
+| id        | `openrouter`                                                                                          |
+| name      | `providers.openrouter.name` (i18n key, default: `OpenRouter`)                                         |
+| baseURL   | `https://openrouter.ai/api`                                                                           |
+| apiKey    | _(empty — user must provide)_                                                                         |
+| apiKeyURL | `https://openrouter.ai/keys`                                                                          |
+| models    | `claude-sonnet-4` (Claude Sonnet 4), `claude-haiku-4` (Claude Haiku 4)                                |
+| modelMap  | model: `claude-sonnet-4`, sonnet: `claude-sonnet-4`, haiku: `claude-haiku-4`, opus: `claude-sonnet-4` |
+
+## Reset to Template Defaults
+
+When editing a provider that has a `builtInId`, the form shows a **"Reset to defaults"** button. Clicking it re-applies the template's `baseURL`, `models`, `modelMap`, and `envOverrides` — but preserves the user's `apiKey`, `name`, and `enabled` state. This handles model list staleness when we ship updated templates in new app versions (e.g., new Claude model added to OpenRouter).
+
+The button is only shown when the provider's current config differs from the template. Uses `getBuiltInProvider(builtInId)` to look up the original template.
+
+**Confirmation:** Clicking "Reset to defaults" shows a confirmation dialog before applying, since it's destructive — any user-added models or customizations to baseURL/modelMap/envOverrides will be lost.
+
+### Name Collision Handling
+
+When creating from a built-in template, the pre-filled name (e.g., "OpenRouter") may collide with an existing custom provider's name. Since the backend enforces unique names, the form validation will catch this. The user can simply rename in the form before saving. No special auto-suffixing logic needed — keep it simple.
+
+## Architecture
+
+### New Files
+
+```
+shared/features/provider/built-in.ts
+```
+
+Exports a `BUILT_IN_PROVIDERS` array. Each entry contains all provider fields except `apiKey` and `enabled` (those are set during creation):
+
+```ts
+export type BuiltInProvider = {
+  id: string; // Stable identifier, stored as `builtInId` on Provider
+  nameKey: string; // i18n key for display name (e.g., "providers.openrouter.name")
+  name: string; // Fallback display name when i18n key is missing
+  baseURL: string;
+  apiKeyURL?: string; // Clickable URL that opens browser to the API key page
+  models: Record<string, { displayName?: string }>;
+  modelMap: ProviderModelMap;
+  envOverrides: Record<string, string>;
+};
+
+export const BUILT_IN_PROVIDERS: BuiltInProvider[] = [
+  {
+    id: "openrouter",
+    nameKey: "providers.openrouter.name",
+    name: "OpenRouter",
+    baseURL: "https://openrouter.ai/api",
+    apiKeyURL: "https://openrouter.ai/keys",
+    models: {
+      "claude-sonnet-4": { displayName: "Claude Sonnet 4" },
+      "claude-haiku-4": { displayName: "Claude Haiku 4" },
+    },
+    modelMap: {
+      model: "claude-sonnet-4",
+      sonnet: "claude-sonnet-4",
+      haiku: "claude-haiku-4",
+      opus: "claude-sonnet-4",
+    },
+    envOverrides: {},
+  },
+];
+
+/** Look up a built-in template by its id */
+export function getBuiltInProvider(builtInId: string): BuiltInProvider | undefined {
+  return BUILT_IN_PROVIDERS.find((t) => t.id === builtInId);
+}
+```
+
+### Modified Files
+
+```
+shared/features/provider/types.ts
+```
+
+- Add optional `builtInId?: string` to the `Provider` type. Set when a provider is created from a built-in template, left `undefined` for custom providers.
+
+```
+renderer/features/settings/components/panels/providers-panel.tsx
+```
+
+- Add `selectedTemplate` state (`BuiltInProvider | "custom" | null`)
+- When `isCreating && selectedTemplate === null` → show template picker
+- When template selected → pre-fill form via `setForm()`, set `selectedTemplate`
+- Filter out already-added templates by matching `builtInId` against existing `providers`
+- If no available templates remain, skip picker and go straight to blank form
+- When a template with `apiKeyURL` is active (creating or editing a built-in provider), show a clickable link below the API key input that opens the URL in the browser via `shell.openExternal()`
+- When editing a provider with `builtInId`, show a "Reset to defaults" button that re-applies template values (baseURL, models, modelMap, envOverrides) while keeping apiKey, name, and enabled
+- Use i18n keys (`nameKey`) for template display names in the picker, with `name` as fallback
+
+### Backend Changes
+
+```
+shared/features/provider/contract.ts
+```
+
+- Accept optional `builtInId` in the `create` input schema, pass through to stored provider.
+
+```
+main/features/config/config-store.ts
+```
+
+- `builtInId` is persisted as part of the `Provider` object (no special handling needed — it's just a new optional field on the type).

--- a/packages/desktop/src/main/features/provider/router.ts
+++ b/packages/desktop/src/main/features/provider/router.ts
@@ -65,6 +65,7 @@ export const providerRouter = os.provider.router({
       models: input.models,
       modelMap: input.modelMap,
       envOverrides: input.envOverrides ?? {},
+      ...(input.builtInId ? { builtInId: input.builtInId } : {}),
     };
 
     context.configStore.addProvider(provider);

--- a/packages/desktop/src/renderer/src/features/provider/store.ts
+++ b/packages/desktop/src/renderer/src/features/provider/store.ts
@@ -17,6 +17,7 @@ type ProviderState = {
     models: Record<string, { displayName?: string }>;
     modelMap: { model?: string; haiku?: string; opus?: string; sonnet?: string };
     envOverrides?: Record<string, string>;
+    builtInId?: string;
   }) => Promise<Provider>;
   updateProvider: (id: string, updates: Partial<Omit<Provider, "id">>) => Promise<Provider>;
   removeProvider: (id: string) => Promise<void>;

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -1,9 +1,14 @@
-import { Edit2, Plus, Server, Trash2, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Edit2, ExternalLink, Plus, RotateCcw, Server, Trash2, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { Provider, ProviderModelMap } from "../../../../../../shared/features/provider/types";
 
+import {
+  BUILT_IN_PROVIDERS,
+  getBuiltInProvider,
+  type BuiltInProvider,
+} from "../../../../../../shared/features/provider/built-in";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
 import { Switch } from "../../../../components/ui/switch";
@@ -18,6 +23,7 @@ type ProviderFormData = {
   modelMap: ProviderModelMap;
   envOverrides: Record<string, string>;
   enabled: boolean;
+  builtInId?: string;
 };
 
 const emptyForm: ProviderFormData = {
@@ -39,6 +45,20 @@ function providerToForm(p: Provider): ProviderFormData {
     modelMap: { ...p.modelMap },
     envOverrides: { ...p.envOverrides },
     enabled: p.enabled,
+    builtInId: p.builtInId,
+  };
+}
+
+function builtInToForm(t: BuiltInProvider): ProviderFormData {
+  return {
+    name: t.name,
+    baseURL: t.baseURL,
+    apiKey: "",
+    models: { ...t.models },
+    modelMap: { ...t.modelMap },
+    envOverrides: { ...t.envOverrides },
+    enabled: true,
+    builtInId: t.id,
   };
 }
 
@@ -53,6 +73,7 @@ export const ProvidersPanel = () => {
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const [form, setForm] = useState<ProviderFormData>(emptyForm);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,11 +89,39 @@ export const ProvidersPanel = () => {
     if (!loaded) load();
   }, [loaded, load]);
 
+  const usedBuiltInIds = useMemo(
+    () => new Set(providers.map((p) => p.builtInId).filter(Boolean)),
+    [providers],
+  );
+
+  const availableTemplates = useMemo(
+    () => BUILT_IN_PROVIDERS.filter((t) => !usedBuiltInIds.has(t.id)),
+    [usedBuiltInIds],
+  );
+
   const startCreate = useCallback(() => {
     setEditingId(null);
+    setError(null);
+    if (availableTemplates.length > 0) {
+      setShowTemplatePicker(true);
+      setIsCreating(false);
+    } else {
+      setShowTemplatePicker(false);
+      setIsCreating(true);
+      setForm(emptyForm);
+    }
+  }, [availableTemplates.length]);
+
+  const selectTemplate = useCallback((template: BuiltInProvider) => {
+    setShowTemplatePicker(false);
+    setIsCreating(true);
+    setForm(builtInToForm(template));
+  }, []);
+
+  const selectCustom = useCallback(() => {
+    setShowTemplatePicker(false);
     setIsCreating(true);
     setForm(emptyForm);
-    setError(null);
   }, []);
 
   const startEdit = useCallback((p: Provider) => {
@@ -85,6 +134,7 @@ export const ProvidersPanel = () => {
   const cancel = useCallback(() => {
     setEditingId(null);
     setIsCreating(false);
+    setShowTemplatePicker(false);
     setError(null);
   }, []);
 
@@ -121,6 +171,7 @@ export const ProvidersPanel = () => {
           models: form.models,
           modelMap: form.modelMap,
           envOverrides: Object.keys(form.envOverrides).length > 0 ? form.envOverrides : undefined,
+          builtInId: form.builtInId,
         });
       } else if (editingId) {
         await updateProvider(editingId, {
@@ -206,6 +257,27 @@ export const ProvidersPanel = () => {
     });
   }, []);
 
+  const handleResetDefaults = useCallback(() => {
+    if (!form.builtInId) return;
+    const template = getBuiltInProvider(form.builtInId);
+    if (!template) return;
+    if (!window.confirm(t("settings.providers.resetConfirm"))) return;
+    setForm((f) => ({
+      ...f,
+      baseURL: template.baseURL,
+      models: { ...template.models },
+      modelMap: { ...template.modelMap },
+      envOverrides: { ...template.envOverrides },
+    }));
+  }, [form.builtInId, t]);
+
+  const activeApiKeyURL = useMemo(() => {
+    if (form.builtInId) {
+      return getBuiltInProvider(form.builtInId)?.apiKeyURL;
+    }
+    return undefined;
+  }, [form.builtInId]);
+
   const isEditing = isCreating || editingId !== null;
   const modelKeys = Object.keys(form.models);
 
@@ -216,7 +288,39 @@ export const ProvidersPanel = () => {
         {t("settings.providers")}
       </h1>
 
-      {!isEditing && (
+      {showTemplatePicker && (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">{t("settings.providers.chooseTemplate")}</p>
+          <div className="grid grid-cols-2 gap-3">
+            {availableTemplates.map((template) => (
+              <button
+                key={template.id}
+                className="flex flex-col items-start gap-1 rounded-lg border border-input p-4 text-left hover:border-primary hover:bg-accent transition-colors"
+                onClick={() => selectTemplate(template)}
+              >
+                <span className="text-sm font-medium">
+                  {t(template.nameKey, { defaultValue: template.name })}
+                </span>
+                <span className="text-xs text-muted-foreground">{template.baseURL}</span>
+              </button>
+            ))}
+            <button
+              className="flex flex-col items-start gap-1 rounded-lg border border-dashed border-input p-4 text-left hover:border-primary hover:bg-accent transition-colors"
+              onClick={selectCustom}
+            >
+              <span className="text-sm font-medium">{t("settings.providers.custom")}</span>
+              <span className="text-xs text-muted-foreground">
+                {t("settings.providers.customDescription")}
+              </span>
+            </button>
+          </div>
+          <Button variant="outline" size="sm" onClick={cancel}>
+            {t("settings.providers.cancel")}
+          </Button>
+        </div>
+      )}
+
+      {!isEditing && !showTemplatePicker && (
         <div className="space-y-0">
           {providers.map((p) => (
             <SettingsRow key={p.id} title={p.name} description={p.baseURL}>
@@ -301,6 +405,17 @@ export const ProvidersPanel = () => {
               placeholder="sk-..."
               className="mt-1"
             />
+            {activeApiKeyURL && (
+              <a
+                href={activeApiKeyURL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 mt-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t("settings.providers.getApiKey")}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
           </div>
 
           {/* Enabled */}
@@ -434,6 +549,12 @@ export const ProvidersPanel = () => {
             <Button variant="outline" size="sm" onClick={cancel}>
               {t("settings.providers.cancel")}
             </Button>
+            {editingId && form.builtInId && (
+              <Button variant="ghost" size="sm" onClick={handleResetDefaults} className="ml-auto">
+                <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                {t("settings.providers.resetDefaults")}
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -95,6 +95,13 @@
   "settings.providers.create": "Create",
   "settings.providers.save": "Save",
   "settings.providers.cancel": "Cancel",
+  "settings.providers.chooseTemplate": "Choose a provider template or configure a custom one.",
+  "settings.providers.custom": "Custom",
+  "settings.providers.customDescription": "Configure a custom API endpoint",
+  "settings.providers.getApiKey": "Get your API key",
+  "settings.providers.resetDefaults": "Reset to defaults",
+  "settings.providers.resetConfirm": "Reset baseURL, models, model map, and environment overrides to template defaults? Your API key and name will be kept.",
+  "providers.openrouter.name": "OpenRouter",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP configuration coming soon...",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -95,6 +95,13 @@
   "settings.providers.create": "创建",
   "settings.providers.save": "保存",
   "settings.providers.cancel": "取消",
+  "settings.providers.chooseTemplate": "选择服务商模板或配置自定义端点。",
+  "settings.providers.custom": "自定义",
+  "settings.providers.customDescription": "配置自定义 API 端点",
+  "settings.providers.getApiKey": "获取 API 密钥",
+  "settings.providers.resetDefaults": "重置为默认",
+  "settings.providers.resetConfirm": "将 API 地址、模型、模型映射和环境变量覆盖重置为模板默认值？您的 API 密钥和名称将保留。",
+  "providers.openrouter.name": "OpenRouter",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP 配置即将推出...",

--- a/packages/desktop/src/shared/features/provider/built-in.ts
+++ b/packages/desktop/src/shared/features/provider/built-in.ts
@@ -1,0 +1,38 @@
+import type { ProviderModelMap } from "./types";
+
+export type BuiltInProvider = {
+  id: string;
+  nameKey: string;
+  name: string;
+  baseURL: string;
+  apiKeyURL?: string;
+  models: Record<string, { displayName?: string }>;
+  modelMap: ProviderModelMap;
+  envOverrides: Record<string, string>;
+};
+
+export const BUILT_IN_PROVIDERS: BuiltInProvider[] = [
+  {
+    id: "openrouter",
+    nameKey: "providers.openrouter.name",
+    name: "OpenRouter",
+    baseURL: "https://openrouter.ai/api",
+    apiKeyURL: "https://openrouter.ai/settings/keys",
+    models: {
+      "anthropic/claude-opus-4.6": { displayName: "Claude Opus 4.6" },
+      "anthropic/claude-sonnet-4.6": { displayName: "Claude Sonnet 4.6" },
+      "anthropic/claude-haiku-4.5": { displayName: "Claude Haiku 4.5" },
+    },
+    modelMap: {
+      model: "anthropic/claude-opus-4.6",
+      sonnet: "anthropic/claude-sonnet-4.6",
+      haiku: "anthropic/claude-haiku-4.5",
+      opus: "anthropic/claude-opus-4.6",
+    },
+    envOverrides: {},
+  },
+];
+
+export function getBuiltInProvider(builtInId: string): BuiltInProvider | undefined {
+  return BUILT_IN_PROVIDERS.find((t) => t.id === builtInId);
+}

--- a/packages/desktop/src/shared/features/provider/contract.ts
+++ b/packages/desktop/src/shared/features/provider/contract.ts
@@ -29,6 +29,7 @@ export const providerContract = {
           .refine((m) => Object.keys(m).length > 0, "At least one model required"),
         modelMap: providerModelMapSchema,
         envOverrides: z.record(z.string(), z.string()).optional(),
+        builtInId: z.string().optional(),
       }),
     )
     .output(type<Provider>()),

--- a/packages/desktop/src/shared/features/provider/types.ts
+++ b/packages/desktop/src/shared/features/provider/types.ts
@@ -16,6 +16,7 @@ export type Provider = {
   models: Record<string, ProviderModelEntry>;
   modelMap: ProviderModelMap;
   envOverrides: Record<string, string>;
+  builtInId?: string;
 };
 
 export type ProjectProviderConfig = {


### PR DESCRIPTION
Added built-in provider templates to simplify provider configuration. Users can now select from pre-configured templates like OpenRouter instead of manually entering all settings. Includes template picker UI, API key URL links, and reset-to-defaults functionality for built-in providers.