### PR TITLE
feat: add message rewind functionality for agent conversations

### DIFF
--- a/docs/design/2026-03-13-message-rewind.md
+++ b/docs/design/2026-03-13-message-rewind.md
@@ -1,0 +1,161 @@
+# Message Rewind (Conversation + File)
+
+## Overview
+
+Allow users to rewind conversation and code to any previous user message. A rewind icon appears below each user message on hover. Clicking it opens a popover with restore options. Aligned with Claude Code's rewind behavior.
+
+## UX Flow
+
+1. User hovers over a user message block, a rewind icon fades in below the message bubble (hidden by default, visible on hover via opacity transition)
+2. User clicks the rewind icon
+3. Popover opens, immediately showing "Restore conversation only" option
+4. In parallel, a dry-run call fetches file change info (spinner while loading)
+5. Once loaded, "Restore code and conversation" option appears with summary (e.g. "3 files changed +42 -17")
+6. User picks an option
+7. Rewind executes, messages are removed, input box is pre-filled with the rewound message's text content (images/attachments are dropped — only text is restored)
+8. Toast appears: "Conversation rewound - Undo" with ~10s timeout
+
+## Restore Options (popover)
+
+- **Restore code and conversation** - rewind files via SDK + truncate messages (only shown when file changes exist)
+- **Restore conversation only** - truncate messages, leave files as-is
+
+"Restore code only" is intentionally excluded — it creates a confusing state where messages reference code changes that no longer exist.
+
+## Constraints
+
+- **Disabled during streaming** - rewind buttons are disabled while the agent is actively streaming a response
+- **Abort before rewind** - if the agent has a queued/in-progress turn (e.g. waiting for tool permission), abort it before rewinding
+- **Undo safety net** - removed messages stored in temporary `rewindUndoBuffer` in the Zustand store; toast with "Undo" option for ~10s; buffer cleared after timeout or on next user action
+- **Double rewind** - if user rewinds again before the undo toast expires, dismiss the previous toast, discard the old undo buffer, and replace with the new one (accept data loss — user is intentionally rewinding further)
+- **Clear on session switch** - clear `rewindUndoBuffer` and dismiss undo toast when user switches to a different session tab
+- **Non-text content** - when pre-filling input after rewind, only restore text content; images and file attachments are dropped (not re-inserted into the editor)
+
+## Data Flow
+
+```
+User clicks rewind icon on message X
+  |
+  v
+Frontend calls backend: rewindFilesDryRun(sessionId, messageId)
+  -> SDK rewindFiles(messageId, {dryRun: true})
+  -> Returns { canRewind, filesChanged, insertions, deletions }
+  |
+  v
+Popover renders options:
+  - "Restore conversation only" (always available, shown immediately)
+  - "Restore code and conversation" (shown after dry-run, only if canRewind && filesChanged.length > 0)
+  |
+  v
+User picks an option
+  |
+  v
+If file restore selected:
+  Frontend calls backend: rewindFiles(sessionId, messageId)
+  -> SDK rewindFiles(messageId, {dryRun: false})
+  |
+  v
+Conversation restore (always):
+  1. Abort any in-progress agent turn
+  2. If rewindUndoBuffer exists, dismiss previous undo toast and discard old buffer
+  3. Store removed messages in rewindUndoBuffer
+  4. Slice messages array: remove messageX and everything after it
+  5. Pre-fill input box with messageX text content only (drop images/attachments)
+  6. Show undo toast (~10s timeout)
+  |
+  v
+Done
+```
+
+## Contract Changes (shared/features/agent/contract.ts)
+
+Add two methods to the agent router:
+
+```typescript
+rewindFilesDryRun: {
+  input: {
+    sessionId: string;
+    messageId: string;
+  }
+  output: RewindFilesResult; // { canRewind, filesChanged?, insertions?, deletions?, error? }
+}
+
+rewindFiles: {
+  input: {
+    sessionId: string;
+    messageId: string;
+  }
+  output: RewindFilesResult;
+}
+```
+
+Reuse existing `RewindFilesResult` type from the review plugin.
+
+## Backend Changes (main/features/agent/session-manager.ts)
+
+Two new handlers delegating to the SDK:
+
+- `rewindFilesDryRun` -> `session.query.rewindFiles(messageId, { dryRun: true })`
+- `rewindFiles` -> `session.query.rewindFiles(messageId, { dryRun: false })`
+
+## Frontend Store Changes (renderer/src/features/agent/store.ts)
+
+New state and actions:
+
+```typescript
+// State
+rewindUndoBuffer: { sessionId: string; messages: ChatMessage[] } | null
+
+// Actions
+rewindToMessage(sessionId: string, messageId: string): void
+  // 1. Find message index
+  // 2. Store messages[index..] in rewindUndoBuffer
+  // 3. Slice messages to messages[0..index]
+  // 4. Return the rewound message content for input pre-fill
+
+undoRewind(): void
+  // Restore messages from rewindUndoBuffer, clear buffer
+
+clearRewindBuffer(): void
+  // Called on timeout or next user action
+```
+
+## UI Changes
+
+### New component: MessageRewindButton
+
+Rendered below each user message in message-parts.tsx.
+
+- Rewind icon (RotateCcw from lucide-react)
+- Hidden by default, fades in on hover of the parent message block (opacity-0 -> opacity-100 transition)
+- Click opens Radix Popover with restore options
+- Calls dry-run on popover open to populate file change summary
+- Shows spinner while dry-run is loading
+- Disabled when agent is streaming
+
+### Modified: agent-chat.tsx / message input
+
+- After rewind, pre-fill input with rewound message's text content only (drop images/attachments)
+- On next user message submission, clear rewindUndoBuffer
+- On session switch, clear rewindUndoBuffer and dismiss undo toast
+
+### New: Undo toast
+
+- Shown after rewind with "Undo" action button
+- ~10s auto-dismiss timeout
+- Clicking "Undo" calls undoRewind() and dismisses toast
+
+## Persistence
+
+No `.jsonl` modifications. The SDK handles message continuity naturally when the next message is sent from the rewound point.
+
+## Files to Modify
+
+| File                                                            | Change                                            |
+| --------------------------------------------------------------- | ------------------------------------------------- |
+| `shared/features/agent/contract.ts`                             | Add rewindFilesDryRun, rewindFiles methods        |
+| `main/features/agent/session-manager.ts`                        | Implement the two new handlers                    |
+| `renderer/src/features/agent/store.ts`                          | Add rewindToMessage, undoRewind, rewindUndoBuffer |
+| `renderer/src/features/agent/components/message-parts.tsx`      | Render MessageRewindButton below user messages    |
+| `renderer/src/features/agent/components/agent-chat.tsx`         | Pre-fill input on rewind, clear buffer on submit  |
+| `renderer/src/components/ai-elements/message-rewind-button.tsx` | New component: icon + popover                     |

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -97,6 +97,16 @@ export const agentRouter = os.agent.router({
     return { path: filePath };
   }),
 
