### PR TITLE
feat: add 9 new built-in AI providers with inline i18n support

### DIFF
--- a/docs/designs/2026-03-12-built-in-providers.md
+++ b/docs/designs/2026-03-12-built-in-providers.md
@@ -21,17 +21,169 @@ If all built-in templates are already added, skip the picker entirely and go str
 
 ## Built-in Templates
 
-### OpenRouter
+### 1. Anthropic
 
-| Field     | Value                                                                                                 |
-| --------- | ----------------------------------------------------------------------------------------------------- |
-| id        | `openrouter`                                                                                          |
-| name      | `providers.openrouter.name` (i18n key, default: `OpenRouter`)                                         |
-| baseURL   | `https://openrouter.ai/api`                                                                           |
-| apiKey    | _(empty — user must provide)_                                                                         |
-| apiKeyURL | `https://openrouter.ai/keys`                                                                          |
-| models    | `claude-sonnet-4` (Claude Sonnet 4), `claude-haiku-4` (Claude Haiku 4)                                |
-| modelMap  | model: `claude-sonnet-4`, sonnet: `claude-sonnet-4`, haiku: `claude-haiku-4`, opus: `claude-sonnet-4` |
+> Official Anthropic API — direct access to Claude models
+
+| Field        | Value                                                                                                               |
+| ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| id           | `anthropic`                                                                                                         |
+| name         | `Anthropic`                                                                                                         |
+| description  | en-US: `Official Anthropic API`, zh-CN: `Anthropic 官方 API`                                                        |
+| baseURL      | `https://api.anthropic.com`                                                                                         |
+| apiKeyURL    | `https://console.anthropic.com/settings/keys`                                                                       |
+| docURL       | `https://docs.anthropic.com/en/docs/about-claude/models`                                                            |
+| models       | `claude-opus-4-6` (Claude Opus 4.6), `claude-sonnet-4-6` (Claude Sonnet 4.6), `claude-haiku-4-5` (Claude Haiku 4.5) |
+| modelMap     | model: `claude-opus-4-6`, sonnet: `claude-sonnet-4-6`, haiku: `claude-haiku-4-5`, opus: `claude-opus-4-6`           |
+| envOverrides | _(none)_                                                                                                            |
+
+### 2. OpenRouter
+
+> Multi-model API aggregator with unified billing
+
+| Field        | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id           | `openrouter`                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| name         | `OpenRouter`                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| description  | en-US: `Multi-model API aggregator`, zh-CN: `多模型 API 聚合平台`                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| baseURL      | `https://openrouter.ai/api`                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| apiKeyURL    | `https://openrouter.ai/settings/keys`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| docURL       | `https://openrouter.ai/models`                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| models       | `anthropic/claude-opus-4.6` (Claude Opus 4.6), `anthropic/claude-sonnet-4.6` (Claude Sonnet 4.6), `anthropic/claude-haiku-4.5` (Claude Haiku 4.5), `openai/gpt-5.2-pro` (GPT-5.2 Pro), `google/gemini-3-pro-preview` (Gemini 3 Pro), `google/gemini-3-flash-preview` (Gemini 3 Flash), `z-ai/glm-5` (GLM-5), `deepseek/deepseek-reasoner` (DeepSeek Reasoner), `deepseek/deepseek-chat` (DeepSeek Chat), `moonshotai/kimi-k2.5` (Kimi K2.5), `minimax/minimax-m2.5` (MiniMax-M2.5) |
+| modelMap     | _(empty — default is first model in list)_                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| envOverrides | _(none)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### 3. GLM (CN)
+
+> Zhipu AI models, China endpoint
+
+| Field        | Value                                                                     |
+| ------------ | ------------------------------------------------------------------------- |
+| id           | `glm-cn`                                                                  |
+| name         | `GLM (CN)` · nameLocalized: zh-CN: `智谱 GLM（国内）`                     |
+| description  | en-US: `Zhipu AI models, China endpoint`, zh-CN: `智谱 AI 模型，国内端点` |
+| baseURL      | `https://open.bigmodel.cn/api/anthropic`                                  |
+| apiKeyURL    | `https://open.bigmodel.cn/usercenter/apikeys`                             |
+| docURL       | `https://docs.bigmodel.cn/cn/coding-plan/overview`                        |
+| models       | `glm-5` (GLM-5)                                                           |
+| modelMap     | model: `glm-5`                                                            |
+| envOverrides | _(none)_                                                                  |
+
+### 4. GLM (Global)
+
+> Zhipu AI models, global endpoint
+
+| Field        | Value                                                                      |
+| ------------ | -------------------------------------------------------------------------- |
+| id           | `glm-global`                                                               |
+| name         | `GLM (Global)` · nameLocalized: zh-CN: `智谱 GLM（国际）`                  |
+| description  | en-US: `Zhipu AI models, global endpoint`, zh-CN: `智谱 AI 模型，国际端点` |
+| baseURL      | `https://api.z.ai/api/anthropic`                                           |
+| docURL       | `https://docs.z.ai/devpack/overview`                                       |
+| models       | `glm-5` (GLM-5)                                                            |
+| modelMap     | model: `glm-5`                                                             |
+| envOverrides | _(none)_                                                                   |
+
+### 5. Kimi
+
+> Moonshot's Kimi coding model
+
+| Field        | Value                                                                  |
+| ------------ | ---------------------------------------------------------------------- |
+| id           | `kimi`                                                                 |
+| name         | `Kimi`                                                                 |
+| description  | en-US: `Moonshot's Kimi coding model`, zh-CN: `月之暗面 Kimi 编程模型` |
+| baseURL      | `https://api.kimi.com/coding/`                                         |
+| docURL       | `https://www.kimi.com/coding/docs/en/third-party-agents.html`          |
+| models       | `kimi-for-coding` (Kimi K2.5)                                          |
+| modelMap     | model: `kimi-for-coding`                                               |
+| envOverrides | _(none)_                                                               |
+
+### 6. Moonshot
+
+> Kimi K2.5 via Moonshot API (China)
+
+| Field        | Value                                                                          |
+| ------------ | ------------------------------------------------------------------------------ |
+| id           | `moonshot`                                                                     |
+| name         | `Moonshot`                                                                     |
+| description  | en-US: `Kimi K2.5 via Moonshot API`, zh-CN: `通过 Moonshot API 使用 Kimi K2.5` |
+| baseURL      | `https://api.moonshot.cn/anthropic`                                            |
+| docURL       | `https://platform.moonshot.cn/docs/api/chat`                                   |
+| models       | `sonnet` (Kimi K2.5)                                                           |
+| modelMap     | model: `sonnet`                                                                |
+| envOverrides | _(none)_                                                                       |
+
+### 7. MiniMax (CN)
+
+> MiniMax M2.5 model, China endpoint
+
+| Field        | Value                                                                             |
+| ------------ | --------------------------------------------------------------------------------- |
+| id           | `minimax-cn`                                                                      |
+| name         | `MiniMax (CN)` · nameLocalized: zh-CN: `MiniMax（国内）`                          |
+| description  | en-US: `MiniMax M2.5 model, China endpoint`, zh-CN: `MiniMax M2.5 模型，国内端点` |
+| baseURL      | `https://api.minimaxi.com/anthropic`                                              |
+| docURL       | `https://platform.minimaxi.com/docs/coding-plan/intro`                            |
+| models       | `minimax-m2.5` (MiniMax-M2.5)                                                     |
+| modelMap     | model: `minimax-m2.5`                                                             |
+| envOverrides | _(none)_                                                                          |
+
+### 8. MiniMax (Global)
+
+> MiniMax M2.5 model, global endpoint
+
+| Field        | Value                                                                              |
+| ------------ | ---------------------------------------------------------------------------------- |
+| id           | `minimax-global`                                                                   |
+| name         | `MiniMax (Global)` · nameLocalized: zh-CN: `MiniMax（国际）`                       |
+| description  | en-US: `MiniMax M2.5 model, global endpoint`, zh-CN: `MiniMax M2.5 模型，国际端点` |
+| baseURL      | `https://api.minimax.io/anthropic`                                                 |
+| docURL       | `https://platform.minimax.io/docs/coding-plan/intro`                               |
+| models       | `minimax-m2.5` (MiniMax-M2.5)                                                      |
+| modelMap     | model: `minimax-m2.5`                                                              |
+| envOverrides | _(none)_                                                                           |
+
+### 9. Aliyun Bailian
+
+> Alibaba Cloud multi-model aggregator (Qwen, Kimi, GLM, MiniMax)
+
+| Field        | Value                                                                                                                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| id           | `bailian`                                                                                                                                                                                                    |
+| name         | `Aliyun Bailian` · nameLocalized: zh-CN: `阿里云百炼`                                                                                                                                                        |
+| description  | en-US: `Alibaba Cloud multi-model aggregator`, zh-CN: `阿里云多模型聚合平台`                                                                                                                                 |
+| baseURL      | `https://coding.dashscope.aliyuncs.com/apps/anthropic`                                                                                                                                                       |
+| docURL       | `https://help.aliyun.com/zh/model-studio/coding-plan`                                                                                                                                                        |
+| models       | `qwen3.5-plus` (Qwen 3.5 Plus), `qwen3-coder-next` (Qwen 3 Coder Next), `qwen3-coder-plus` (Qwen 3 Coder Plus), `kimi-k2.5` (Kimi K2.5), `glm-5` (GLM-5), `glm-4.7` (GLM-4.7), `MiniMax-M2.5` (MiniMax-M2.5) |
+| modelMap     | model: `kimi-k2.5`                                                                                                                                                                                           |
+| envOverrides | _(none)_                                                                                                                                                                                                     |
+
+### 10. ZenMux
+
+> Multi-model API aggregator
+
+| Field        | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id           | `zenmux`                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| name         | `ZenMux`                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| description  | en-US: `Multi-model API aggregator`, zh-CN: `多模型 API 聚合平台`                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| baseURL      | `https://zenmux.ai/api/anthropic/v1`                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| docURL       | `https://docs.zenmux.ai/`                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| models       | `anthropic/claude-opus-4.6` (Claude Opus 4.6), `anthropic/claude-sonnet-4.6` (Claude Sonnet 4.6), `anthropic/claude-haiku-4.5` (Claude Haiku 4.5), `openai/gpt-5.2-pro` (GPT-5.2 Pro), `google/gemini-3-pro-preview` (Gemini 3 Pro), `google/gemini-3-flash-preview` (Gemini 3 Flash), `z-ai/glm-5` (GLM-5), `deepseek/deepseek-reasoner` (DeepSeek Reasoner), `deepseek/deepseek-chat` (DeepSeek Chat), `moonshotai/kimi-k2.5` (Kimi K2.5), `minimax/minimax-m2.5` (MiniMax-M2.5) |
+| modelMap     | _(empty — default is first model in list)_                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| envOverrides | _(none)_                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### Design Decisions
+
+- **Non-Claude providers**: Only `modelMap.model` is set. The `haiku`/`opus`/`sonnet` slots are left empty because these providers don't have natural equivalents to the Claude model tiers.
+- **Model IDs**: Each provider uses the actual model ID its API accepts (e.g., `glm-5`, `kimi-for-coding`, `minimax-m2.5`). Moonshot is the exception — its Anthropic-compatible proxy accepts Claude aliases, so `sonnet` is used.
+- **Multi-model aggregators**: OpenRouter, ZenMux, and Bailian list top models from multiple vendors. `modelMap` is empty — the default model is determined by the first entry in the `models` record.
+- **Single model per provider**: Most non-Claude providers offer one primary model for coding.
+- **CN/Global split**: GLM and MiniMax are kept as separate built-in entries (different base URLs, same models) rather than merged with a region toggle, to keep the UX simple.
+- **envOverrides**: All new providers use empty `envOverrides`. Auth is handled by the framework (`apiKey` → `ANTHROPIC_AUTH_TOKEN` in session-manager.ts).
+- **Descriptions**: Each provider has a brief one-line description shown in the template picker to help users distinguish similar providers (e.g., CN vs Global variants).
+- **Inline i18n**: Translations are embedded in the provider config (`L10nText` maps) rather than in locale files. This makes provider definitions self-contained — critical for future plugin-based provider extensions where plugins shouldn't need to inject into locale files. `name` is a plain string (brand name / en-US fallback); `nameLocalized` is optional for the few providers needing locale-specific names; `description` is always a `L10nText` map.
 
 ## Reset to Template Defaults
 
