### PR TITLE
feat: add global model selector to chat settings

### DIFF
--- a/docs/designs/2026-03-14-model-settings.md
+++ b/docs/designs/2026-03-14-model-settings.md
@@ -1,0 +1,152 @@
+# Model Setting in Chat Settings Page
+
+## Summary
+
+Replace the "Coming Soon" placeholder in the chat settings panel with a model selector.
+
+- **Single SettingsRow** with a Menu trigger showing current selection (e.g. "SDK Default / Claude Sonnet 4")
+- Clicking opens a grouped Menu dropdown — same UX pattern as the toolbar `ModelSelect`
+- Provider groups as headers, models as radio items within each group
+- "Default (auto)" option at the top to reset to SDK defaults
+- When no custom providers exist, provider group headers are hidden — just a flat model list
+- Fetches current global selection from backend on mount to avoid stale state
+- Sets the **global default** model, used when no session/project override exists
+
+## UI
+
+```
+With providers:
+
+│ Model                                            │
+│ Set the default model for new sessions           │
+│                                                  │
+│  ┌──────────────────────────────────┐            │
+│  │ SDK Default / Claude Sonnet 4  ▼ │            │
+│  ├──────────────────────────────────┤            │
+│  │ Default (auto)                   │            │
+│  │ ─────────────────────            │            │
+│  │ SDK Default                      │            │
+│  │   ○ Claude Sonnet 4              │            │
+│  │   ○ Claude Haiku 3.5             │            │
+│  │   ○ Claude Opus 4                │            │
+│  │ ─────────────────────            │            │
+│  │ My Provider                      │            │
+│  │   ○ gpt-4o                       │            │
+│  │   ○ gpt-4o-mini                  │            │
+│  └──────────────────────────────────┘            │
+
+No providers configured:
+
+│ Model                                            │
+│ Set the default model for new sessions           │
+│                                                  │
+│  ┌──────────────────────────────────┐            │
+│  │ Default (auto)                ▼  │            │
+│  ├──────────────────────────────────┤            │
+│  │ Default (auto)                   │            │
+│  │ ─────────────────────            │            │
+│  │   ○ Claude Sonnet 4              │            │
+│  │   ○ Claude Haiku 3.5             │            │
+│  │   ○ Claude Opus 4                │            │
+│  └──────────────────────────────────┘            │
+```
+
+Selecting a model implicitly sets the provider (from the group it belongs to).
+
+## Data Flow
+
+### Reading current selection
+
+- Provider: `configStore.getGlobalSelection().provider`
+- Model:
+  - If provider set: `configStore.getGlobalSelection().model`
+  - If SDK Default: `~/.claude/settings.json` → `model` key
+
+### Writing selection
+
+- Model in provider group selected: `configStore.setGlobalSelection(providerId, model)` + clear `~/.claude/settings.json` model
+- Model in SDK Default group selected: `configStore.setGlobalSelection(null, null)` + `writeModelSetting("global", model, {})`
+- **Default (auto)** selected: clear both stores so SDK picks its own default
+
+### Getting available models
+
+- For providers: `provider.models` from config (always available)
+- For SDK Default: `agentStore.sessions[id].availableModels` from any active pre-warmed session (almost always available; shows only "Default (auto)" if no session exists)
+
+### Refresh on mount
+
+- On settings panel mount, call `client.config.getGlobalModelSelection()` to get the current global selection
+- Avoids stale state when the user changes the global model from the toolbar (right-click → "Set as global default") and then opens settings
+
+## Backend Changes
+
+### 1. Config contract (`shared/features/config/contract.ts`)
+
+Add 2 endpoints:
+
+```typescript
+getGlobalModelSelection: oc.output(type<{ providerId?: string; model?: string }>());
+
+setGlobalModelSelection: oc.input(
+  z.object({
+    providerId: z.string().nullable(),
+    model: z.string().nullable(),
+  }),
+).output(type<void>());
+```
+
+### 2. Config router (`main/features/config/router.ts`)
+
+Implement the two endpoints:
+
+- `getGlobalModelSelection`:
+  - Read `configStore.getGlobalSelection()` → `{ provider?, model? }`
+  - If no provider, also read `~/.claude/settings.json` for SDK Default model (reuse `readJsonFile` from `claude-settings.ts`)
+  - Return combined `{ providerId, model }`
+
+- `setGlobalModelSelection`:
+  - If `providerId` is non-null:
+    - `configStore.setGlobalSelection(providerId, model)`
+    - Clear `~/.claude/settings.json` model to avoid conflict
+  - If `providerId` is null (SDK Default):
+    - `configStore.setGlobalSelection(null, null)`
+    - If model is non-null: `writeModelSetting("global", model, {})`
+    - If model is null: `writeModelSetting("global", null, {})` (reset to auto)
+
+## Frontend Changes
+
+### chat-panel.tsx
+
+Replace "Coming Soon" block (lines 58-69) with a single `<SettingsRow>`:
+
+- **Menu trigger**: shows `"Provider / Model"`, `"Model"` (no provider), or `"Default (auto)"`
+- **Menu dropdown** (grouped, same pattern as toolbar `ModelSelect`):
+  - `MenuRadioItem` for "Default (auto)" at top
+  - Separator
+  - SDK Default group header (only when providers exist)
+  - `MenuRadioItem` for each SDK model (from `useAgentStore` active sessions)
+  - Separator (only when providers exist)
+  - Provider group headers + `MenuRadioItem` for each provider model
+- Selected value encoded as `"providerId:model"` or `":model"` (SDK Default) or `""` (auto)
+- On change: parse value, call `client.config.setGlobalModelSelection()`
+- On mount: `useEffect` calls `client.config.getGlobalModelSelection()` to hydrate state
+
+## i18n Keys
+
+Add to translation files:
+
+| Key                               | English                                                 |
+| --------------------------------- | ------------------------------------------------------- |
+| `settings.chat.model`             | Model (already exists)                                  |
+| `settings.chat.model.description` | Set the default model for new sessions (already exists) |
+| `settings.chat.model.auto`        | Default (auto)                                          |
+| `settings.chat.model.sdkDefault`  | SDK Default                                             |
+
+## Files Modified
+
+| File                                                              | Change                                           |
+| ----------------------------------------------------------------- | ------------------------------------------------ |
+| `shared/features/config/contract.ts`                              | Add 2 endpoints                                  |
+| `main/features/config/router.ts`                                  | Implement endpoints                              |
+| `renderer/src/features/settings/components/panels/chat-panel.tsx` | Replace "Coming Soon" with grouped Menu selector |
+| i18n translation files                                            | Add new keys                                     |

