### PR TITLE
feat: support custom npm registries in skill installer

### DIFF
--- a/docs/designs/2026-03-15-npm-custom-registry.md
+++ b/docs/designs/2026-03-15-npm-custom-registry.md
@@ -1,0 +1,102 @@
+# npm Custom Registry Support
+
+## Overview
+
+Extend `NpmInstaller` to support custom npm registries (e.g. tnpm, cnpm, private registries) by encoding the registry URL directly in `sourceRef`.
+
+## How it works
+
+The `sourceRef` for npm sources gains an optional `?registry=<url>` query parameter:
+
+```
+npm:@corp/skills-pack                                              # default registry
+npm:@corp/skills-pack?registry=https://registry.tnpm.example.com/  # custom registry
+```
+
+`NpmInstaller` parses the query param and passes `--registry=<url>` to all npm commands. No new source type, no schema changes, no plugin involvement.
+
+## Changes
+
+### 1. `NpmInstaller` — parse registry from sourceRef
+
+Replace `normalizePackage()` with `parseSourceRef()`:
+
+```ts
+private parseSourceRef(sourceRef: string): { pkg: string; registry?: string } {
+  const raw = sourceRef.replace(/^npm:/, "");
+  const qIdx = raw.indexOf("?registry=");
+  if (qIdx === -1) return { pkg: raw };
+  return {
+    pkg: raw.slice(0, qIdx),
+    registry: raw.slice(qIdx + "?registry=".length),
+  };
+}
+```
+
+### 2. Pass `--registry` to npm commands
+
+In `fetchAndExtract()` and `getLatestVersion()`, append `["--registry", registry]` to the npm args when registry is defined.
+
+### 3. Remote registry JSON — no change needed
+
+The registry URL is part of `sourceRef`. A tnpm skill entry:
+
+```json
+{
+  "name": "Corp Deploy",
+  "description": "Internal deploy helper",
+  "source": "npm",
+  "sourceRef": "npm:@corp/skills-pack?registry=https://registry.tnpm.example.com/",
+  "skillName": "deploy-tool",
+  "version": "1.0.0"
+}
+```
+
+### 4. `getLatestVersion()` — parse registry before stripping version
+
+The current code strips `@version` with a trailing regex:
+
+```ts
+const pkg = this.normalizePackage(sourceRef).replace(/@[\d.]+$/, "");
+```
+
+With `npm:@corp/pkg@2.1.0?registry=https://...`, the `@version` is no longer at the end — `?registry=` is. Must call `parseSourceRef()` first to split off registry, then strip version from `pkg`:
+
+```ts
+async getLatestVersion(sourceRef: string): Promise<string | undefined> {
+  const { pkg: rawPkg, registry } = this.parseSourceRef(sourceRef);
+  const pkg = rawPkg.replace(/@[\d.]+$/, "");
+  const args = ["view", pkg, "version"];
+  if (registry) args.push("--registry", registry);
+  // ...
+}
+```
+
+### 5. `detect()` — handle bare scoped packages with query params
+
+`detect()` matches `@scope/pkg` without the `npm:` prefix. A bare `@corp/pkg?registry=https://...` still matches (the `@` prefix check passes), and `parseSourceRef`'s `replace(/^npm:/, "")` is a no-op when the prefix is absent — so it works, but only by accident. No code change needed, but worth noting for future maintainers.
+
+### 6. Debug logging — include registry in log output
+
+When npm commands fail against a custom registry, error messages from npm won't mention which registry was used. Include the registry URL in existing `debug()` calls so private registry issues are diagnosable:
+
+```ts
+log("fetchAndExtract", { pkg, registry: registry ?? "default" });
+log("getLatestVersion", { pkg, registry: registry ?? "default" });
+```
+
+## What stays the same
+
+- `SkillSource` type — stays `"prebuilt" | "git" | "npm"`
+- `SkillInstaller` interface — no change
+- `remoteSkillSchema` — `sourceRef` is `z.string()`, query param passes as-is
+- `writeInstallMeta()` — full sourceRef (with registry) persisted, so updates/version checks use the correct registry automatically
+- `detect()` — no change (still matches `npm:` prefix or `@scope/pkg`)
+- Plugin system — not involved
+- Renderer / UI — no change
+
+## File changes
+
+| File                                     | Change                                                                                  |
+| ---------------------------------------- | --------------------------------------------------------------------------------------- |
+| `main/features/skills/installers/npm.ts` | Replace `normalizePackage()` with `parseSourceRef()`, pass `--registry` to npm commands |

--- a/docs/examples/skills-registry.json
+++ b/docs/examples/skills-registry.json
@@ -62,5 +62,13 @@
     "sourceRef": "npm:@claude-skills/i18n-helper@1.0.1",
     "skillName": "i18n-helper",
     "version": "1.0.1"