@@ -41,90 +193,53 @@ The button is only shown when the provider's current config differs from the tem
 
 **Confirmation:** Clicking "Reset to defaults" shows a confirmation dialog before applying, since it's destructive — any user-added models or customizations to baseURL/modelMap/envOverrides will be lost.
 
+### Update Indicator (future improvement)
+
+When we ship updated model lists in a new app version, existing users with a `builtInId` provider won't see the changes until they manually click "Reset to defaults." To improve discoverability, show a subtle dot/badge on the provider card or "Reset to defaults" button when the built-in template has changed since the provider was last synced. Comparison can use a shallow diff of `baseURL + models + modelMap + envOverrides` against the current template.
+
 ### Name Collision Handling
 
 When creating from a built-in template, the pre-filled name (e.g., "OpenRouter") may collide with an existing custom provider's name. Since the backend enforces unique names, the form validation will catch this. The user can simply rename in the form before saving. No special auto-suffixing logic needed — keep it simple.
 
-## Architecture
+## Implementation Changes
 
-### New Files
+### `shared/features/provider/built-in.ts`
 
-```
-shared/features/provider/built-in.ts
-```
-
-Exports a `BUILT_IN_PROVIDERS` array. Each entry contains all provider fields except `apiKey` and `enabled` (those are set during creation):
+Provider type with inline i18n — translations live in the provider config itself (no locale file entries needed), so plugins can ship self-contained provider definitions:
 
 ```ts
+export type L10nText = Record<string, string>;
+
 export type BuiltInProvider = {
-  id: string; // Stable identifier, stored as `builtInId` on Provider
-  nameKey: string; // i18n key for display name (e.g., "providers.openrouter.name")
-  name: string; // Fallback display name when i18n key is missing
+  id: string;
+  name: string; // brand name (en-US fallback, also used as form default)
+  nameLocalized?: L10nText; // only for providers with locale-specific names
+  description: L10nText; // always localized, keyed by locale
   baseURL: string;
-  apiKeyURL?: string; // Clickable URL that opens browser to the API key page
+  apiKeyURL?: string;
+  docURL?: string;
   models: Record<string, { displayName?: string }>;
   modelMap: ProviderModelMap;
   envOverrides: Record<string, string>;
 };
-
-export const BUILT_IN_PROVIDERS: BuiltInProvider[] = [
-  {
-    id: "openrouter",
-    nameKey: "providers.openrouter.name",
-    name: "OpenRouter",
-    baseURL: "https://openrouter.ai/api",
-    apiKeyURL: "https://openrouter.ai/keys",
-    models: {
-      "claude-sonnet-4": { displayName: "Claude Sonnet 4" },
-      "claude-haiku-4": { displayName: "Claude Haiku 4" },
-    },
-    modelMap: {
-      model: "claude-sonnet-4",
-      sonnet: "claude-sonnet-4",
-      haiku: "claude-haiku-4",
-      opus: "claude-sonnet-4",
-    },
-    envOverrides: {},
-  },
-];
-
-/** Look up a built-in template by its id */
-export function getBuiltInProvider(builtInId: string): BuiltInProvider | undefined {
-  return BUILT_IN_PROVIDERS.find((t) => t.id === builtInId);
-}
 ```
 
