### PR TITLE
feat: add query status loading indicator with animated spinner and thinking duration

### DIFF
--- a/docs/design/2026-03-13-query-status.md
+++ b/docs/design/2026-03-13-query-status.md
@@ -1,0 +1,145 @@
+# Query Status Loading Indicator
+
+## Overview
+
+Add a Claude Code-style loading indicator above the message input that shows during active queries. Displays an animated spinner, a randomly selected fun verb, elapsed time, and extended thinking duration.
+
+Example: `✻ Quantumizing… (1m 33s · thought for 2s)`
+
+## Architecture
+
+```
+chat-state.ts (store)     →  useQueryStatus() hook  →  <QueryStatus> component
+  - turnStartedAt              - elapsed timer           - spinner animation
+  - thinkingStartedAt          - verb selection           - status text
+  - thinkingDuration           - spinner frame index      - conditional rendering
+```
+
+## Files to modify
+
+1. `packages/desktop/src/renderer/src/features/agent/chat-state.ts` — add 3 fields + update on chunk processing
+2. **New**: `packages/desktop/src/renderer/src/features/agent/hooks/use-query-status.ts` — hook
+3. **New**: `packages/desktop/src/renderer/src/features/agent/components/query-status.tsx` — component + verbs list
+4. `packages/desktop/src/renderer/src/features/agent/components/message-input.tsx` — render `<QueryStatus>` above the input box
+
+## Store changes (`chat-state.ts`)
+
+Add 3 fields to `ClaudeCodeChatStoreState`:
+
+```typescript
+turnStartedAt: number | null; // Date.now() when turn begins
+thinkingStartedAt: number | null; // Date.now() when reasoning-start arrives
+thinkingDuration: number | null; // ms, accumulated across all reasoning blocks in a turn
+lastChunkAt: number | null; // Date.now() on each non-reasoning chunk (for stall detection)
+```
+
+### State transitions
+
+- **Turn starts** (`status` → `"submitted"`): set `turnStartedAt = Date.now()`, clear `thinkingStartedAt` and `thinkingDuration`
+- **`reasoning-start` chunk**: set `thinkingStartedAt = Date.now()`
+- **`reasoning-end` chunk**: accumulate `thinkingDuration = (thinkingDuration ?? 0) + (Date.now() - thinkingStartedAt)`, clear `thinkingStartedAt` (supports multiple reasoning blocks per turn)
+- **Turn ends** (`status` → `"ready"`): clear `turnStartedAt`, `thinkingStartedAt`, `thinkingDuration` after completion flash (see below)
+
+## Hook (`useQueryStatus`)
+
+```typescript
+function useQueryStatus(sessionId: string | null): {
+  isActive: boolean;
+  phase: "active" | "completing" | "idle";
+  verb: string;
+  elapsedMs: number;
+  thinkingDurationMs: number | null;
+  isThinking: boolean;
+  isStalled: boolean;
+  spinnerFrame: string;
+};
+```
+
+- Picks a random verb when turn starts (stable for the duration of the turn)
+- Runs `setInterval(100ms)` during active turns for elapsed time + spinner frame updates
+- Spinner frames: `["·", "✢", "✳", "✶", "✻", "✽"]` in ping-pong cycle (~200ms per frame)
+- Cleans up interval on turn end
+- **Completion flash**: on turn end, transitions to `phase: "completing"` for 2.5s before `"idle"` (shows past-tense verb)
+- **Stalled detection**: `isStalled = true` if no non-reasoning chunk received for >3s during active turn. Reasoning chunks are excluded — during active thinking the user already sees "thinking..." and knows the model is alive. `lastChunkAt` only updates on text, tool, and other non-reasoning chunks.
+
+## Component (`<QueryStatus>`)
+
+Renders above the input as a slim status strip.
+
+### Display format
+
+```
+{spinnerFrame} {Verb}… ({elapsed} · thought for {duration})
+```
+
+- Left-aligned, `text-xs text-muted-foreground`
+- Spinner character in foreground color
+- Elapsed timer formatted: `0s` → `59s` → `1m 0s` → `1h 2m 3s`
+- "thought for Xs" shown only after thinking completes (not during active thinking)
+- During active thinking: show "thinking..." with subtle pulse/opacity animation
+- **Stalled state**: spinner color shifts to `text-destructive/60` when `isStalled` is true (no chunks for >3s)
+- Strip fades in on appear, hidden when idle
+
+### Completion flash
+
+On turn end, briefly show past-tense result before hiding:
+
+```
+✻ Quantumized for 1m 33s
+```
+
+- Displayed for 2.5s with a fade-out transition
+- Past tense stored as verb pairs `[gerund, pastTense]` (e.g. `["Quantumizing", "Quantumized"]`), not derived by suffix rules — too many irregular forms (Beboppin' → Bebopped, Dilly-dallying → Dilly-dallied, etc.)
+- After fade-out, `phase` transitions to `"idle"` and store fields are cleared
+
+### Render isolation
+
+`useQueryStatus()` re-renders 10x/sec (100ms interval). To avoid re-rendering the entire `<MessageInput>` tree:
+
+- `<MessageInput>` only decides whether to mount `<QueryStatus>` based on chat status (cheap, already available)
+- `<QueryStatus>` calls `useQueryStatus()` internally — all timer/spinner re-renders are isolated to this component
+- The parent never subscribes to the high-frequency hook
+
+### Placement
+
+Rendered inside `message-input.tsx`, between the message list and the input border container. Mounted when `status !== "ready"` or during the completion flash timeout.
+
+## Verbs list (140+)
+
+Full set from Claude Code CLI, stored as `[gerund, pastTense]` pairs:
+
+```typescript
+const VERBS: [string, string][] = [
+  ["Accomplishing", "Accomplished"],
+  ["Actioning", "Actioned"],
+  ["Actualizing", "Actualized"],
+  ["Architecting", "Architected"],
+  ["Baking", "Baked"],
+  ["Beaming", "Beamed"],
+  ["Beboppin'", "Bebopped"],
+  ["Befuddling", "Befuddled"],
+  ["Billowing", "Billowed"],
+  // ... (140+ pairs total, full list in query-status.tsx)
+];
+```
+
+## Spinner animation
+
+- Frames: `["·", "✢", "✳", "✶", "✻", "✽"]`
+- Ping-pong: forward then reverse → `["·", "✢", "✳", "✶", "✻", "✽", "✻", "✶", "✳", "✢"]`
+- ~200ms per frame (advance every 2 ticks of the 100ms interval)
+
+## Timer formatting
+
+```typescript
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m ${s % 60}s`;
+}
+```
+
+Show immediately from 0s (no threshold).

--- a/packages/desktop/src/renderer/src/features/agent/chat-state.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-state.ts
@@ -28,6 +28,12 @@ export interface ClaudeCodeChatStoreState {
   }>;
   capabilities: ClaudeCodeChatCapabilities | null;
   pendingContextClear?: PendingContextClear;
+
+  // Query status timing
+  turnStartedAt: number | null;
+  thinkingStartedAt: number | null;
+  thinkingDuration: number | null;
+  lastChunkAt: number | null;
 }
 
 export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
@@ -41,6 +47,10 @@ export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
       eventError: undefined,
       pendingRequests: [],
       capabilities: null,
+      turnStartedAt: null,
+      thinkingStartedAt: null,
+      thinkingDuration: null,
+      lastChunkAt: null,
     }));
   }
 
@@ -57,7 +67,18 @@ export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
   }
 
   set status(status: ChatStatus) {
-    this.store.setState({ status });
+    const prev = this.store.getState().status;
+    if ((status === "submitted" || status === "streaming") && prev === "ready") {
+      this.store.setState({
+        status,
+        turnStartedAt: Date.now(),
+        thinkingStartedAt: null,
+        thinkingDuration: null,
+        lastChunkAt: Date.now(),
+      });
+    } else {
+      this.store.setState({ status });
+    }
   }
 
   get error() {
@@ -69,7 +90,21 @@ export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
   }
 
   pushMessage = (message: ClaudeCodeUIMessage) => {
-    this.store.setState((state) => ({ messages: state.messages.concat(this.snapshot(message)) }));
+    const now = Date.now();
+    const state = this.store.getState();
+    const timingUpdate: Partial<ClaudeCodeChatStoreState> = { lastChunkAt: now };
+
+    // If thinking was active when a new message starts, accumulate duration
+    if (state.thinkingStartedAt) {
+      timingUpdate.thinkingDuration =
+        (state.thinkingDuration ?? 0) + (now - state.thinkingStartedAt);
+      timingUpdate.thinkingStartedAt = null;
+    }
+
+    this.store.setState((s) => ({
+      ...timingUpdate,
+      messages: s.messages.concat(this.snapshot(message)),
+    }));
   };
 
   popMessage = () => {
@@ -77,11 +112,31 @@ export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
   };
 
   replaceMessage = (index: number, message: ClaudeCodeUIMessage) => {
-    this.store.setState((state) => ({
+    const now = Date.now();
+    const state = this.store.getState();
+    const lastPart = message.parts[message.parts.length - 1];
+    const isReasoning = lastPart?.type === "reasoning";
+
+    const timingUpdate: Partial<ClaudeCodeChatStoreState> = {};
+
+    if (isReasoning && !state.thinkingStartedAt) {
+      timingUpdate.thinkingStartedAt = now;
+    } else if (!isReasoning && state.thinkingStartedAt) {
+      timingUpdate.thinkingDuration =
+        (state.thinkingDuration ?? 0) + (now - state.thinkingStartedAt);
+      timingUpdate.thinkingStartedAt = null;
+    }
+
+    if (!isReasoning) {
+      timingUpdate.lastChunkAt = now;
+    }
+
+    this.store.setState((s) => ({
+      ...timingUpdate,
       messages: [
-        ...state.messages.slice(0, index),
+        ...s.messages.slice(0, index),
         this.snapshot(message),
-        ...state.messages.slice(index + 1),
+        ...s.messages.slice(index + 1),
       ],
     }));
   };

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -21,6 +21,7 @@ import { AttachmentPreview } from "./attachment-preview";
 import { createImagePasteExtension } from "./image-paste-extension";
 import { InputToolbar } from "./input-toolbar";
 import { createMentionExtension } from "./mention-extension";
+import { QueryStatus } from "./query-status";
 import { createSlashCommandsExtension } from "./slash-commands-extension";
 
 const log = debug("neovate:message-input");
@@ -247,6 +248,7 @@ export function MessageInput({
 
   return (
     <div className={cn("p-4", dockAttached ? "px-4 pb-4 pt-0" : "border-t border-border")}>
+      {activeSessionId && <QueryStatus sessionId={activeSessionId} />}
       <input
         ref={fileInputRef}
         type="file"

--- a/packages/desktop/src/renderer/src/features/agent/components/query-status.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/query-status.tsx
@@ -1,0 +1,256 @@
+import { cn } from "../../../lib/utils";
+import { useQueryStatus } from "../hooks/use-query-status";
+
+// [gerund, pastTense] pairs — full set from Claude Code CLI
+export const VERBS: [string, string][] = [
+  ["Accomplishing", "Accomplished"],
+  ["Actioning", "Actioned"],
+  ["Actualizing", "Actualized"],
+  ["Architecting", "Architected"],
+  ["Baking", "Baked"],
+  ["Beaming", "Beamed"],
+  ["Beboppin'", "Bebopped"],
+  ["Befuddling", "Befuddled"],
+  ["Billowing", "Billowed"],
+  ["Blanching", "Blanched"],
+  ["Bloviating", "Bloviated"],
+  ["Boogieing", "Boogied"],
+  ["Boondoggling", "Boondoggled"],
+  ["Booping", "Booped"],
+  ["Bootstrapping", "Bootstrapped"],
+  ["Brewing", "Brewed"],
+  ["Bunning", "Bunned"],
+  ["Burrowing", "Burrowed"],
+  ["Calculating", "Calculated"],
+  ["Canoodling", "Canoodled"],
+  ["Caramelizing", "Caramelized"],
+  ["Cascading", "Cascaded"],
+  ["Catapulting", "Catapulted"],
+  ["Cerebrating", "Cerebrated"],
+  ["Channeling", "Channeled"],
+  ["Channelling", "Channelled"],
+  ["Choreographing", "Choreographed"],
+  ["Churning", "Churned"],
+  ["Clauding", "Clauded"],
+  ["Coalescing", "Coalesced"],
+  ["Cogitating", "Cogitated"],
+  ["Combobulating", "Combobulated"],
+  ["Composing", "Composed"],
+  ["Computing", "Computed"],
+  ["Concocting", "Concocted"],
+  ["Considering", "Considered"],
+  ["Contemplating", "Contemplated"],
+  ["Cooking", "Cooked"],
+  ["Crafting", "Crafted"],
+  ["Creating", "Created"],
+  ["Crunching", "Crunched"],
+  ["Crystallizing", "Crystallized"],
+  ["Cultivating", "Cultivated"],
+  ["Deciphering", "Deciphered"],
+  ["Deliberating", "Deliberated"],
+  ["Determining", "Determined"],
+  ["Dilly-dallying", "Dilly-dallied"],
+  ["Discombobulating", "Discombobulated"],
+  ["Doing", "Done"],
+  ["Doodling", "Doodled"],
+  ["Drizzling", "Drizzled"],
+  ["Ebbing", "Ebbed"],
+  ["Effecting", "Effected"],
+  ["Elucidating", "Elucidated"],
+  ["Embellishing", "Embellished"],
+  ["Enchanting", "Enchanted"],
+  ["Envisioning", "Envisioned"],
+  ["Evaporating", "Evaporated"],
+  ["Fermenting", "Fermented"],
+  ["Fiddle-faddling", "Fiddle-faddled"],
+  ["Finagling", "Finagled"],
+  ["Flambéing", "Flambéed"],
+  ["Flibbertigibbeting", "Flibbertigibbeted"],
+  ["Flowing", "Flowed"],
+  ["Flummoxing", "Flummoxed"],
+  ["Fluttering", "Fluttered"],
+  ["Forging", "Forged"],
+  ["Forming", "Formed"],
+  ["Frolicking", "Frolicked"],
+  ["Frosting", "Frosted"],
+  ["Gallivanting", "Gallivanted"],
+  ["Galloping", "Galloped"],
+  ["Garnishing", "Garnished"],
+  ["Generating", "Generated"],
+  ["Gesticulating", "Gesticulated"],
+  ["Germinating", "Germinated"],
+  ["Gitifying", "Gitified"],
+  ["Grooving", "Grooved"],
+  ["Gusting", "Gusted"],
+  ["Harmonizing", "Harmonized"],
+  ["Hashing", "Hashed"],
+  ["Hatching", "Hatched"],
+  ["Herding", "Herded"],
+  ["Honking", "Honked"],
+  ["Hullaballooing", "Hullaballooed"],
+  ["Hyperspacing", "Hyperspaced"],
+  ["Ideating", "Ideated"],
+  ["Imagining", "Imagined"],
+  ["Improvising", "Improvised"],
+  ["Incubating", "Incubated"],
+  ["Inferring", "Inferred"],
+  ["Infusing", "Infused"],
+  ["Ionizing", "Ionized"],
+  ["Jitterbugging", "Jitterbugged"],
+  ["Julienning", "Julienned"],
+  ["Kneading", "Kneaded"],
+  ["Leavening", "Leavened"],
+  ["Levitating", "Levitated"],
+  ["Lollygagging", "Lollygagged"],
+  ["Manifesting", "Manifested"],
+  ["Marinating", "Marinated"],
+  ["Meandering", "Meandered"],
+  ["Metamorphosing", "Metamorphosed"],
+  ["Misting", "Misted"],
+  ["Moonwalking", "Moonwalked"],
+  ["Moseying", "Moseyed"],
+  ["Mulling", "Mulled"],
+  ["Mustering", "Mustered"],
+  ["Musing", "Mused"],
+  ["Nebulizing", "Nebulized"],
+  ["Nesting", "Nested"],
+  ["Newspapering", "Newspapered"],
+  ["Noodling", "Noodled"],
+  ["Nucleating", "Nucleated"],
+  ["Orbiting", "Orbited"],
+  ["Orchestrating", "Orchestrated"],
+  ["Osmosing", "Osmosed"],
+  ["Perambulating", "Perambulated"],
+  ["Percolating", "Percolated"],
+  ["Perusing", "Perused"],
+  ["Philosophising", "Philosophised"],
+  ["Photosynthesizing", "Photosynthesized"],
+  ["Pollinating", "Pollinated"],
+  ["Pondering", "Pondered"],
+  ["Pontificating", "Pontificated"],
+  ["Pouncing", "Pounced"],
+  ["Precipitating", "Precipitated"],
+  ["Prestidigitating", "Prestidigitated"],
+  ["Processing", "Processed"],
+  ["Proofing", "Proofed"],
+  ["Propagating", "Propagated"],
+  ["Puttering", "Puttered"],
+  ["Puzzling", "Puzzled"],
+  ["Quantumizing", "Quantumized"],
+  ["Razzle-dazzling", "Razzle-dazzled"],
+  ["Razzmatazzing", "Razzmatazzed"],
+  ["Recombobulating", "Recombobulated"],
+  ["Reticulating", "Reticulated"],
+  ["Roosting", "Roosted"],
+  ["Ruminating", "Ruminated"],
+  ["Sautéing", "Sautéed"],
+  ["Scampering", "Scampered"],
+  ["Schlepping", "Schlepped"],
+  ["Scurrying", "Scurried"],
+  ["Seasoning", "Seasoned"],
+  ["Shenaniganing", "Shenaniganed"],
+  ["Shimmying", "Shimmied"],
+  ["Simmering", "Simmered"],
+  ["Skedaddling", "Skedaddled"],
+  ["Sketching", "Sketched"],
+  ["Slithering", "Slithered"],
+  ["Smooshing", "Smooshed"],
+  ["Sock-hopping", "Sock-hopped"],
+  ["Spelunking", "Spelunked"],
+  ["Spinning", "Spun"],
+  ["Sprouting", "Sprouted"],
+  ["Stewing", "Stewed"],
+  ["Sublimating", "Sublimated"],
+  ["Swirling", "Swirled"],
+  ["Swooping", "Swooped"],
+  ["Symbioting", "Symbioted"],
+  ["Synthesizing", "Synthesized"],
+  ["Tempering", "Tempered"],
+  ["Thinking", "Thought"],
+  ["Thundering", "Thundered"],
+  ["Tinkering", "Tinkered"],
+  ["Tomfoolering", "Tomfoolered"],
+  ["Topsy-turvying", "Topsy-turvied"],
+  ["Transfiguring", "Transfigured"],
+  ["Transmuting", "Transmuted"],
+  ["Twisting", "Twisted"],
+  ["Undulating", "Undulated"],
+  ["Unfurling", "Unfurled"],
+  ["Unravelling", "Unravelled"],
+  ["Vibing", "Vibed"],
+  ["Waddling", "Waddled"],
+  ["Wandering", "Wandered"],
+  ["Warping", "Warped"],
+  ["Whatchamacalliting", "Whatchamacallited"],
+  ["Whirlpooling", "Whirlpooled"],
+  ["Whirring", "Whirred"],
+  ["Whisking", "Whisked"],
+  ["Wibbling", "Wibbled"],
+  ["Working", "Worked"],
+  ["Wrangling", "Wrangled"],
+  ["Zesting", "Zested"],
+  ["Zigzagging", "Zigzagged"],
+];
+
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m ${s % 60}s`;
+}
+
+function formatThinkingDuration(ms: number): string {
+  return `${Math.max(1, Math.round(ms / 1000))}s`;
+}
+
+export function QueryStatus({ sessionId }: { sessionId: string }) {
+  const status = useQueryStatus(sessionId);
+
+  if (status.phase === "idle") return null;
+
+  const isCompleting = status.phase === "completing";
+
+  // Build the detail parts inside parentheses
+  const details: string[] = [];
+  details.push(formatElapsed(status.elapsedMs));
+  if (status.isThinking) {
+    // will be rendered separately with animation
+  } else if (status.thinkingDurationMs !== null && status.thinkingDurationMs > 0) {
+    details.push(`thought for ${formatThinkingDuration(status.thinkingDurationMs)}`);
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 px-3 py-1 text-xs transition-opacity duration-300",
+        isCompleting ? "opacity-0" : "opacity-100",
+      )}
+    >
+      <span
+        className={cn(
+          "font-mono",
+          status.isStalled ? "text-destructive/60" : "text-muted-foreground",
+        )}
+      >
+        {status.spinnerFrame}
+      </span>
+      <span className="text-muted-foreground">
+        {isCompleting ? (
+          <>
+            {status.pastVerb} for {formatElapsed(status.elapsedMs)}
+          </>
+        ) : (
+          <>
+            {status.verb}…{" "}
+            <span className="text-muted-foreground/70">
+              ({details.join(" · ")}
+              {status.isThinking && <span className="animate-pulse"> · thinking…</span>})
+            </span>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-query-status.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-query-status.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+
+import { claudeCodeChatManager } from "../chat-manager";
+import { VERBS } from "../components/query-status";
+
+const SPINNER_FRAMES = ["·", "✢", "✳", "✶", "✻", "✽"];
+const PING_PONG = [...SPINNER_FRAMES, ...SPINNER_FRAMES.slice(1, -1).reverse()];
+const STALL_THRESHOLD_MS = 3_000;
+const COMPLETION_FLASH_MS = 2_500;
+const TICK_MS = 100;
+const FRAMES_PER_TICK = 2; // advance spinner every 2 ticks (~200ms)
+
+export type QueryStatusPhase = "idle" | "active" | "completing";
+
+export interface QueryStatus {
+  phase: QueryStatusPhase;
+  verb: string;
+  pastVerb: string;
+  elapsedMs: number;
+  thinkingDurationMs: number | null;
+  isThinking: boolean;
+  isStalled: boolean;
+  spinnerFrame: string;
+}
+
+const IDLE: QueryStatus = {
+  phase: "idle",
+  verb: "",
+  pastVerb: "",
+  elapsedMs: 0,
+  thinkingDurationMs: null,
+  isThinking: false,
+  isStalled: false,
+  spinnerFrame: SPINNER_FRAMES[0],
+};
+
+function pickVerb(): [string, string] {
+  return VERBS[Math.floor(Math.random() * VERBS.length)];
+}
+
+const noop = () => () => {};
+
+export function useQueryStatus(sessionId: string | null): QueryStatus {
+  const chat = sessionId ? claudeCodeChatManager.getChat(sessionId) : undefined;
+
+  const subscribe = useCallback(
+    (cb: () => void) => (chat ? chat.store.subscribe(cb) : noop()),
+    [chat],
+  );
+
+  const chatStatus = useSyncExternalStore(
+    subscribe,
+    () => chat?.store.getState().status ?? "ready",
+  );
+
+  const isActive = chatStatus === "submitted" || chatStatus === "streaming";
+
+  const verbRef = useRef<[string, string]>(pickVerb());
+  const [tick, setTick] = useState(0);
+  const [phase, setPhase] = useState<QueryStatusPhase>("idle");
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevActiveRef = useRef(false);
+
+  // Detect turn start/end transitions
+  useEffect(() => {
+    if (isActive && !prevActiveRef.current) {
+      // Turn just started
+      verbRef.current = pickVerb();
+      setPhase("active");
+      setTick(0);
+      if (flashTimerRef.current) {
+        clearTimeout(flashTimerRef.current);
+        flashTimerRef.current = null;
+      }
+    } else if (!isActive && prevActiveRef.current) {
+      // Turn just ended — start completion flash
+      setPhase("completing");
+      flashTimerRef.current = setTimeout(() => {
+        setPhase("idle");
+        // Clear store timing fields
+        chat?.store.setState({
+          turnStartedAt: null,
+          thinkingStartedAt: null,
+          thinkingDuration: null,
+          lastChunkAt: null,
+        });
+      }, COMPLETION_FLASH_MS);
+    }
+    prevActiveRef.current = isActive;
+  }, [isActive, chat]);
+
+  // Tick interval for elapsed time + spinner animation
+  useEffect(() => {
+    if (phase !== "active") return;
+    const id = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(id);
+  }, [phase]);
+
+  // Cleanup flash timer on unmount
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
+
+  if (phase === "idle") return IDLE;
+
+  const state = chat?.store.getState();
+  const turnStartedAt = state?.turnStartedAt ?? 0;
+  const thinkingStartedAt = state?.thinkingStartedAt ?? null;
+  const thinkingDuration = state?.thinkingDuration ?? null;
+  const lastChunkAt = state?.lastChunkAt ?? null;
+  const now = Date.now();
+
+  const elapsedMs = turnStartedAt ? now - turnStartedAt : 0;
+  const isThinking = thinkingStartedAt !== null;
+  const isStalled =
+    !isThinking &&
+    phase === "active" &&
+    lastChunkAt !== null &&
+    now - lastChunkAt > STALL_THRESHOLD_MS;
+
+  // Accumulate current thinking block duration if still thinking
+  let thinkingDurationMs = thinkingDuration;
+  if (isThinking && thinkingStartedAt) {
+    thinkingDurationMs = (thinkingDuration ?? 0) + (now - thinkingStartedAt);
+  }
+
+  const frameIndex = Math.floor(tick / FRAMES_PER_TICK) % PING_PONG.length;
+
+  return {
+    phase,
+    verb: verbRef.current[0],
+    pastVerb: verbRef.current[1],
+    elapsedMs,
+    thinkingDurationMs,
+    isThinking,
+    isStalled,
+    spinnerFrame: PING_PONG[frameIndex],
+  };
+}


### PR DESCRIPTION
Added a Claude Code-style loading indicator above the message input that displays during active queries. Includes an animated spinner, random fun verbs, elapsed time tracking, and extended thinking duration display. New components include useQueryStatus hook and QueryStatus component with 140+ verb pairs.