### PR TITLE
feat: replace benchmarkModel with checkModel for pre-save testing

### DIFF
--- a/docs/design/2026-03-13-provider-check.md
+++ b/docs/design/2026-03-13-provider-check.md
@@ -1,0 +1,99 @@
+# Provider Check: Benchmark on Add Page + Single-Model Dropdown
+
+## Summary
+
+Replace `benchmarkModel` (requires saved provider) with `checkModel` (accepts raw credentials). This enables benchmarking on the provider add page without saving first, and unifies the check logic for both create and edit flows. Add a split button UI to support testing a single model via dropdown.
+
+## Motivation
+
+- Currently the test/benchmark button only appears on the edit form (provider must be saved first)
+- No way to verify API key + model connectivity before saving a provider
+- No way to test a single model — only "test all"
+
+## API Change
+
+### Replace `benchmarkModel` with `checkModel`
+
+**Before:**
+
+```
+benchmarkModel({ providerId: string, modelId: string }) -> BenchmarkResult
+```
+
+**After:**
+
+```
+checkModel({ baseURL: string, apiKey: string, modelId: string }) -> BenchmarkResult
+```
+
+The backend no longer looks up a saved provider. The frontend always passes raw credentials from the form state, whether creating or editing.
+
+## Files Changed
+
+| File                                                                   | Change                                                                                                                                                                                       |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/features/provider/contract.ts`                                 | Replace `benchmarkModel` with `checkModel` (new input schema: `baseURL`, `apiKey`, `modelId`)                                                                                                |
+| `main/features/provider/router.ts`                                     | Replace `benchmarkModel` handler — construct temp provider object from input, call `runBenchmark()`. Remove provider-exists/enabled checks (no longer relevant).                             |
+| `renderer/src/features/provider/store.ts`                              | Replace `benchmarkModel(providerId, modelId)` with `checkModel(baseURL, apiKey, modelId)`. Replace `benchmarkAll` with `checkAll(baseURL, apiKey, modelIds)`. Key format: `baseURL:modelId`. |
+| `renderer/src/features/provider/benchmark-button.tsx`                  | Accept `baseURL + apiKey` props instead of `providerId`. Add split button with dropdown for single-model test.                                                                               |
+| `renderer/src/features/settings/components/panels/providers-panel.tsx` | Show benchmark button on both create and edit forms. Pass `baseURL` and `apiKey` from form state. Remove `onBeforeBenchmark` that saved models before testing.                               |
+
+## Naming Convention
+
+Only the RPC endpoint is renamed (`benchmarkModel` -> `checkModel`). All frontend component names stay as-is (`BenchmarkButton`, `BenchmarkMetrics`, `BenchmarkTooltipContent`, `benchmark-button.tsx`, etc.). The RPC rename is the meaningful change; component names are internal.
+
+## Split Button UI
+
+```
+When 2+ models:
++----------------+-----+
+|  (gauge) Test  |  v  |   <- main click = test all models
++----------------+-----+
+                   |
+                   v (dropdown)
+           +----------------------------+
+           | claude-sonnet-4  Sonnet    |
+           | claude-haiku-4   Haiku     |
+           | claude-opus-4    Opus      |
+           +----------------------------+
+
+When 1 model:
++----------------+
+|  (gauge) Test  |   <- plain button, no chevron/dropdown
++----------------+
+
+When running:
++----------------+
+|  (stop) Stop   |   <- replaces entire button
++----------------+
+```
+
+## Design Decisions
+
+### 1. Key format: `baseURL:modelId`
+
+Use `baseURL:modelId` as the store key universally (instead of `providerId:modelId`). This is deterministic, works for both create and edit, and naturally invalidates results when the user changes the base URL.
+
+### 2. Disable test when baseURL is invalid
+
+Button enabled condition: `apiKey.trim() !== "" && modelKeys.length > 0 && isValidURL(baseURL)`. Prevents confusing network errors from invalid URLs.
+
+### 3. Dropdown shows display name
+
+Dropdown entries show `displayName` alongside model ID when available, matching the model list display.
+
+### 4. Skip dropdown for single model
+
+When only 1 model exists, render a plain button (no chevron, no dropdown). Split button only appears with 2+ models.
+
+### 5. Clear previous result on re-test
+
+When testing a single model, clear its previous result before starting so the user sees a spinner instead of stale data.
+
+## What stays the same
+
+- `runBenchmark()` function in router.ts — untouched
+- `BenchmarkResult` type — untouched
+- Benchmark result display (metrics badges, tooltips) — untouched
+- `BenchmarkMetrics`, `BenchmarkTooltipContent` components — untouched
+- `benchmark-utils.ts` color thresholds — untouched

--- a/packages/desktop/src/main/features/provider/router.ts
+++ b/packages/desktop/src/main/features/provider/router.ts
@@ -207,33 +207,10 @@ export const providerRouter = os.provider.router({
     log("remove: id=%s", input.id);
   }),
 
-  benchmarkModel: os.provider.benchmarkModel.handler(async ({ input, context, signal }) => {
-    const { providerId, modelId } = input;
-
-    const provider = context.configStore.getProvider(providerId);
-    if (!provider) {
-      throw new ORPCError("NOT_FOUND", {
-        defined: true,
-        message: `Provider not found: ${providerId}`,
-      });
-    }
-
-    if (!provider.enabled) {
-      throw new ORPCError("BAD_REQUEST", {
-        defined: true,
-        message: `Provider ${provider.name} is disabled`,
-      });
-    }
-
-    if (!provider.models[modelId]) {
-      throw new ORPCError("BAD_REQUEST", {
-        defined: true,
-        message: `Model ${modelId} not found in provider ${provider.name}`,
-      });
-    }
-
-    log("benchmarkModel: provider=%s model=%s", providerId, modelId);
-    return runBenchmark(provider, modelId, signal);
+  checkModel: os.provider.checkModel.handler(async ({ input, signal }) => {
+    const { baseURL, apiKey, modelId } = input;
+    log("checkModel: baseURL=%s model=%s", baseURL, modelId);
+    return runBenchmark({ id: "_check", baseURL, apiKey } as Provider, modelId, signal);
   }),
 
   setSelection: os.provider.setSelection.handler(({ input, context }) => {

--- a/packages/desktop/src/renderer/src/features/provider/benchmark-button.tsx
+++ b/packages/desktop/src/renderer/src/features/provider/benchmark-button.tsx
@@ -1,14 +1,15 @@
-import { Gauge, Square } from "lucide-react";
+import { ChevronDown, Gauge, Square } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button, type ButtonProps } from "../../components/ui/button";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../../components/ui/menu";
 import { useProviderStore } from "./store";
 
 interface BenchmarkButtonProps {
-  providerId: string;
-  modelIds: string[];
-  onBeforeBenchmark?: () => Promise<void>;
+  baseURL: string;
+  apiKey: string;
+  models: Record<string, { displayName?: string }>;
   onComplete?: () => void;
   disabled?: boolean;
   size?: ButtonProps["size"];
@@ -17,9 +18,9 @@ interface BenchmarkButtonProps {
 }
 
 export function BenchmarkButton({
-  providerId,
-  modelIds,
-  onBeforeBenchmark,
+  baseURL,
+  apiKey,
+  models,
   onComplete,
   disabled,
   size = "sm",
@@ -27,16 +28,18 @@ export function BenchmarkButton({
   className,
 }: BenchmarkButtonProps) {
   const { t } = useTranslation();
-  const benchmarkAll = useProviderStore((s) => s.benchmarkAll);
+  const checkAll = useProviderStore((s) => s.checkAll);
   const cancelBenchmarks = useProviderStore((s) => s.cancelBenchmarks);
   const benchmarkingModels = useProviderStore((s) => s.benchmarkingModels);
   const [running, setRunning] = useState(false);
 
-  const isAnyRunning = running || modelIds.some((id) => benchmarkingModels[`${providerId}:${id}`]);
+  const modelIds = Object.keys(models);
+  const isAnyRunning = running || modelIds.some((id) => benchmarkingModels[`${baseURL}:${id}`]);
 
   const showLabel = size !== "icon" && size !== "icon-sm" && size !== "icon-xs";
+  const hasMultipleModels = modelIds.length > 1;
 
-  const handleClick = useCallback(async () => {
+  const handleTestAll = useCallback(async () => {
     if (isAnyRunning) {
       cancelBenchmarks();
       setRunning(false);
@@ -45,28 +48,34 @@ export function BenchmarkButton({
     if (modelIds.length === 0) return;
     setRunning(true);
     try {
-      if (onBeforeBenchmark) {
-        await onBeforeBenchmark();
-      }
-      await benchmarkAll(providerId, modelIds);
+      await checkAll(baseURL, apiKey, modelIds);
       onComplete?.();
     } catch (e) {
-      // AbortError is expected on cancel
       if (!(e instanceof DOMException && e.name === "AbortError")) {
         console.error("Benchmark failed:", e);
       }
     } finally {
       setRunning(false);
     }
-  }, [
-    isAnyRunning,
-    modelIds,
-    providerId,
-    benchmarkAll,
-    cancelBenchmarks,
-    onBeforeBenchmark,
-    onComplete,
-  ]);
+  }, [isAnyRunning, modelIds, baseURL, apiKey, checkAll, cancelBenchmarks, onComplete]);
+
+  const handleTestSingle = useCallback(
+    async (modelId: string) => {
+      if (isAnyRunning) return;
+      setRunning(true);
+      try {
+        await checkAll(baseURL, apiKey, [modelId]);
+        onComplete?.();
+      } catch (e) {
+        if (!(e instanceof DOMException && e.name === "AbortError")) {
+          console.error("Benchmark failed:", e);
+        }
+      } finally {
+        setRunning(false);
+      }
+    },
+    [isAnyRunning, baseURL, apiKey, checkAll, onComplete],
+  );
 
   if (isAnyRunning) {
     return (
@@ -74,7 +83,7 @@ export function BenchmarkButton({
         variant="destructive-outline"
         size={size}
         className={className}
-        onClick={handleClick}
+        onClick={handleTestAll}
         aria-label={t("settings.providers.benchmark.cancel")}
       >
         <Square className="h-3 w-3" />
@@ -83,17 +92,53 @@ export function BenchmarkButton({
     );
   }
 
+  if (!hasMultipleModels) {
+    return (
+      <Button
+        variant={variant}
+        size={size}
+        className={className}
+        disabled={disabled || modelIds.length === 0}
+        onClick={handleTestAll}
+        aria-label={t("settings.providers.benchmark.testAll")}
+      >
+        <Gauge className="h-3.5 w-3.5" />
+        {showLabel && <span>{t("settings.providers.benchmark.test")}</span>}
+      </Button>
+    );
+  }
+
   return (
-    <Button
-      variant={variant}
-      size={size}
-      className={className}
-      disabled={disabled || modelIds.length === 0}
-      onClick={handleClick}
-      aria-label={t("settings.providers.benchmark.testAll")}
-    >
-      <Gauge className="h-3.5 w-3.5" />
-      {showLabel && <span>{t("settings.providers.benchmark.test")}</span>}
-    </Button>
+    <div className="inline-flex">
+      <Button
+        variant={variant}
+        size={size}
+        className={`${className ?? ""} rounded-r-none border-r-0`}
+        disabled={disabled}
+        onClick={handleTestAll}
+        aria-label={t("settings.providers.benchmark.testAll")}
+      >
+        <Gauge className="h-3.5 w-3.5" />
+        {showLabel && <span>{t("settings.providers.benchmark.test")}</span>}
+      </Button>
+      <Menu>
+        <MenuTrigger
+          className={`inline-flex items-center justify-center rounded-l-none border border-input bg-popover px-1 text-foreground shadow-xs/5 hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-64 ${size === "xs" ? "h-7 sm:h-6" : size === "sm" ? "h-8 sm:h-7" : "h-9 sm:h-8"}`}
+          disabled={disabled}
+        >
+          <ChevronDown className="h-3 w-3" />
+        </MenuTrigger>
+        <MenuPopup align="end" side="bottom" sideOffset={4}>
+          {modelIds.map((id) => (
+            <MenuItem key={id} onClick={() => handleTestSingle(id)}>
+              <code className="text-xs">{id}</code>
+              {models[id]?.displayName && (
+                <span className="text-muted-foreground text-xs ml-2">{models[id].displayName}</span>
+              )}
+            </MenuItem>
+          ))}
+        </MenuPopup>
+      </Menu>
+    </div>
   );
 }

--- a/packages/desktop/src/renderer/src/features/provider/store.ts
+++ b/packages/desktop/src/renderer/src/features/provider/store.ts
@@ -26,14 +26,9 @@ type ProviderState = {
   }) => Promise<Provider>;
   updateProvider: (id: string, updates: Partial<Omit<Provider, "id">>) => Promise<Provider>;
   removeProvider: (id: string) => Promise<void>;
-  benchmarkModel: (
-    providerId: string,
-    modelId: string,
-    signal?: AbortSignal,
-  ) => Promise<BenchmarkResult | undefined>;
-  benchmarkAll: (providerId: string, modelIds: string[]) => Promise<void>;
+  checkAll: (baseURL: string, apiKey: string, modelIds: string[]) => Promise<void>;
   cancelBenchmarks: () => void;
-  clearProviderBenchmarkResults: (providerId: string) => void;
+  clearBenchmarkResults: (baseURL: string) => void;
 };
 
 export const useProviderStore = create<ProviderState>()(
@@ -75,30 +70,7 @@ export const useProviderStore = create<ProviderState>()(
       });
     },
 
-    benchmarkModel: async (providerId, modelId, signal) => {
-      const key = `${providerId}:${modelId}`;
-      if (get().benchmarkingModels[key]) return get().benchmarkResults[key];
-
-      set((state) => {
-        state.benchmarkingModels[key] = true;
-      });
-      try {
-        const result = await client.provider.benchmarkModel(
-          { providerId, modelId },
-          ...(signal ? [{ signal }] : []),
-        );
-        set((state) => {
-          state.benchmarkResults[key] = result;
-        });
-        return result;
-      } finally {
-        set((state) => {
-          delete state.benchmarkingModels[key];
-        });
-      }
-    },
-
-    benchmarkAll: async (providerId, modelIds) => {
+    checkAll: async (baseURL, apiKey, modelIds) => {
       benchmarkController?.abort();
 
       const controller = new AbortController();
@@ -107,7 +79,26 @@ export const useProviderStore = create<ProviderState>()(
       try {
         for (const modelId of modelIds) {
           if (controller.signal.aborted) break;
-          await get().benchmarkModel(providerId, modelId, controller.signal);
+          const key = `${baseURL}:${modelId}`;
+          if (get().benchmarkingModels[key]) continue;
+
+          set((state) => {
+            delete state.benchmarkResults[key];
+            state.benchmarkingModels[key] = true;
+          });
+          try {
+            const result = await client.provider.checkModel(
+              { baseURL, apiKey, modelId },
+              { signal: controller.signal },
+            );
+            set((state) => {
+              state.benchmarkResults[key] = result;
+            });
+          } finally {
+            set((state) => {
+              delete state.benchmarkingModels[key];
+            });
+          }
         }
       } finally {
         if (benchmarkController === controller) {
@@ -126,10 +117,10 @@ export const useProviderStore = create<ProviderState>()(
       }
     },
 
-    clearProviderBenchmarkResults: (providerId) => {
+    clearBenchmarkResults: (baseURL) => {
       set((state) => {
         for (const key of Object.keys(state.benchmarkResults)) {
-          if (key.startsWith(`${providerId}:`)) {
+          if (key.startsWith(`${baseURL}:`)) {
             delete state.benchmarkResults[key];
           }
         }

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -102,7 +102,7 @@ export const ProvidersPanel = () => {
   const benchmarkResults = useProviderStore((s) => s.benchmarkResults);
   const benchmarkingModels = useProviderStore((s) => s.benchmarkingModels);
   const cancelBenchmarks = useProviderStore((s) => s.cancelBenchmarks);
-  const clearProviderBenchmarkResults = useProviderStore((s) => s.clearProviderBenchmarkResults);
+  const clearBenchmarkResults = useProviderStore((s) => s.clearBenchmarkResults);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
@@ -140,9 +140,14 @@ export const ProvidersPanel = () => {
     [providers],
   );
 
-  const testableModelIds = useMemo(() => {
-    return editingId ? Object.keys(form.models) : [];
-  }, [editingId, form.models]);
+  const canCheck = useMemo(() => {
+    try {
+      new URL(form.baseURL);
+      return form.apiKey.trim() !== "" && Object.keys(form.models).length > 0;
+    } catch {
+      return false;
+    }
+  }, [form.baseURL, form.apiKey, form.models]);
 
   const startCreate = useCallback(() => {
     setEditingId(null);
@@ -171,14 +176,14 @@ export const ProvidersPanel = () => {
 
   const startEdit = useCallback(
     (p: Provider) => {
-      clearProviderBenchmarkResults(p.id);
+      clearBenchmarkResults(p.baseURL);
       setEditingId(p.id);
       setIsCreating(false);
       setShowApiKey(false);
       setForm(providerToForm(p));
       setError(null);
     },
-    [clearProviderBenchmarkResults],
+    [clearBenchmarkResults],
   );
 
   const cancel = useCallback(() => {
@@ -576,28 +581,21 @@ export const ProvidersPanel = () => {
           <div>
             <div className="flex items-center justify-between">
               <label className="text-sm font-medium">{t("settings.providers.models")}</label>
-              {editingId && form.enabled && (
+              {canCheck && (
                 <BenchmarkButton
-                  providerId={editingId}
-                  modelIds={testableModelIds}
+                  baseURL={form.baseURL}
+                  apiKey={form.apiKey}
+                  models={form.models}
                   size="xs"
                   variant="outline"
-                  onBeforeBenchmark={async () => {
-                    if (editingId) {
-                      await updateProvider(editingId, {
-                        models: form.models,
-                        modelMap: form.modelMap,
-                      });
-                    }
-                  }}
                 />
               )}
             </div>
             <div className="mt-1 space-y-1">
               {Object.entries(form.models).map(([key, entry]) => {
-                const benchKey = editingId ? `${editingId}:${key}` : "";
-                const result = benchKey ? benchmarkResults[benchKey] : undefined;
-                const isRunning = benchKey ? benchmarkingModels[benchKey] : false;
+                const benchKey = `${form.baseURL}:${key}`;
+                const result = benchmarkResults[benchKey];
+                const isRunning = benchmarkingModels[benchKey] ?? false;
 
                 return (
                   <div key={key} className="flex items-center gap-2 text-sm">

--- a/packages/desktop/src/shared/features/provider/contract.ts
+++ b/packages/desktop/src/shared/features/provider/contract.ts
@@ -54,10 +54,11 @@ export const providerContract = {
 
   remove: oc.input(z.object({ id: z.string() })).output(type<void>()),
 
-  benchmarkModel: oc
+  checkModel: oc
     .input(
       z.object({
-        providerId: z.string(),
+        baseURL: z.string().url(),
+        apiKey: z.string().min(1),
         modelId: z.string(),
       }),
     )


### PR DESCRIPTION
Replaced the `benchmarkModel` RPC endpoint with `checkModel` that accepts raw credentials (baseURL, apiKey, modelId) instead of requiring a saved provider. This enables testing API connectivity before saving a provider. Added a split button UI with dropdown for testing individual models. Changed benchmark result keys from `providerId:modelId` to `baseURL:modelId`.