### PR TITLE
fix: apply sendMessageWith config in message input

### DIFF
--- a/docs/designs/2026-03-13-fix-send-message-config.md
+++ b/docs/designs/2026-03-13-fix-send-message-config.md
@@ -1,0 +1,123 @@
+# Fix: `sendMessageWith` config not applied
+
+**Date:** 2026-03-13
+**Status:** Proposed
+
+## Problem
+
+The `sendMessageWith` setting (`"enter"` | `"cmdEnter"`) in Chat Settings has no effect.
+The keyboard handler in `message-input.tsx` is hardcoded to always send on bare Enter.
+
+## Root Cause
+
+`packages/desktop/src/renderer/src/features/agent/components/message-input.tsx` lines 132-144:
+The ProseMirror `chatKeymap` plugin ignores the `sendMessageWith` config value entirely.
+
+## Design
+
+Use the `useLatestRef` pattern (already used in this file for `cwdRef`, `attachmentsRef`) to expose the config value to the ProseMirror plugin closure.
+
+### Changes
+
+#### 1. `packages/desktop/src/renderer/src/features/agent/components/message-input.tsx`
+
+Subscribe to the config value and create a ref:
+
+```ts
+const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
+const sendMessageWithRef = useLatestRef(sendMessageWith);
+```
+
+Update `handleKeyDown` in the `chatKeymap` plugin:
+
+```ts
+handleKeyDown(_view, event) {
+  const mode = sendMessageWithRef.current;
+
+  // Bare Enter (no modifier)
+  if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey) {
+    if (document.querySelector("[data-suggestion-popup]")) return false;
+
+    if (mode === "cmdEnter") {
+      // bare Enter in cmdEnter mode -> insert newline (default ProseMirror behavior)
+      return false;
+    }
+
+    // mode === "enter": send
+    event.preventDefault();
+    const text = extractText(editor.getJSON()).trim();
+    if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
+      editor.commands.clearContent();
+      createNewSession(cwdRef.current);
+      return true;
+    }
+    send();
+    return true;
+  }
+
+  // Cmd/Ctrl+Enter
+  if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+    if (document.querySelector("[data-suggestion-popup]")) return false;
+
+    if (mode === "cmdEnter") {
+      // send
+      event.preventDefault();
+      const text = extractText(editor.getJSON()).trim();
+      if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
+        editor.commands.clearContent();
+        createNewSession(cwdRef.current);
+        return true;
+      }
+      send();
+      return true;
+    }
+
+    // mode === "enter": Cmd+Enter -> insert newline
+    editor.commands.setHardBreak();
+    return true;
+  }
+
+  if (event.key === "Enter" && event.altKey) {
+    editor.commands.setHardBreak();
+    return true;
+  }
+
+  // ... rest unchanged (Shift+Tab, Escape)
+}
+```
+
+#### 2. `packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx`
+
+Add a `title` tooltip on the send button reflecting the current keybinding:
+
+```tsx
+// Add to InputToolbar props or read directly:
+const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
+
+// On the send button (line 87):
+<Button
+  type="button"
+  size="icon"
+  className="h-7 w-7"
+  disabled={disabled}
+  onClick={onSend}
+  title={sendMessageWith === "cmdEnter" ? "Send (⌘+Enter)" : "Send (Enter)"}
+>
+```
+
+## Behavior Matrix
+
+| Key combo      | mode=`"enter"`    | mode=`"cmdEnter"` |
+| -------------- | ----------------- | ----------------- |
+| Enter          | Send              | Newline           |
+| Cmd/Ctrl+Enter | Newline           | Send              |
+| Shift+Enter    | Newline (default) | Newline (default) |
+| Alt+Enter      | Hard break        | Hard break        |
+
+## Notes
+
+- No new abstractions; follows existing `useLatestRef` convention.
+- `event.metaKey` covers Cmd on macOS; `event.ctrlKey` covers Ctrl on Windows/Linux.
+- Suggestion popup guard applied on both Enter and Cmd+Enter paths.
+- Easter egg handling remains on the send path regardless of mode.
+- Send button tooltip updates reactively via `useConfigStore`.

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -33,6 +33,7 @@ import {
   MenuRadioItem,
 } from "../../../components/ui/menu";
 import { client } from "../../../orpc";
+import { useConfigStore } from "../../config/store";
 import { useProviderStore } from "../../provider/store";
 import { useSettingsStore } from "../../settings/store";
 import { claudeCodeChatManager } from "../chat-manager";
@@ -58,6 +59,8 @@ export function InputToolbar({
   onAttach,
   activeSessionId,
 }: Props) {
+  const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
+
   return (
     <div className="flex items-center gap-1 border-border/50 px-2 py-1 bg-background-secondary">
       <Button
@@ -84,7 +87,14 @@ export function InputToolbar({
           <Square className="h-3.5 w-3.5" />
         </Button>
       ) : (
-        <Button type="button" size="icon" className="h-7 w-7" disabled={disabled} onClick={onSend}>
+        <Button
+          type="button"
+          size="icon"
+          className="h-7 w-7"
+          disabled={disabled}
+          onClick={onSend}
+          title={sendMessageWith === "cmdEnter" ? "Send (⌘+Enter)" : "Send (Enter)"}
+        >
           <SendHorizonal className="h-4 w-4" />
         </Button>
       )}

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -90,6 +90,9 @@ export function MessageInput({
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
 
+  const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
+  const sendMessageWithRef = useLatestRef(sendMessageWith);
+
   const mentionExtension = useMemo(() => createMentionExtension(() => cwdRef.current), []);
 
   const slashCommandsExtension = useMemo(
@@ -130,8 +133,22 @@ export function MessageInput({
               key: new PluginKey("chatKeymap"),
               props: {
                 handleKeyDown(_view, event) {
-                  if (event.key === "Enter" && !event.shiftKey && !event.altKey) {
+                  const mode = sendMessageWithRef.current;
+
+                  // Bare Enter (no modifier)
+                  if (
+                    event.key === "Enter" &&
+                    !event.shiftKey &&
+                    !event.altKey &&
+                    !event.metaKey &&
+                    !event.ctrlKey
+                  ) {
                     if (document.querySelector("[data-suggestion-popup]")) return false;
+
+                    if (mode === "cmdEnter") {
+                      return false;
+                    }
+
                     event.preventDefault();
                     const text = extractText(editor.getJSON()).trim();
                     if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
@@ -140,6 +157,25 @@ export function MessageInput({
                       return true;
                     }
                     send();
+                    return true;
+                  }
+                  // Cmd/Ctrl+Enter
+                  if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                    if (document.querySelector("[data-suggestion-popup]")) return false;
+
+                    if (mode === "cmdEnter") {
+                      event.preventDefault();
+                      const text = extractText(editor.getJSON()).trim();
+                      if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
+                        editor.commands.clearContent();
+                        createNewSession(cwdRef.current);
+                        return true;
+                      }
+                      send();
+                      return true;
+                    }
+
+                    editor.commands.setHardBreak();
                     return true;
                   }
                   if (event.key === "Enter" && event.altKey) {


### PR DESCRIPTION
Fixed the sendMessageWith setting ("enter" vs "cmdEnter") not being respected in the chat input. The keyboard handler now correctly sends messages based on the configured keybinding and updates the send button tooltip accordingly.