--- a/packages/desktop/src/main/features/config/router.ts
+++ b/packages/desktop/src/main/features/config/router.ts
@@ -1,15 +1,49 @@
 import { implement } from "@orpc/server";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import type { AppConfig } from "../../../shared/features/config/types";
 import type { AppContext } from "../../router";
 
 import { configContract } from "../../../shared/features/config/contract";
+import { writeModelSetting } from "../agent/claude-settings";
 
 const os = implement({ config: configContract }).$context<AppContext>();
 
 export const configRouter = os.config.router({
   get: os.config.get.handler(({ context }) => {
     return context.configStore.getAll();
+  }),
+
+  getGlobalModelSelection: os.config.getGlobalModelSelection.handler(({ context }) => {
+    const sel = context.configStore.getGlobalSelection();
+    if (sel.provider) {
+      return { providerId: sel.provider, model: sel.model };
+    }
+    // SDK Default: read model from ~/.claude/settings.json
+    try {
+      const json = JSON.parse(readFileSync(join(homedir(), ".claude", "settings.json"), "utf-8"));
+      if (typeof json?.model === "string" && json.model) {
+        return { model: json.model };
+      }
+    } catch {
+      // file doesn't exist or invalid JSON
+    }
+    return {};
+  }),
+
+  setGlobalModelSelection: os.config.setGlobalModelSelection.handler(({ input, context }) => {
+    const { providerId, model } = input;
+    if (providerId) {
+      // Provider mode: store in configStore, clear SDK Default model
+      context.configStore.setGlobalSelection(providerId, model);
+      writeModelSetting("global", null, {});
+    } else {
+      // SDK Default mode: clear provider from configStore, write model to ~/.claude/settings.json
+      context.configStore.setGlobalSelection(null, null);
+      writeModelSetting("global", model, {});
+    }
   }),
 
   set: os.config.set.handler(({ input, context }) => {

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -1,4 +1,5 @@
-import { MessageSquare } from "lucide-react";
+import { ChevronDown, MessageSquare } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type {
@@ -8,6 +9,16 @@ import type {
 } from "../../../../../../shared/features/config/types";
 
 import {
+  Menu,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuTrigger,
+} from "../../../../components/ui/menu";
+import {
   Select,
   SelectItem,
   SelectPopup,
@@ -16,7 +27,10 @@ import {
 } from "../../../../components/ui/select";
 import { Spinner } from "../../../../components/ui/spinner";
 import { ToggleOptions } from "../../../../components/ui/toggle-options";
+import { client } from "../../../../orpc";
+import { useAgentStore } from "../../../agent/store";
 import { useConfigStore } from "../../../config/store";
+import { useProviderStore } from "../../../provider/store";
 import { SettingsRow } from "../settings-row";
 
 // Translation key mappings
@@ -30,6 +44,21 @@ const permissionModeKeys = {
   acceptEdits: "settings.chat.permissionMode.acceptEdits",
   bypassPermissions: "settings.chat.permissionMode.bypassPermissions",
 } as const satisfies Record<ConfigPermissionMode, string>;
+
+/** Encode provider+model into a single radio value. "" = auto. */
+function encodeValue(providerId: string | undefined, model: string | undefined): string {
+  if (!model) return "";
+  return providerId ? `${providerId}:${model}` : `:${model}`;
+}
+
+/** Decode radio value back to providerId + model. */
+function decodeValue(value: string): { providerId: string | null; model: string | null } {
+  if (!value) return { providerId: null, model: null };
+  const idx = value.indexOf(":");
+  const providerId = value.slice(0, idx) || null;
+  const model = value.slice(idx + 1) || null;
+  return { providerId, model };
+}
 
 export const ChatPanel = () => {
   const { t } = useTranslation();
@@ -55,17 +84,12 @@ export const ChatPanel = () => {
       </h1>
 
       <div className="space-y-0">
-        {/* Model - Coming Soon */}
+        {/* Model */}
         <SettingsRow
           title={t("settings.chat.model")}
           description={t("settings.chat.model.description")}
         >
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">{t("settings.chat.comingSoon")}</span>
-            <span className="inline-flex items-center rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
-              {t("settings.chat.requiresBackend")}
-            </span>
-          </div>
+          <GlobalModelSelect />
         </SettingsRow>
 
         {/* Agent Language */}
@@ -131,3 +155,126 @@ export const ChatPanel = () => {
     </div>
   );
 };
+
+function GlobalModelSelect() {
+  const { t } = useTranslation();
+
+  // Current global selection state
+  const [selectedProviderId, setSelectedProviderId] = useState<string | undefined>();
+  const [selectedModel, setSelectedModel] = useState<string | undefined>();
+  const [selectionLoaded, setSelectionLoaded] = useState(false);
+
+  // Providers
+  const providers = useProviderStore((s) => s.providers);
+  const providersLoaded = useProviderStore((s) => s.loaded);
+  const loadProviders = useProviderStore((s) => s.load);
+
+  // SDK models from any active non-provider session
+  const sdkModels = useAgentStore((s) => {
+    for (const session of s.sessions.values()) {
+      if (!session.providerId && session.availableModels.length > 0) {
+        return session.availableModels;
+      }
+    }
+    return [];
+  });
+
+  // Load providers and current selection on mount
+  useEffect(() => {
+    if (!providersLoaded) loadProviders();
+  }, [providersLoaded, loadProviders]);
+
+  useEffect(() => {
+    client.config.getGlobalModelSelection().then((sel) => {
+      setSelectedProviderId(sel.providerId);
+      setSelectedModel(sel.model);
+      setSelectionLoaded(true);
+    });
+  }, []);
+
+  const enabledProviders = providers.filter((p) => p.enabled);
+
+  const handleSelect = useCallback((value: unknown) => {
+    const { providerId, model } = decodeValue(value as string);
+    setSelectedProviderId(providerId ?? undefined);
+    setSelectedModel(model ?? undefined);
+    client.config.setGlobalModelSelection({ providerId, model });
+  }, []);
+
+  if (!selectionLoaded) {
+    return <Spinner className="h-4 w-4" />;
+  }
+
+  // Build display label
+  const activeProvider = selectedProviderId
+    ? enabledProviders.find((p) => p.id === selectedProviderId)
+    : undefined;
+  const autoLabel = t("settings.chat.model.auto");
+
+  let displayLabel: string;
+  if (!selectedModel) {
+    displayLabel = autoLabel;
+  } else if (activeProvider) {
+    const modelDisplay = activeProvider.models[selectedModel]?.displayName ?? selectedModel;
+    displayLabel = `${activeProvider.name} / ${modelDisplay}`;
+  } else {
+    const sdkModel = sdkModels.find((m) => m.value === selectedModel);
+    displayLabel = sdkModel?.displayName ?? selectedModel;
+  }
+
+  const currentValue = encodeValue(selectedProviderId, selectedModel);
+
+  return (
+    <Menu>
+      <MenuTrigger className="inline-flex h-8 max-w-[220px] items-center gap-1 rounded-md border border-input bg-background px-3 text-sm text-foreground outline-none hover:bg-accent cursor-pointer">
+        <span className="truncate">{displayLabel}</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+      </MenuTrigger>
+      <MenuPopup side="bottom" align="end" className="max-h-80 overflow-y-auto">
+        <MenuRadioGroup value={currentValue} onValueChange={handleSelect}>
+          {/* Default (auto) */}
+          <MenuRadioItem value="">{autoLabel}</MenuRadioItem>
+
+          <MenuSeparator />
+
+          {/* SDK Default models */}
+          {enabledProviders.length > 0 && (
+            <MenuGroup>
+              <MenuGroupLabel>{t("settings.chat.model.sdkDefault")}</MenuGroupLabel>
+            </MenuGroup>
+          )}
+          {sdkModels.map((m) => (
+            <MenuRadioItem
+              key={m.value}
+              value={encodeValue(undefined, m.value)}
+              className={enabledProviders.length > 0 ? "pl-6" : ""}
+            >
+              {m.displayName}
+            </MenuRadioItem>
+          ))}
+
+          {/* Provider groups */}
+          {enabledProviders.map((p) => (
+            <MenuGroup key={p.id}>
+              <MenuSeparator />
+              <MenuGroupLabel>{p.name}</MenuGroupLabel>
+              {Object.entries(p.models).map(([key, entry]) => {
+                const aliases: string[] = [];
+                if (p.modelMap.model === key) aliases.push("default");
+                if (p.modelMap.haiku === key) aliases.push("haiku");
+                if (p.modelMap.opus === key) aliases.push("opus");
+                if (p.modelMap.sonnet === key) aliases.push("sonnet");
+                const badge = aliases.length > 0 ? ` (${aliases.join(", ")})` : "";
+                return (
+                  <MenuRadioItem key={key} value={encodeValue(p.id, key)} className="pl-6">
+                    {(entry.displayName ?? key) + badge}
+                  </MenuRadioItem>
+                );
+              })}
+            </MenuGroup>
+          ))}
+        </MenuRadioGroup>
+      </MenuPopup>
+    </Menu>
+  );
+}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -51,8 +51,8 @@
   "settings.chat.notification.funk": "Funk",
   "settings.chat.sendMessage": "Send Message",
   "settings.chat.sendMessage.description": "Keyboard shortcut to send messages",
-  "settings.chat.comingSoon": "Coming Soon",
-  "settings.chat.requiresBackend": "Requires Backend Service",
+  "settings.chat.model.auto": "Default (auto)",
+  "settings.chat.model.sdkDefault": "SDK Default",
   "settings.chat.selectPlaceholder": "Select...",
 
   "settings.about": "About",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -51,8 +51,8 @@
   "settings.chat.notification.funk": "Funk",
   "settings.chat.sendMessage": "发送消息",
   "settings.chat.sendMessage.description": "发送消息的键盘快捷键",
-  "settings.chat.comingSoon": "即将推出",
-  "settings.chat.requiresBackend": "需要后端服务",
+  "settings.chat.model.auto": "默认（自动）",
+  "settings.chat.model.sdkDefault": "SDK 默认",
   "settings.chat.selectPlaceholder": "请选择...",
 
   "settings.about": "关于",

--- a/packages/desktop/src/shared/features/config/contract.ts
+++ b/packages/desktop/src/shared/features/config/contract.ts
@@ -27,6 +27,17 @@ const sidebarSortByValueSchema = z.enum(["created", "updated"]);
 export const configContract = {
   get: oc.output(type<AppConfig>()),
 
+  getGlobalModelSelection: oc.output(type<{ providerId?: string; model?: string }>()),
+
+  setGlobalModelSelection: oc
+    .input(
+      z.object({
+        providerId: z.string().nullable(),
+        model: z.string().nullable(),
+      }),
+    )
+    .output(type<void>()),
+
   set: oc
     .input(
       z.union([


### PR DESCRIPTION
Replaced the "Coming Soon" placeholder in chat settings with a functional global model selector. Added backend endpoints to get/set global model selection and integrated a grouped dropdown menu for selecting default models across providers and SDK defaults.