### PR TITLE
fix: 关掉 i18n 转译

### DIFF
--- a/packages/desktop/src/renderer/src/core/i18n/manager.ts
+++ b/packages/desktop/src/renderer/src/core/i18n/manager.ts
@@ -64,6 +64,9 @@ export class I18nManager {
         useSuspense: false,
         bindI18n: "languageChanged loaded",
       },
+      interpolation: {
+        escapeValue: false,
+      },
     });
 
     // If no preference was saved, save detected locale to store


### PR DESCRIPTION
react 已经有转译了，重复转译导致显示错误