### PR TITLE
fix: include uncommitted changes in branch review diff

### DIFF
--- a/docs/designs/2026-03-13-review-branch-uncommitted.md
+++ b/docs/designs/2026-03-13-review-branch-uncommitted.md
@@ -1,0 +1,37 @@
+# Review Panel: Include Uncommitted Changes in Branch Diff
+
+## Problem
+
+The review panel's "branch" category only compared committed state (`HEAD`) against the tracking branch using `git diff --name-status ${tracking}...HEAD`. When the local and remote branches pointed to the same commit, the diff was empty even though there were uncommitted working tree changes.
+
+Users expect the branch review to show the **full picture**: all changes (committed + uncommitted) relative to the upstream branch.
+
+## Solution
+
+Use the **merge-base** of the tracking branch and HEAD as the comparison baseline, and diff against the **working tree** instead of HEAD.
+
+### Changes
+
+**File:** `packages/desktop/src/main/plugins/git/router.ts`
+
+#### `getBranchFiles()`
+
+- Compute merge-base: `git merge-base ${tracking} HEAD`
+- Changed file list command from `git diff --name-status ${tracking}...HEAD` to `git diff --name-status ${mergeBase}`
+- This compares the fork point against the working tree, capturing both committed and uncommitted changes
+
+#### `getBranchFileDiff()`
+
+- Compute merge-base (same as above)
+- `oldContent`: changed from `${tracking}:${file}` to `${mergeBase}:${file}`
+- `newContent`: changed from `git show HEAD:${file}` to `fs.readFileSync(path.resolve(cwd, file))` (reads working tree)
+
+### Why merge-base instead of tracking directly
+
+Using `git diff ${tracking}` (without merge-base) breaks when the tracking branch has diverged (behind > 0). Upstream-only commits would appear as "removed" changes, which is misleading.
+
+The merge-base approach shows "everything this branch changed since it forked from upstream, including uncommitted work" -- essentially a PR preview plus working tree state.
+
+### Fallback
+
+Both functions fall back to using the tracking ref directly if `git merge-base` fails.

--- a/packages/desktop/src/main/plugins/git/router.ts
+++ b/packages/desktop/src/main/plugins/git/router.ts
@@ -459,10 +459,18 @@ async function getBranchFiles(cwd: string) {
     // ignore
   }
 
-  // Get changed files
+  // Get merge-base so we diff "since fork point" including uncommitted changes
+  let mergeBase: string;
+  try {
+    mergeBase = (await gitClient.raw(["merge-base", tracking, "HEAD"])).trim();
+  } catch {
+    mergeBase = tracking;
+  }
+
+  // Get changed files (merge-base vs working tree)
   const files: GitBranchFile[] = [];
   try {
-    const nameStatus = await gitClient.raw(["diff", "--name-status", `${tracking}...HEAD`]);
+    const nameStatus = await gitClient.raw(["diff", "--name-status", mergeBase]);
     for (const line of nameStatus.trim().split("\n")) {
       if (!line) continue;
       const [statusChar, ...fileParts] = line.split("\t");
@@ -495,18 +503,27 @@ async function getBranchFileDiff(cwd: string, file: string) {
     return { success: false, error: "no_upstream" };
   }
 
+  // Use merge-base for oldContent so we compare from the fork point
+  let mergeBase: string;
+  try {
+    mergeBase = (await gitClient.raw(["merge-base", tracking, "HEAD"])).trim();
+  } catch {
+    mergeBase = tracking;
+  }
+
   let oldContent = "";
   let newContent = "";
 
   try {
-    oldContent = await gitClient.show([`${tracking}:${file}`]);
+    oldContent = await gitClient.show([`${mergeBase}:${file}`]);
   } catch {
     // new file on branch
     oldContent = "";
   }
 
+  // Read from working tree to include uncommitted changes
   try {
-    newContent = await gitClient.show([`HEAD:${file}`]);
+    newContent = fs.readFileSync(path.resolve(cwd, file), "utf8");
   } catch {
     // deleted file on branch
     newContent = "";


### PR DESCRIPTION
Updated the review panel's branch diff to show both committed and uncommitted changes by using merge-base as comparison baseline and reading from working tree instead of HEAD.