-### Modified Files
+A `resolveL10n(value, lang, localized?)` helper resolves the display string for the current locale with en-US fallback.
 
-```
-shared/features/provider/types.ts
-```
+Update `BUILT_IN_PROVIDERS` array: add 8 new entries (Anthropic, GLM CN, GLM Global, Kimi, Moonshot, MiniMax CN, MiniMax Global, Bailian) and update the existing OpenRouter entry with current model IDs.
 
-- Add optional `builtInId?: string` to the `Provider` type. Set when a provider is created from a built-in template, left `undefined` for custom providers.
+### `renderer/src/features/settings/components/panels/providers-panel.tsx`
 
-```
-renderer/features/settings/components/panels/providers-panel.tsx
-```
+- Template picker cards: use `resolveL10n()` to display localized name and description, and abbreviated baseURL (hostname only) below that — so users see all three: name, description, and endpoint at a glance.
+- Template picker grid: bump from `grid-cols-2` to `grid-cols-3` to reduce vertical scrolling (10 cards = 4 rows instead of 5).
+- `builtInToForm()` resolves the localized name for the current locale as the form default.
+- Edit form: show `docURL` as a "View docs" link next to the existing apiKeyURL "Get your API key" link.
+- TODO: Add "Test Connection" button to verify API key works (separate PR).
 