+  },
+  {
+    "name": "Corp Deploy",
+    "description": "Internal deploy helper for corporate infrastructure",
+    "source": "npm",
+    "sourceRef": "npm:@corp/skills-pack@1.0.0?registry=https://registry.tnpm.example.com/",
+    "skillName": "corp-deploy",
+    "version": "1.0.0"
   }
 ]

--- a/packages/desktop/src/main/features/skills/installers/npm.ts
+++ b/packages/desktop/src/main/features/skills/installers/npm.ts
@@ -24,13 +24,13 @@ export class NpmInstaller implements SkillInstaller {
   }
 
   async scan(sourceRef: string): Promise<{ previewId: string; skills: PreviewSkill[] }> {
-    log("scan", { sourceRef });
-    const pkg = this.normalizePackage(sourceRef);
+    const { pkg, registry } = this.parseSourceRef(sourceRef);
+    log("scan", { pkg, registry: registry ?? "default" });
     const previewId = randomUUID();
     const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${previewId}`);
     await mkdir(tmpDir, { recursive: true });
 
-    await this.fetchAndExtract(pkg, tmpDir);
+    await this.fetchAndExtract(pkg, tmpDir, registry);
 
     this.previewDirs.set(previewId, tmpDir);
     // npm pack extracts to a "package" subdirectory
@@ -40,14 +40,14 @@ export class NpmInstaller implements SkillInstaller {
   }
 
   async install(sourceRef: string, skillName: string, targetDir: string): Promise<void> {
-    log("install", { sourceRef, skillName, targetDir });
-    const pkg = this.normalizePackage(sourceRef);
+    const { pkg, registry } = this.parseSourceRef(sourceRef);
+    log("install", { pkg, skillName, targetDir, registry: registry ?? "default" });
     const previewId = randomUUID();
     const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${previewId}`);
     await mkdir(tmpDir, { recursive: true });
 
     try {
-      await this.fetchAndExtract(pkg, tmpDir);
+      await this.fetchAndExtract(pkg, tmpDir, registry);
       const extractedDir = path.join(tmpDir, "package");
       const src = path.join(extractedDir, skillName);
       const dest = path.join(targetDir, skillName);
@@ -85,10 +85,13 @@ export class NpmInstaller implements SkillInstaller {
   }
 
   async getLatestVersion(sourceRef: string): Promise<string | undefined> {
-    log("getLatestVersion", { sourceRef });
+    const { pkg: rawPkg, registry } = this.parseSourceRef(sourceRef);
+    const pkg = rawPkg.replace(/@[\d.]+$/, "");
+    log("getLatestVersion", { pkg, registry: registry ?? "default" });
     try {
-      const pkg = this.normalizePackage(sourceRef).replace(/@[\d.]+$/, "");
-      const { stdout } = await execFileAsync("npm", ["view", pkg, "version"], {
+      const args = ["view", pkg, "version"];
+      if (registry) args.push("--registry", registry);
+      const { stdout } = await execFileAsync("npm", args, {
         timeout: 15_000,
       });
       return stdout.trim() || undefined;
@@ -97,13 +100,21 @@ export class NpmInstaller implements SkillInstaller {
     }
   }
 
-  private normalizePackage(sourceRef: string): string {
-    return sourceRef.replace(/^npm:/, "");
+  private parseSourceRef(sourceRef: string): { pkg: string; registry?: string } {
+    const raw = sourceRef.replace(/^npm:/, "");
+    const qIdx = raw.indexOf("?registry=");
+    if (qIdx === -1) return { pkg: raw };
+    return {
+      pkg: raw.slice(0, qIdx),
+      registry: raw.slice(qIdx + "?registry=".length),
+    };
   }
 
-  private async fetchAndExtract(pkg: string, destDir: string): Promise<void> {
+  private async fetchAndExtract(pkg: string, destDir: string, registry?: string): Promise<void> {
     // npm pack downloads tarball to cwd
-    await execFileAsync("npm", ["pack", pkg, "--pack-destination", destDir], {
+    const args = ["pack", pkg, "--pack-destination", destDir];
+    if (registry) args.push("--registry", registry);
+    await execFileAsync("npm", args, {
       timeout: 60_000,
       cwd: destDir,
     });


### PR DESCRIPTION
## Summary

- Extend `NpmInstaller` to parse an optional `?registry=<url>` query parameter from `sourceRef` (e.g. `npm:@corp/pkg@1.0.0?registry=https://registry.tnpm.example.com/`)
- Pass `--registry` to `npm pack` and `npm view` commands when a custom registry is specified
- Add debug logging that includes the registry URL for troubleshooting private registry issues
- Add design doc and example registry entry demonstrating the custom registry format

## Test plan

- [ ] Verify `npm:@scope/pkg` (no registry) still works as before
- [ ] Verify `npm:@scope/pkg?registry=https://custom.registry/` passes `--registry` to npm commands
- [ ] Verify `npm:@scope/pkg@1.0.0?registry=https://custom.registry/` correctly strips version before `npm view`
- [ ] Verify `getLatestVersion` uses custom registry when present
- [ ] Verify debug logs include registry info (`neovate:skills:npm`)