### PR TITLE
chore: migrate commands to skills

### DIFF
--- a/.claude/skills/bug-report/SKILL.md
+++ b/.claude/skills/bug-report/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: bug-report
 description: Create a bug report issue on GitHub
+disable-model-invocation: true
 ---
 
 Create a GitHub bug report issue for this project. Follow this process:

--- a/.claude/skills/feature-request/SKILL.md
+++ b/.claude/skills/feature-request/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: feature-request
 description: Create a feature request issue on GitHub
+disable-model-invocation: true
 ---
 
 Create a GitHub feature request issue for this project. Follow this process:

--- a/.claude/skills/ready-pr/SKILL.md
+++ b/.claude/skills/ready-pr/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ready-pr
+description: Run readiness checks, fix issues, and create a PR
+disable-model-invocation: true
+---
+
+# Ready PR
+
+Run `bun ready` to validate the project, fix any issues, and create a pull request.
+
+## Steps
+
+1. Run `bun ready`
+2. If it fails:
+   - Read the error output to identify what failed (format, typecheck, lint, or tests)
+   - Fix the issues
+   - Run `bun ready` again
+   - Repeat until it passes (max 3 attempts, then stop and report)
+3. Stage and commit any files changed during fixes (use Conventional Commits)
+4. Analyze all commits on the current branch vs `master` using `git log master..HEAD` and `git diff master...HEAD`
+5. Draft a PR title (under 70 chars) and body with a Summary section and Test plan
+6. Push the branch and create the PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --base master --title "<title>" --body "<body>"
+   ```
+7. Return the PR URL


### PR DESCRIPTION
## Summary

- Migrated `bug-report` and `feature-request` from `.claude/commands/` to `.claude/skills/` with `disable-model-invocation: true`
- Added new `ready-pr` skill that runs `bun ready`, fixes issues, and creates a PR
- Removed empty `.claude/commands/` directory

## Test plan

- [ ] Verify `/bug-report` skill is invocable and works as before
- [ ] Verify `/feature-request` skill is invocable and works as before
- [ ] Verify `/ready-pr` skill runs checks and creates PRs
- [ ] Confirm none of the skills auto-trigger (disable-model-invocation)