-- Add `selectedTemplate` state (`BuiltInProvider | "custom" | null`)
-- When `isCreating && selectedTemplate === null` → show template picker
-- When template selected → pre-fill form via `setForm()`, set `selectedTemplate`
-- Filter out already-added templates by matching `builtInId` against existing `providers`
-- If no available templates remain, skip picker and go straight to blank form
-- When a template with `apiKeyURL` is active (creating or editing a built-in provider), show a clickable link below the API key input that opens the URL in the browser via `shell.openExternal()`
-- When editing a provider with `builtInId`, show a "Reset to defaults" button that re-applies template values (baseURL, models, modelMap, envOverrides) while keeping apiKey, name, and enabled
-- Use i18n keys (`nameKey`) for template display names in the picker, with `name` as fallback
+### `renderer/src/locales/*.json`
 
-### Backend Changes
+No provider-specific i18n keys needed — all provider name/description translations are inline in `built-in.ts`. This makes provider configs self-contained, which is required for future plugin-based provider extensions.
 
-```
-shared/features/provider/contract.ts
-```
+### No other backend changes needed
 
-- Accept optional `builtInId` in the `create` input schema, pass through to stored provider.
-
-```
-main/features/config/config-store.ts
-```
-
-- `builtInId` is persisted as part of the `Provider` object (no special handling needed — it's just a new optional field on the type).
+The existing architecture (types.ts `builtInId`, contract.ts, session-manager.ts env injection) already supports multiple built-in providers.

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -7,6 +7,7 @@ import type { Provider, ProviderModelMap } from "../../../../../../shared/featur
 import {
   BUILT_IN_PROVIDERS,
   getBuiltInProvider,
+  resolveL10n,
   type BuiltInProvider,
 } from "../../../../../../shared/features/provider/built-in";
 import { Button } from "../../../../components/ui/button";
@@ -49,9 +50,9 @@ function providerToForm(p: Provider): ProviderFormData {
   };
 }
 
