### PR TITLE
fix: close suggestion popups when settings opens

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -11,6 +11,7 @@ import { useEventCallback } from "../../../hooks/use-event-callback";
 import { useLatestRef } from "../../../hooks/use-latest-ref";
 import { cn } from "../../../lib/utils";
 import { useConfigStore } from "../../config/store";
+import { useSettingsStore } from "../../settings";
 import { claudeCodeChatManager } from "../chat-manager";
 import { useNewSession } from "../hooks/use-new-session";
 import { useAgentStore } from "../store";
@@ -202,6 +203,14 @@ export function MessageInput({
   useEffect(() => {
     editor?.setEditable(!disabled && !streaming);
   }, [editor, disabled, streaming]);
+
+  // Close suggestion popups when settings opens
+  const showSettings = useSettingsStore((s) => s.showSettings);
+  useEffect(() => {
+    if (showSettings) {
+      document.querySelectorAll("[data-suggestion-popup]").forEach((el) => el.remove());
+    }
+  }, [showSettings]);
 
   // Listen for insert-mention events from file tree
   useEffect(() => {


### PR DESCRIPTION
Added an effect to remove suggestion popups when the settings panel is opened, preventing UI overlap issues.

Close https://github.com/neovateai/neovate-desktop/issues/120