### PR TITLE
fix: make terminal links open with Cmd/Ctrl+click

### DIFF
--- a/packages/desktop/src/renderer/src/plugins/terminal/terminal-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/terminal/terminal-view.tsx
@@ -114,7 +114,13 @@ export default function TerminalView() {
     const fitAddon = new FitAddon();
     fitAddonRef.current = fitAddon;
     xterm.loadAddon(fitAddon);
-    xterm.loadAddon(new WebLinksAddon());
+    xterm.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        if (isMac ? event.metaKey : event.ctrlKey) {
+          window.open(uri);
+        }
+      }),
+    );
     xterm.open(container);
     fitAddon.fit();
 


### PR DESCRIPTION
## Summary

- Fix terminal links not opening when clicked (#118)
- WebLinksAddon's default handler calls `window.open()` without a URL, which Electron's `setWindowOpenHandler` denies before the URL is ever set
- Pass a custom handler that calls `window.open(uri)` with the actual URL, so `setWindowOpenHandler` receives it and delegates to `shell.openExternal`
- Links now require Cmd+click (Mac) / Ctrl+click (Windows/Linux), matching standard terminal behavior

## Test plan

- [ ] Start a dev server in the terminal that prints a URL (e.g. `http://localhost:3000`)
- [ ] Cmd+click (Mac) / Ctrl+click (Windows/Linux) the link — should open in default browser
- [ ] Plain click on the link should NOT open it
- [ ] Text selection in the terminal still works normally

Closes #118