+  rewindFilesDryRun: os.agent.rewindFilesDryRun.handler(async ({ input, context }) => {
+    agentLog("rewindFilesDryRun: sessionId=%s messageId=%s", input.sessionId, input.messageId);
+    return context.sessionManager.rewindFilesDryRun(input.sessionId, input.messageId);
+  }),
+
+  rewindFiles: os.agent.rewindFiles.handler(async ({ input, context }) => {
+    agentLog("rewindFiles: sessionId=%s messageId=%s", input.sessionId, input.messageId);
+    return context.sessionManager.rewindFiles(input.sessionId, input.messageId);
+  }),
+
   setModelSetting: os.agent.setModelSetting.handler(({ input, context }) => {
     const { sessionId, model, scope } = input;
     const cwd = context.sessionManager.getSessionCwd(sessionId);

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -534,6 +534,34 @@ export class SessionManager {
     }
   }
 
+  /** Dry-run rewind: preview file changes for a given user message. */
+  async rewindFilesDryRun(sessionId: string, messageId: string): Promise<RewindFilesResult> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown session: ${sessionId}`);
+    try {
+      return await session.query.rewindFiles(messageId, { dryRun: true });
+    } catch (error) {
+      return {
+        canRewind: false,
+        error: error instanceof Error ? error.message : "Failed to preview rewind",
+      };
+    }
+  }
+
+  /** Rewind files to the state before a given user message. */
+  async rewindFiles(sessionId: string, messageId: string): Promise<RewindFilesResult> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown session: ${sessionId}`);
+    try {
+      return await session.query.rewindFiles(messageId, { dryRun: false });
+    } catch (error) {
+      return {
+        canRewind: false,
+        error: error instanceof Error ? error.message : "Failed to rewind files",
+      };
+    }
+  }
+
   /** Get the diff for a single file changed in the last agent turn. */
   async lastTurnDiff(
     sessionId: string,

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -181,6 +181,7 @@ function AgentChatSession({
       text.length,
       attachments?.length ?? 0,
     );
+    useAgentStore.getState().clearRewindBuffer();
     const files = attachmentsToFileParts(attachments);
     sendMessage({
       text,
@@ -199,7 +200,12 @@ function AgentChatSession({
       <Conversation>
         <ConversationContent>
           {messages.map((message) => (
-            <MessageParts key={message.id} message={message} />
+            <MessageParts
+              key={message.id}
+              message={message}
+              sessionId={sessionId}
+              streaming={status === "streaming"}
+            />
           ))}
         </ConversationContent>
         <ConversationScrollButton />

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -232,6 +232,19 @@ export function MessageInput({
     return () => window.removeEventListener("neovate:insert-mention", handler);
   }, [editor]);
 
+  // Listen for rewind pre-fill events
+  useEffect(() => {
+    if (!editor) return;
+    const handler = (e: Event) => {
+      const { text } = (e as CustomEvent<{ text: string }>).detail;
+      log("rewind-prefill received len=%d", text.length);
+      editor.commands.clearContent();
+      editor.chain().focus().insertContent(text).run();
+    };
+    window.addEventListener("neovate:rewind-prefill", handler);
+    return () => window.removeEventListener("neovate:rewind-prefill", handler);
+  }, [editor]);
+
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;

--- a/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-parts.tsx
@@ -8,9 +8,18 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from "../../../components/ai-elements/reasoning";
+import { MessageRewindButton } from "./message-rewind-button";
 import { ClaudeCodeToolUIPart } from "./tool-parts";
 
-export function MessageParts({ message }: { message: ClaudeCodeUIMessage }) {
+export function MessageParts({
+  message,
+  sessionId,
+  streaming,
+}: {
+  message: ClaudeCodeUIMessage;
+  sessionId?: string;
+  streaming?: boolean;
+}) {
   return (
     <>
       {message.parts.map((part, index) => {
@@ -40,6 +49,15 @@ export function MessageParts({ message }: { message: ClaudeCodeUIMessage }) {
                     <p>{part.text}</p>
                   )}
                 </MessageContent>
+                {message.role === "user" && sessionId && (
+                  <div className="mt-1 flex justify-end">
+                    <MessageRewindButton
+                      sessionId={sessionId}
+                      messageId={message.id}
+                      disabled={streaming}
+                    />
+                  </div>
+                )}
               </Message>
             );
           case "reasoning":

--- a/packages/desktop/src/renderer/src/features/agent/components/message-rewind-button.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-rewind-button.tsx
@@ -1,0 +1,184 @@
+import { RotateCcwIcon, LoaderCircleIcon } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+import type { ClaudeCodeUIMessage } from "../../../../../shared/claude-code/types";
+import type { RewindFilesResult } from "../../../../../shared/features/agent/types";
+
+import { Button } from "../../../components/ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../../../components/ui/popover";
+import { toastManager } from "../../../components/ui/toast";
+import { client } from "../../../orpc";
+import { claudeCodeChatManager } from "../chat-manager";
+import { useAgentStore } from "../store";
+
+interface MessageRewindButtonProps {
+  sessionId: string;
+  messageId: string;
+  disabled?: boolean;
+}
+
+/** Saved chat-state messages for undo, kept outside React to survive re-renders. */
+let savedChatMessages: ClaudeCodeUIMessage[] | null = null;
+
+export function MessageRewindButton({ sessionId, messageId, disabled }: MessageRewindButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [dryRunResult, setDryRunResult] = useState<RewindFilesResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [executing, setExecuting] = useState(false);
+  const prevToastIdRef = useRef<string | null>(null);
+
+  const handleOpen = useCallback(
+    async (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        setDryRunResult(null);
+        return;
+      }
+      setLoading(true);
+      try {
+        const result = await client.agent.rewindFilesDryRun({ sessionId, messageId });
+        setDryRunResult(result);
+      } catch {
+        setDryRunResult({ canRewind: false, error: "Failed to check file changes" });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [sessionId, messageId],
+  );
+
+  const executeRewind = useCallback(
+    async (restoreFiles: boolean) => {
+      setExecuting(true);
+      try {
+        const chat = claudeCodeChatManager.getChat(sessionId);
+
+        // Interrupt any in-progress agent turn
+        const status = chat?.store.getState().status;
+        if (status === "streaming" || status === "submitted") {
+          await chat?.interrupt();
+        }
+
+        // Dismiss previous undo toast if double-rewinding
+        if (prevToastIdRef.current) {
+          toastManager.close(prevToastIdRef.current);
+          prevToastIdRef.current = null;
+          useAgentStore.getState().clearRewindBuffer();
+          savedChatMessages = null;
+        }
+
+        // Rewind files if requested
+        if (restoreFiles) {
+          await client.agent.rewindFiles({ sessionId, messageId });
+        }
+
+        // Save per-session chat messages for undo before slicing
+        if (chat) {
+          const chatMessages = chat.store.getState().messages;
+          const chatIndex = chatMessages.findIndex((m) => m.id === messageId);
+          if (chatIndex !== -1) {
+            savedChatMessages = chatMessages.slice(chatIndex);
+            chat.store.setState({ messages: chatMessages.slice(0, chatIndex) });
+          }
+        }
+
+        // Rewind conversation in agent store
+        const rewoundContent = useAgentStore.getState().rewindToMessage(sessionId, messageId);
+
+        // Pre-fill input with rewound message text
+        if (rewoundContent) {
+          window.dispatchEvent(
+            new CustomEvent("neovate:rewind-prefill", { detail: { text: rewoundContent } }),
+          );
+        }
+
+        // Show undo toast
+        const toastId = toastManager.add({
+          type: "info",
+          title: "Conversation rewound",
+          actionProps: {
+            children: "Undo",
+            onClick: () => {
+              // Restore agent store messages
+              useAgentStore.getState().undoRewind();
+              // Restore per-session chat state messages
+              if (savedChatMessages && chat) {
+                chat.store.setState((s) => ({
+                  messages: [...s.messages, ...savedChatMessages!],
+                }));
+                savedChatMessages = null;
+              }
+              prevToastIdRef.current = null;
+              toastManager.close(toastId);
+            },
+          },
+          timeout: 10_000,
+          onClose: () => {
+            useAgentStore.getState().clearRewindBuffer();
+            savedChatMessages = null;
+            prevToastIdRef.current = null;
+          },
+        });
+        prevToastIdRef.current = toastId;
+      } finally {
+        setExecuting(false);
+        setOpen(false);
+      }
+    },
+    [sessionId, messageId],
+  );
+
+  const hasFileChanges =
+    dryRunResult?.canRewind && dryRunResult.filesChanged && dryRunResult.filesChanged.length > 0;
+
+  return (
+    <Popover open={open} onOpenChange={handleOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            disabled={disabled || executing}
+            className="opacity-0 group-hover:opacity-100 transition-opacity h-6 w-6 text-muted-foreground hover:text-foreground"
+          />
+        }
+      >
+        <RotateCcwIcon size={14} />
+        <span className="sr-only">Rewind to this message</span>
+      </PopoverTrigger>
+      <PopoverPopup side="bottom" align="start" sideOffset={4} className="w-64 !py-2 !px-0">
+        <div className="flex flex-col">
+          <button
+            type="button"
+            className="flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-muted/50 transition-colors disabled:opacity-50"
+            onClick={() => executeRewind(false)}
+            disabled={executing}
+          >
+            Restore conversation only
+          </button>
+          {loading ? (
+            <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+              <LoaderCircleIcon size={14} className="animate-spin" />
+              Checking file changes...
+            </div>
+          ) : hasFileChanges ? (
+            <button
+              type="button"
+              className="flex flex-col gap-0.5 px-3 py-2 text-sm text-left hover:bg-muted/50 transition-colors disabled:opacity-50"
+              onClick={() => executeRewind(true)}
+              disabled={executing}
+            >
+              <span>Restore code and conversation</span>
+              <span className="text-xs text-muted-foreground">
+                {dryRunResult!.filesChanged!.length} file
+                {dryRunResult!.filesChanged!.length !== 1 ? "s" : ""} changed
+                {dryRunResult!.insertions != null && ` +${dryRunResult!.insertions}`}
+                {dryRunResult!.deletions != null && ` -${dryRunResult!.deletions}`}
+              </span>
+            </button>
+          ) : null}
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -69,11 +69,17 @@ export type ChatSession = {
 
 export type TurnResult = "success" | "error";
 
+export type RewindUndoBuffer = {
+  sessionId: string;
+  messages: ChatMessage[];
+};
+
 type AgentState = {
   sessions: Map<string, ChatSession>;
   activeSessionId: string | null;
   agentSessions: SessionInfo[];
   unseenTurnResults: Map<string, TurnResult>;
+  rewindUndoBuffer: RewindUndoBuffer | null;
   _nextMessageId: number;
 
   setActiveSession: (sessionId: string | null) => void;
@@ -90,6 +96,9 @@ type AgentState = {
   ) => void;
   removeSession: (sessionId: string) => void;
   addUserMessage: (sessionId: string, content: string) => void;
+  rewindToMessage: (sessionId: string, messageId: string) => string | undefined;
+  undoRewind: () => void;
+  clearRewindBuffer: () => void;
   setAvailableCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
   setAvailableModels: (sessionId: string, models: ModelInfo[]) => void;
   setCurrentModel: (sessionId: string, model: string) => void;
@@ -105,6 +114,7 @@ export const useAgentStore = create<AgentState>()(
     activeSessionId: null,
     agentSessions: [],
     unseenTurnResults: new Map(),
+    rewindUndoBuffer: null,
     _nextMessageId: 0,
 
     setActiveSession: (sessionId) => {
@@ -112,6 +122,7 @@ export const useAgentStore = create<AgentState>()(
       set((state) => {
         state.activeSessionId = sessionId;
         if (sessionId) state.unseenTurnResults.delete(sessionId);
+        state.rewindUndoBuffer = null;
       });
     },
 
@@ -210,6 +221,46 @@ export const useAgentStore = create<AgentState>()(
           session.messages.length,
           state._nextMessageId,
         );
+      });
+    },
+
+    rewindToMessage: (sessionId, messageId) => {
+      storeLog("rewindToMessage: sid=%s msgId=%s", sessionId, messageId);
+      let rewoundContent: string | undefined;
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (!session) return;
+        const index = session.messages.findIndex((m) => m.id === messageId);
+        if (index === -1) return;
+        const removed = session.messages.slice(index);
+        rewoundContent = removed[0]?.content;
+        state.rewindUndoBuffer = { sessionId, messages: removed as ChatMessage[] };
+        session.messages = session.messages.slice(0, index);
+        storeLog(
+          "rewindToMessage: removed=%d remaining=%d",
+          removed.length,
+          session.messages.length,
+        );
+      });
+      return rewoundContent;
+    },
+
+    undoRewind: () => {
+      storeLog("undoRewind");
+      set((state) => {
+        const buf = state.rewindUndoBuffer;
+        if (!buf) return;
+        const session = state.sessions.get(buf.sessionId);
+        if (!session) return;
+        session.messages.push(...buf.messages);
+        state.rewindUndoBuffer = null;
+        storeLog("undoRewind: restored=%d total=%d", buf.messages.length, session.messages.length);
+      });
+    },
+
+    clearRewindBuffer: () => {
+      set((state) => {
+        state.rewindUndoBuffer = null;
       });
     },
 

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -10,7 +10,7 @@ import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../claude-code/types";
-import type { ActiveSessionInfo, ModelScope, SessionInfo } from "./types";
+import type { ActiveSessionInfo, ModelScope, RewindFilesResult, SessionInfo } from "./types";
 
 export const agentContract = {
   activeSessions: oc.input(z.object({})).output(type<ActiveSessionInfo[]>()),
@@ -76,6 +76,14 @@ export const agentContract = {
       }),
     )
     .output(type<{ path: string }>()),
+
+  rewindFilesDryRun: oc
+    .input(z.object({ sessionId: z.string(), messageId: z.string() }))
+    .output(type<RewindFilesResult>()),
+
+  rewindFiles: oc
+    .input(z.object({ sessionId: z.string(), messageId: z.string() }))
+    .output(type<RewindFilesResult>()),
 
   setModelSetting: oc
     .input(


### PR DESCRIPTION
Implemented a message rewind feature allowing users to restore conversation and code state to any previous user message. Includes dry-run preview, undo buffer with toast notifications, and UI components for the rewind button and popover.