### PR TITLE
feat: upgrade insert-mention to insert-chat for multi-file support

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -16,6 +16,7 @@ import { claudeCodeChatManager } from "../chat-manager";
 import { useNewSession } from "../hooks/use-new-session";
 import { useAgentStore } from "../store";
 import { extractText } from "../utils/extract-text";
+import { buildInsertChatContent, type InsertChatDetail } from "../utils/insert-chat";
 import { readFileAsAttachment } from "../utils/read-file-as-attachment";
 import { AttachmentPreview } from "./attachment-preview";
 import { createImagePasteExtension } from "./image-paste-extension";
@@ -250,23 +251,22 @@ export function MessageInput({
     }
   }, [showSettings]);
 
-  // Listen for insert-mention events from file tree
+  // Listen for insert-chat events from file tree and other entry points
   useEffect(() => {
     if (!editor) return;
     const handler = (e: Event) => {
-      const { path } = (e as CustomEvent<{ path: string }>).detail;
-      log("insert-mention received path=%s", path);
-      editor
-        .chain()
-        .focus()
-        .insertContent([
-          { type: "mention", attrs: { id: path, label: path } },
-          { type: "text", text: " " },
-        ])
-        .run();
+      const detail = (e as CustomEvent<InsertChatDetail>).detail ?? {};
+      const content = buildInsertChatContent(detail);
+      log(
+        "insert-chat received textLen=%d mentions=%d",
+        detail.text?.length ?? 0,
+        detail.mentions?.length ?? 0,
+      );
+      if (content.length === 0) return;
+      editor.chain().focus().insertContent(content).run();
     };
-    window.addEventListener("neovate:insert-mention", handler);
-    return () => window.removeEventListener("neovate:insert-mention", handler);
+    window.addEventListener("neovate:insert-chat", handler);
+    return () => window.removeEventListener("neovate:insert-chat", handler);
   }, [editor]);
 
   const handleFileSelect = useCallback(

--- a/packages/desktop/src/renderer/src/features/agent/utils/__tests__/insert-chat.test.ts
+++ b/packages/desktop/src/renderer/src/features/agent/utils/__tests__/insert-chat.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildInsertChatContent } from "../insert-chat";
+
+describe("buildInsertChatContent", () => {
+  it("builds content for multiple mentions followed by text", () => {
+    expect(
+      buildInsertChatContent({
+        text: "Review",
+        mentions: [{ id: "src/a.ts" }, { id: "src/b.ts", label: "src/b.ts" }],
+      }),
+    ).toEqual([
+      { type: "mention", attrs: { id: "src/a.ts", label: "src/a.ts" } },
+      { type: "text", text: " " },
+      { type: "mention", attrs: { id: "src/b.ts", label: "src/b.ts" } },
+      { type: "text", text: " " },
+      { type: "text", text: "Review" },
+    ]);
+  });
+
+  it("does not add a duplicate separator when text already starts with whitespace", () => {
+    expect(
+      buildInsertChatContent({
+        text: " Review",
+        mentions: [{ id: "src/a.ts" }],
+      }),
+    ).toEqual([
+      { type: "mention", attrs: { id: "src/a.ts", label: "src/a.ts" } },
+      { type: "text", text: " Review" },
+    ]);
+  });
+});

--- a/packages/desktop/src/renderer/src/features/agent/utils/insert-chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/utils/insert-chat.ts
@@ -1,0 +1,27 @@
+import type { JSONContent } from "@tiptap/react";
+
+export type InsertChatDetail = {
+  text?: string;
+  mentions?: Array<{ id: string; label?: string }>;
+};
+
+export function buildInsertChatContent({ text, mentions = [] }: InsertChatDetail): JSONContent[] {
+  const content: JSONContent[] = [];
+
+  for (const [index, mention] of mentions.entries()) {
+    content.push({
+      type: "mention",
+      attrs: { id: mention.id, label: mention.label ?? mention.id },
+    });
+
+    if (index < mentions.length - 1 || !text || !/^\s/.test(text)) {
+      content.push({ type: "text", text: " " });
+    }
+  }
+
+  if (text) {
+    content.push({ type: "text", text });
+  }
+
+  return content;
+}

--- a/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
@@ -199,10 +199,10 @@ function FilesViewComponent({ project }: FilesViewProps) {
   };
   /** 添加文件到对话 */
   const handleAddContext = (item: FileTreeItem) => {
-    log("insert-mention dispatching path=%s", item.relPath);
+    log("insert-chat dispatching mention=%s", item.relPath);
     window.dispatchEvent(
-      new CustomEvent("neovate:insert-mention", {
-        detail: { path: item.relPath },
+      new CustomEvent("neovate:insert-chat", {
+        detail: { mentions: [{ id: item.relPath, label: item.relPath }] },
       }),
     );
   };


### PR DESCRIPTION
## Summary
- Enhances file mention insertion mechanism to support multiple files with optional custom text content
- Adds `buildInsertChatContent` utility for composing mentions + text
- Renames event from `neovate:insert-mention` to `neovate:insert-chat`
- Updates detail format from single `{ path }` to flexible `{ mentions: [], text? }`
- Includes unit tests for the new content builder

## Test plan
- [ ] Unit tests pass for `buildInsertChatContent`
- [ ] Manual test: select a file from file tree and verify it inserts correctly
- [ ] Manual test: verify mention nodes render properly in chat input