### PR TITLE
feat: add collapsePart to layout api

### DIFF
--- a/packages/desktop/src/renderer/src/core/__tests__/app.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/app.test.ts
@@ -27,6 +27,7 @@ describe("RendererApp", () => {
     expect(app.workbench).toBeDefined();
     expect(app.workbench.layout).toBeDefined();
     expect(typeof app.workbench.layout.expandPart).toBe("function");
+    expect(typeof app.workbench.layout.collapsePart).toBe("function");
     expect(app.workbench.contentPanel).toBeDefined();
     expect(typeof app.workbench.contentPanel.openView).toBe("function");
   });

--- a/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/plugin-manager.test.ts
@@ -11,7 +11,12 @@ function createMockApp(): IRendererApp {
     subscriptions: { push: vi.fn() },
     i18nManager: {} as IRendererApp["i18nManager"],
     workbench: {
-      layout: { expandPart: vi.fn(), togglePart: vi.fn(), maximizePart: vi.fn() },
+      layout: {
+        expandPart: vi.fn(),
+        collapsePart: vi.fn(),
+        togglePart: vi.fn(),
+        maximizePart: vi.fn(),
+      },
       contentPanel: {} as any,
     },
     project: {} as any,

--- a/packages/desktop/src/renderer/src/core/__tests__/workbench-layout-service.test.ts
+++ b/packages/desktop/src/renderer/src/core/__tests__/workbench-layout-service.test.ts
@@ -42,6 +42,32 @@ describe("WorkbenchLayoutService", () => {
     expect(togglePart).not.toHaveBeenCalled();
   });
 
+  it("collapses an expanded part by delegating to togglePart", () => {
+    const togglePart = vi.fn();
+    const service = new WorkbenchLayoutService({
+      isExpanded: vi.fn(() => true),
+      togglePart,
+      maximizeContentPanel: vi.fn(),
+    });
+
+    service.collapsePart("contentPanel");
+
+    expect(togglePart).toHaveBeenCalledWith("contentPanel");
+  });
+
+  it("does nothing when the part is already collapsed", () => {
+    const togglePart = vi.fn();
+    const service = new WorkbenchLayoutService({
+      isExpanded: vi.fn(() => false),
+      togglePart,
+      maximizeContentPanel: vi.fn(),
+    });
+
+    service.collapsePart("contentPanel");
+
+    expect(togglePart).not.toHaveBeenCalled();
+  });
+
   it("delegates togglePart directly to the adapter", () => {
     const togglePart = vi.fn();
     const service = new WorkbenchLayoutService({
@@ -62,6 +88,7 @@ describe("WorkbenchLayoutService", () => {
       maximizeContentPanel: vi.fn(),
     });
 
+    expect(typeof service.collapsePart).toBe("function");
     expect(typeof service.maximizePart).toBe("function");
   });
 

--- a/packages/desktop/src/renderer/src/core/workbench/layout/service.ts
+++ b/packages/desktop/src/renderer/src/core/workbench/layout/service.ts
@@ -21,6 +21,11 @@ export class WorkbenchLayoutService implements IWorkbenchLayoutService {
     return this.adapter.togglePart(part);
   }
 
+  collapsePart(part: CollapsibleWorkbenchPartId): void | Promise<void> {
+    if (!this.adapter.isExpanded(part)) return;
+    return this.adapter.togglePart(part);
+  }
+
   togglePart(part: CollapsibleWorkbenchPartId): void | Promise<void> {
     return this.adapter.togglePart(part);
   }

--- a/packages/desktop/src/renderer/src/core/workbench/layout/types.ts
+++ b/packages/desktop/src/renderer/src/core/workbench/layout/types.ts
@@ -20,6 +20,7 @@ export type MaximizableWorkbenchPartId = "contentPanel";
 
 export interface IWorkbenchLayoutService {
   expandPart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
+  collapsePart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
   togglePart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
   maximizePart(part: MaximizableWorkbenchPartId): void | Promise<void>;
 }

--- a/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
@@ -29,6 +29,7 @@ function makeOptions(overrides?: Partial<ContentPanelOptions>): ContentPanelOpti
     save: vi.fn(() => Promise.resolve()),
     layout: {
       expandPart: vi.fn(),
+      collapsePart: vi.fn(),
       togglePart: vi.fn(),
       maximizePart: vi.fn(),
     } satisfies IWorkbenchLayoutService,

--- a/packages/desktop/src/renderer/src/features/content-panel/__tests__/view-context.test.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/__tests__/view-context.test.tsx
@@ -18,7 +18,12 @@ let panel: ContentPanel;
 vi.mock("../../../core", () => ({
   useRendererApp: () => ({
     workbench: {
-      layout: { expandPart: vi.fn(), togglePart: vi.fn(), maximizePart: vi.fn() },
+      layout: {
+        expandPart: vi.fn(),
+        collapsePart: vi.fn(),
+        togglePart: vi.fn(),
+        maximizePart: vi.fn(),
+      },
       contentPanel: panel,
     },
   }),
@@ -39,6 +44,7 @@ beforeEach(() => {
     views: VIEWS,
     layout: {
       expandPart: vi.fn(),
+      collapsePart: vi.fn(),
       togglePart: vi.fn(),
       maximizePart: vi.fn(),
     } satisfies IWorkbenchLayoutService,


### PR DESCRIPTION
## Summary
- add workbench layout method collapsePart(part) as the inverse of expandPart(part), with a no-op when the part is already collapsed
- cover the new API at the service layer and expose it through the renderer app layout contract
- update layout service test doubles to match the expanded interface

## Test Plan
- bunx vitest run