### PR TITLE
fix: add error boundary to content panel views

### DIFF
--- a/docs/designs/2026-03-15-content-panel-error-boundary.md
+++ b/docs/designs/2026-03-15-content-panel-error-boundary.md
@@ -1,0 +1,109 @@
+# Content Panel View Error Boundary
+
+## Problem
+
+Content panel views (terminal, review, git, etc.) crash the entire app when an error occurs. The most common trigger is HMR during development: when a view file is hot-updated, `ViewIdContext` (created by `createContext()` in `view-context.tsx`) can get a new object identity, causing a provider/consumer mismatch. `useContentPanelViewContext` throws, React has no error boundary to catch it, and the whole renderer crashes and reloads.
+
+Observed in `/tmp/dev.log`:
+
+```
+[renderer:error] Uncaught Error: useContentPanelViewContext must be used within ContentPanelViewContextProvider
+[renderer:warning] An error occurred in the <ReviewView> component.
+```
+
+## Solution
+
+Wrap each content panel view in the existing `ErrorBoundary` component (`components/ui/error-boundary.tsx`), placed **outside** the `Suspense` and `ContentPanelViewContextProvider` so it catches both context failures and view-level errors.
+
+## Change
+
+**File**: `packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx`
+
+Add `ErrorBoundary` import and wrap each tab's subtree:
+
+Before:
+
+```tsx
+<TabViewWithActivity key={tab.id} isActive={...} deactivation={...}>
+  <Suspense>
+    <ContentPanelViewContextProvider viewId={tab.id}>
+      <LazyComponent />
+    </ContentPanelViewContextProvider>
+  </Suspense>
+</TabViewWithActivity>
+```
+
+After:
+
+```tsx
+<TabViewWithActivity key={tab.id} isActive={...} deactivation={...}>
+  <ErrorBoundary
+    fallback={(error, reset) => (
+      <ViewErrorFallback
+        error={error}
+        onRetry={reset}
+        onClose={() => contentPanel.closeView(tab.id)}
+      />
+    )}
+  >
+    <Suspense>
+      <ContentPanelViewContextProvider viewId={tab.id}>
+        <LazyComponent />
+      </ContentPanelViewContextProvider>
+    </Suspense>
+  </ErrorBoundary>
+</TabViewWithActivity>
+```
+
+`ViewErrorFallback` is a small local component in the same file:
+
+```tsx
+function ViewErrorFallback({
+  error,
+  onRetry,
+  onClose,
+}: {
+  error: Error;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <p className="text-sm font-medium text-destructive">Something went wrong</p>
+      <pre className="max-w-md overflow-auto rounded-md bg-muted px-4 py-3 text-left text-xs text-muted-foreground">
+        {error.message}
+      </pre>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+        >
+          Try Again
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent"
+        >
+          Close Tab
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Behavior
+
+- When any content panel view crashes, the affected tab shows the error message with two actions:
+  - **Try Again** - resets the error state and re-mounts the provider + lazy component (recovers from transient HMR issues)
+  - **Close Tab** - dismisses the broken tab (escape hatch for persistent errors)
+- Other tabs remain unaffected.
+- `useContentPanelViewContext` keeps its throw behavior (correct for catching real bugs during development).
+
+## Scope
+
+- 1 file changed (`content-panel.tsx`): add `ErrorBoundary` import, `ViewErrorFallback` component, and wrapper element
+- No API contract changes
+- Existing tests pass unchanged

--- a/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
@@ -6,6 +6,7 @@ import type { ContentPanelView } from "../../../core/plugin/contributions";
 import type { ContentPanelStoreState } from "../types";
 
 import { IMAGE_URLS, getEmpty1Url } from "../../../assets/images";
+import { ErrorBoundary } from "../../../components/ui/error-boundary";
 import { useRendererApp } from "../../../core";
 import { cn } from "../../../lib/utils";
 import { useProjectStore } from "../../project/store";
@@ -59,6 +60,41 @@ function TabViewWithActivity({
       aria-hidden={!isActive || undefined}
     >
       {children}
+    </div>
+  );
+}
+
+function ViewErrorFallback({
+  error,
+  onRetry,
+  onClose,
+}: {
+  error: Error;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <p className="text-sm font-medium text-destructive">Something went wrong</p>
+      <pre className="max-w-md overflow-auto rounded-md bg-muted px-4 py-3 text-left text-xs text-muted-foreground">
+        {error.message}
+      </pre>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+        >
+          Try Again
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent"
+        >
+          Close Tab
+        </button>
+      </div>
     </div>
   );
 }
@@ -140,11 +176,21 @@ export function ContentPanelRenderer() {
                       isActive={state.activeTabId === tab.id}
                       deactivation={view.deactivation}
                     >
-                      <Suspense>
-                        <ContentPanelViewContextProvider viewId={tab.id}>
-                          <LazyComponent />
-                        </ContentPanelViewContextProvider>
-                      </Suspense>
+                      <ErrorBoundary
+                        fallback={(error, reset) => (
+                          <ViewErrorFallback
+                            error={error}
+                            onRetry={reset}
+                            onClose={() => contentPanel.closeView(tab.id)}
+                          />
+                        )}
+                      >
+                        <Suspense>
+                          <ContentPanelViewContextProvider viewId={tab.id}>
+                            <LazyComponent />
+                          </ContentPanelViewContextProvider>
+                        </Suspense>
+                      </ErrorBoundary>
                     </TabViewWithActivity>
                   );
                 })}


### PR DESCRIPTION
## Summary

- Wrap each content panel view in `ErrorBoundary` with a custom `ViewErrorFallback` that offers **Try Again** (recovers from transient HMR context loss) and **Close Tab** (escape hatch for persistent errors)
- A crash in one tab no longer takes down the entire app — other tabs remain unaffected
- Add design doc at `docs/designs/2026-03-15-content-panel-error-boundary.md`

## Test plan

- [ ] Open multiple content panel tabs (terminal, review, etc.)
- [ ] Trigger HMR by editing a view file — verify the affected tab shows the error fallback instead of crashing the app
- [ ] Click "Try Again" — verify the view recovers
- [ ] Click "Close Tab" — verify the tab is removed
- [ ] Verify other tabs remain functional during and after the error
- [ ] `bun ready` passes (format, typecheck, lint, tests)