### PR TITLE
fix: scroll selected suggestion into view

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/suggestion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/suggestion-list.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -30,10 +31,15 @@ export type SuggestionListHandle = {
 export const SuggestionList = forwardRef<SuggestionListHandle, Props>(
   ({ items, command, header, icon }, ref) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
+    const selectedRef = useRef<HTMLButtonElement | null>(null);
 
     useEffect(() => {
       setSelectedIndex(0);
     }, [items]);
+
+    useEffect(() => {
+      selectedRef.current?.scrollIntoView({ block: "nearest" });
+    }, [selectedIndex]);
 
     useImperativeHandle(ref, () => ({
       onKeyDown: ({ event }) => {
@@ -67,6 +73,7 @@ export const SuggestionList = forwardRef<SuggestionListHandle, Props>(
           {items.map((item, index) => (
             <button
               key={item.id ?? item.label}
+              ref={index === selectedIndex ? selectedRef : undefined}
               className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left ${
                 index === selectedIndex ? "bg-accent" : ""
               }`}


### PR DESCRIPTION
Added scrollIntoView behavior to the suggestion list component so that the currently selected item is automatically scrolled into view when navigating with arrow keys.