-function builtInToForm(t: BuiltInProvider): ProviderFormData {
+function builtInToForm(t: BuiltInProvider, lang: string): ProviderFormData {
   return {
-    name: t.name,
+    name: resolveL10n(t.name, lang, t.nameLocalized),
     baseURL: t.baseURL,
     apiKey: "",
     models: { ...t.models },
@@ -63,7 +64,7 @@ function builtInToForm(t: BuiltInProvider): ProviderFormData {
 }
 
 export const ProvidersPanel = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const providers = useProviderStore((s) => s.providers);
   const loaded = useProviderStore((s) => s.loaded);
   const load = useProviderStore((s) => s.load);
@@ -115,7 +116,7 @@ export const ProvidersPanel = () => {
   const selectTemplate = useCallback((template: BuiltInProvider) => {
     setShowTemplatePicker(false);
     setIsCreating(true);
-    setForm(builtInToForm(template));
+    setForm(builtInToForm(template, i18n.language));
   }, []);
 
   const selectCustom = useCallback(() => {
@@ -271,12 +272,13 @@ export const ProvidersPanel = () => {
     }));
   }, [form.builtInId, t]);
 
-  const activeApiKeyURL = useMemo(() => {
-    if (form.builtInId) {
-      return getBuiltInProvider(form.builtInId)?.apiKeyURL;
-    }
-    return undefined;
-  }, [form.builtInId]);
+  const activeBuiltIn = useMemo(
+    () => (form.builtInId ? getBuiltInProvider(form.builtInId) : undefined),
+    [form.builtInId],
+  );
+
+  const activeApiKeyURL = activeBuiltIn?.apiKeyURL;
+  const activeDocURL = activeBuiltIn?.docURL;
 
   const isEditing = isCreating || editingId !== null;
   const modelKeys = Object.keys(form.models);
@@ -291,21 +293,27 @@ export const ProvidersPanel = () => {
       {showTemplatePicker && (
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">{t("settings.providers.chooseTemplate")}</p>
-          <div className="grid grid-cols-2 gap-3">
-            {availableTemplates.map((template) => (
-              <button
-                key={template.id}
-                className="flex flex-col items-start gap-1 rounded-lg border border-input p-4 text-left hover:border-primary hover:bg-accent transition-colors"
-                onClick={() => selectTemplate(template)}
-              >
-                <span className="text-sm font-medium">
-                  {t(template.nameKey, { defaultValue: template.name })}
-                </span>
-                <span className="text-xs text-muted-foreground">{template.baseURL}</span>
-              </button>
-            ))}
+          <div className="grid grid-cols-3 gap-3">
+            {availableTemplates.map((template) => {
+              const hostname = new URL(template.baseURL).hostname;
+              return (
+                <button
+                  key={template.id}
+                  className="flex flex-col items-start gap-1 rounded-lg border border-input p-3 text-left hover:border-primary hover:bg-accent transition-colors"
+                  onClick={() => selectTemplate(template)}
+                >
+                  <span className="text-sm font-medium">
+                    {resolveL10n(template.name, i18n.language, template.nameLocalized)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {resolveL10n(template.description, i18n.language)}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground/60">{hostname}</span>
+                </button>
+              );
+            })}
             <button
-              className="flex flex-col items-start gap-1 rounded-lg border border-dashed border-input p-4 text-left hover:border-primary hover:bg-accent transition-colors"
+              className="flex flex-col items-start gap-1 rounded-lg border border-dashed border-input p-3 text-left hover:border-primary hover:bg-accent transition-colors"
               onClick={selectCustom}
             >
               <span className="text-sm font-medium">{t("settings.providers.custom")}</span>
@@ -405,16 +413,31 @@ export const ProvidersPanel = () => {
               placeholder="sk-..."
               className="mt-1"
             />
-            {activeApiKeyURL && (
-              <a
-                href={activeApiKeyURL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 mt-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t("settings.providers.getApiKey")}
-                <ExternalLink className="h-3 w-3" />
-              </a>
+            {(activeApiKeyURL || activeDocURL) && (
+              <div className="flex items-center gap-3 mt-1.5">
+                {activeApiKeyURL && (
+                  <a
+                    href={activeApiKeyURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {t("settings.providers.getApiKey")}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+                {activeDocURL && (
+                  <a
+                    href={activeDocURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {t("settings.providers.viewDocs")}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </div>
             )}
           </div>
 

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -101,7 +101,7 @@
   "settings.providers.getApiKey": "Get your API key",
   "settings.providers.resetDefaults": "Reset to defaults",
   "settings.providers.resetConfirm": "Reset baseURL, models, model map, and environment overrides to template defaults? Your API key and name will be kept.",
-  "providers.openrouter.name": "OpenRouter",
+  "settings.providers.viewDocs": "View docs",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP configuration coming soon...",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -101,7 +101,7 @@
   "settings.providers.getApiKey": "获取 API 密钥",
   "settings.providers.resetDefaults": "重置为默认",
   "settings.providers.resetConfirm": "将 API 地址、模型、模型映射和环境变量覆盖重置为模板默认值？您的 API 密钥和名称将保留。",
-  "providers.openrouter.name": "OpenRouter",
+  "settings.providers.viewDocs": "查看文档",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP 配置即将推出...",

--- a/packages/desktop/src/shared/features/provider/built-in.ts
+++ b/packages/desktop/src/shared/features/provider/built-in.ts
@@ -1,34 +1,227 @@
 import type { ProviderModelMap } from "./types";
 
+export type L10nText = Record<string, string>;
+
 export type BuiltInProvider = {
   id: string;
-  nameKey: string;
   name: string;
+  nameLocalized?: L10nText;
+  description: L10nText;
   baseURL: string;
   apiKeyURL?: string;
+  docURL?: string;
   models: Record<string, { displayName?: string }>;
   modelMap: ProviderModelMap;
   envOverrides: Record<string, string>;
 };
 
+export function resolveL10n(value: string | L10nText, lang: string, localized?: L10nText): string {
+  if (typeof value === "string") return localized?.[lang] ?? value;
+  return value[lang] ?? value["en-US"] ?? Object.values(value)[0] ?? "";
+}
+
 export const BUILT_IN_PROVIDERS: BuiltInProvider[] = [
   {
+    id: "anthropic",
+    name: "Anthropic",
+    description: {
+      "en-US": "Official Anthropic API",
+      "zh-CN": "Anthropic 官方 API",
+    },
+    baseURL: "https://api.anthropic.com",
+    apiKeyURL: "https://console.anthropic.com/settings/keys",
+    docURL: "https://docs.anthropic.com/en/docs/about-claude/models",
+    models: {
+      "claude-opus-4-6": { displayName: "Claude Opus 4.6" },
+      "claude-sonnet-4-6": { displayName: "Claude Sonnet 4.6" },
+      "claude-haiku-4-5": { displayName: "Claude Haiku 4.5" },
+    },
+    modelMap: {
+      model: "claude-opus-4-6",
+      sonnet: "claude-sonnet-4-6",
+      haiku: "claude-haiku-4-5",
+      opus: "claude-opus-4-6",
+    },
+    envOverrides: {},
+  },
+  {
     id: "openrouter",
-    nameKey: "providers.openrouter.name",
     name: "OpenRouter",
+    description: {
+      "en-US": "Multi-model API aggregator",
+      "zh-CN": "多模型 API 聚合平台",
+    },
     baseURL: "https://openrouter.ai/api",
     apiKeyURL: "https://openrouter.ai/settings/keys",
+    docURL: "https://openrouter.ai/models",
     models: {
       "anthropic/claude-opus-4.6": { displayName: "Claude Opus 4.6" },
       "anthropic/claude-sonnet-4.6": { displayName: "Claude Sonnet 4.6" },
       "anthropic/claude-haiku-4.5": { displayName: "Claude Haiku 4.5" },
+      "google/gemini-3-pro-preview": { displayName: "Gemini 3 Pro" },
+      "google/gemini-3-flash-preview": { displayName: "Gemini 3 Flash" },
+      "z-ai/glm-5": { displayName: "GLM-5" },
+      "deepseek/deepseek-reasoner": { displayName: "DeepSeek Reasoner" },
+      "deepseek/deepseek-chat": { displayName: "DeepSeek Chat" },
+      "moonshotai/kimi-k2.5": { displayName: "Kimi K2.5" },
+      "minimax/minimax-m2.5": { displayName: "MiniMax-M2.5" },
+    },
+    modelMap: {},
+    envOverrides: {},
+  },
+  {
+    id: "glm-cn",
+    name: "GLM (CN)",
+    nameLocalized: { "zh-CN": "智谱 GLM（国内）" },
+    description: {
+      "en-US": "Zhipu AI models, China endpoint",
+      "zh-CN": "智谱 AI 模型，国内端点",
+    },
+    baseURL: "https://open.bigmodel.cn/api/anthropic",
+    apiKeyURL: "https://open.bigmodel.cn/usercenter/apikeys",
+    docURL: "https://docs.bigmodel.cn/cn/coding-plan/overview",
+    models: {
+      "glm-5": { displayName: "GLM-5" },
     },
     modelMap: {
-      model: "anthropic/claude-opus-4.6",
-      sonnet: "anthropic/claude-sonnet-4.6",
-      haiku: "anthropic/claude-haiku-4.5",
-      opus: "anthropic/claude-opus-4.6",
+      model: "glm-5",
     },
+    envOverrides: {},
+  },
+  {
+    id: "glm-global",
+    name: "GLM (Global)",
+    nameLocalized: { "zh-CN": "智谱 GLM（国际）" },
+    description: {
+      "en-US": "Zhipu AI models, global endpoint",
+      "zh-CN": "智谱 AI 模型，国际端点",
+    },
+    baseURL: "https://api.z.ai/api/anthropic",
+    docURL: "https://docs.z.ai/devpack/overview",
+    models: {
+      "glm-5": { displayName: "GLM-5" },
+    },
+    modelMap: {
+      model: "glm-5",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "kimi",
+    name: "Kimi",
+    description: {
+      "en-US": "Moonshot's Kimi coding model",
+      "zh-CN": "月之暗面 Kimi 编程模型",
+    },
+    baseURL: "https://api.kimi.com/coding/",
+    docURL: "https://www.kimi.com/coding/docs/en/third-party-agents.html",
+    models: {
+      "kimi-for-coding": { displayName: "Kimi K2.5" },
+    },
+    modelMap: {
+      model: "kimi-for-coding",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "moonshot",
+    name: "Moonshot",
+    description: {
+      "en-US": "Kimi K2.5 via Moonshot API",
+      "zh-CN": "通过 Moonshot API 使用 Kimi K2.5",
+    },
+    baseURL: "https://api.moonshot.cn/anthropic",
+    docURL: "https://platform.moonshot.cn/docs/api/chat",
+    models: {
+      sonnet: { displayName: "Kimi K2.5" },
+    },
+    modelMap: {
+      model: "sonnet",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "minimax-cn",
+    name: "MiniMax (CN)",
+    nameLocalized: { "zh-CN": "MiniMax（国内）" },
+    description: {
+      "en-US": "MiniMax M2.5 model, China endpoint",
+      "zh-CN": "MiniMax M2.5 模型，国内端点",
+    },
+    baseURL: "https://api.minimaxi.com/anthropic",
+    docURL: "https://platform.minimaxi.com/docs/coding-plan/intro",
+    models: {
+      "minimax-m2.5": { displayName: "MiniMax-M2.5" },
+    },
+    modelMap: {
+      model: "minimax-m2.5",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "minimax-global",
+    name: "MiniMax (Global)",
+    nameLocalized: { "zh-CN": "MiniMax（国际）" },
+    description: {
+      "en-US": "MiniMax M2.5 model, global endpoint",
+      "zh-CN": "MiniMax M2.5 模型，国际端点",
+    },
+    baseURL: "https://api.minimax.io/anthropic",
+    docURL: "https://platform.minimax.io/docs/coding-plan/intro",
+    models: {
+      "minimax-m2.5": { displayName: "MiniMax-M2.5" },
+    },
+    modelMap: {
+      model: "minimax-m2.5",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "bailian",
+    name: "Aliyun Bailian",
+    nameLocalized: { "zh-CN": "阿里云百炼" },
+    description: {
+      "en-US": "Alibaba Cloud multi-model aggregator",
+      "zh-CN": "阿里云多模型聚合平台",
+    },
+    baseURL: "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+    docURL: "https://help.aliyun.com/zh/model-studio/coding-plan",
+    models: {
+      "qwen3.5-plus": { displayName: "Qwen 3.5 Plus" },
+      "qwen3-coder-next": { displayName: "Qwen 3 Coder Next" },
+      "qwen3-coder-plus": { displayName: "Qwen 3 Coder Plus" },
+      "kimi-k2.5": { displayName: "Kimi K2.5" },
+      "glm-5": { displayName: "GLM-5" },
+      "glm-4.7": { displayName: "GLM-4.7" },
+      "MiniMax-M2.5": { displayName: "MiniMax-M2.5" },
+    },
+    modelMap: {
+      model: "kimi-k2.5",
+    },
+    envOverrides: {},
+  },
+  {
+    id: "zenmux",
+    name: "ZenMux",
+    description: {
+      "en-US": "Multi-model API aggregator",
+      "zh-CN": "多模型 API 聚合平台",
+    },
+    baseURL: "https://zenmux.ai/api/anthropic",
+    docURL: "https://docs.zenmux.ai/",
+    models: {
+      "anthropic/claude-opus-4.6": { displayName: "Claude Opus 4.6" },
+      "anthropic/claude-sonnet-4.6": { displayName: "Claude Sonnet 4.6" },
+      "anthropic/claude-haiku-4.5": { displayName: "Claude Haiku 4.5" },
+      "google/gemini-3-pro-preview": { displayName: "Gemini 3 Pro" },
+      "google/gemini-3-flash-preview": { displayName: "Gemini 3 Flash" },
+      "z-ai/glm-5": { displayName: "GLM-5" },
+      "deepseek/deepseek-reasoner": { displayName: "DeepSeek Reasoner" },
+      "deepseek/deepseek-chat": { displayName: "DeepSeek Chat" },
+      "moonshotai/kimi-k2.5": { displayName: "Kimi K2.5" },
+      "minimax/minimax-m2.5": { displayName: "MiniMax-M2.5" },
+    },
+    modelMap: {},
     envOverrides: {},
   },
 ];


### PR DESCRIPTION
Expanded built-in provider templates from 1 to 10, adding Anthropic, GLM (CN/Global), Kimi, Moonshot, MiniMax (CN/Global), Aliyun Bailian, and ZenMux. Implemented inline i18n system with L10nText for self-contained provider configs, added docURL links, and improved template picker UI with 3-column grid and hostname display.