### PR TITLE
perf: reduce unnecessary re-renders in session list

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
@@ -29,18 +29,18 @@ export const ChronologicalList = memo(function ChronologicalList() {
   const switchToProjectByPath = useProjectStore((s) => s.switchToProjectByPath);
 
   const handleActivate = useCallback(
-    (sessionId: string, projectPath: string) => {
-      switchToProjectByPath(projectPath);
+    (sessionId: string, projectPath?: string) => {
+      if (projectPath) switchToProjectByPath(projectPath);
       setActiveSession(sessionId);
     },
     [switchToProjectByPath, setActiveSession],
   );
 
   const handleLoad = useCallback(
-    async (sessionId: string, projectPath: string) => {
+    async (sessionId: string, projectPath?: string) => {
       setRestoring(sessionId);
       try {
-        switchToProjectByPath(projectPath);
+        if (projectPath) switchToProjectByPath(projectPath);
         await loadSession(sessionId);
       } finally {
         setRestoring((prev) => (prev === sessionId ? null : prev));
@@ -64,8 +64,8 @@ export const ChronologicalList = memo(function ChronologicalList() {
             activeSessionId={activeSessionId}
             isPinned={false}
             restoring={restoring}
-            onActivate={(sid) => handleActivate(sid, item.projectPath)}
-            onLoad={(sid) => handleLoad(sid, item.projectPath)}
+            onActivate={handleActivate}
+            onLoad={handleLoad}
           />
         );
       })}

--- a/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/pinned-session-list.tsx
@@ -19,18 +19,18 @@ export const PinnedSessionList = memo(function PinnedSessionList() {
   const items = useFilteredSessions({ filter: "pinned" });
 
   const handleActivate = useCallback(
-    (sessionId: string, projectPath: string) => {
-      switchToProjectByPath(projectPath);
+    (sessionId: string, projectPath?: string) => {
+      if (projectPath) switchToProjectByPath(projectPath);
       setActiveSession(sessionId);
     },
     [switchToProjectByPath, setActiveSession],
   );
 
   const handleLoad = useCallback(
-    async (sessionId: string, projectPath: string) => {
+    async (sessionId: string, projectPath?: string) => {
       setRestoring(sessionId);
       try {
-        switchToProjectByPath(projectPath);
+        if (projectPath) switchToProjectByPath(projectPath);
         await loadSession(sessionId);
       } finally {
         setRestoring((prev) => (prev === sessionId ? null : prev));
@@ -55,8 +55,8 @@ export const PinnedSessionList = memo(function PinnedSessionList() {
               activeSessionId={activeSessionId}
               isPinned
               restoring={restoring}
-              onActivate={(sid) => handleActivate(sid, item.projectPath)}
-              onLoad={(sid) => handleLoad(sid, item.projectPath)}
+              onActivate={handleActivate}
+              onLoad={handleLoad}
             />
           );
         })}

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -55,7 +55,7 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
       setActiveSession(sessionId);
     },
     [switchToProjectByPath, project.path, setActiveSession],
-  );
+  ) as (sessionId: string, projectPath?: string) => void;
 
   const handleLoad = useCallback(
     async (sessionId: string) => {
@@ -68,7 +68,7 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
       }
     },
     [switchToProjectByPath, project.path, loadSession],
-  );
+  ) as (sessionId: string, projectPath?: string) => Promise<void>;
 
   if (items.length === 0) {
     return <EmptySessionState variant="compact" />;

--- a/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-actions-menu.tsx
@@ -42,10 +42,10 @@ export function SessionActionsMenu({
   const pinnedSessions = useProjectStore((s) => s.pinnedSessions);
   const isPinned = (pinnedSessions[projectPath] ?? []).includes(sessionId);
 
-  const sessions = useAgentStore((s) => s.sessions);
-  const session = sessions.get(sessionId);
-  const cwd = session?.cwd ?? projectPath;
-  const isNew = session?.isNew ?? false;
+  const sessionCwd = useAgentStore((s) => s.sessions.get(sessionId)?.cwd);
+  const sessionIsNew = useAgentStore((s) => s.sessions.get(sessionId)?.isNew);
+  const cwd = sessionCwd ?? projectPath;
+  const isNew = sessionIsNew ?? false;
 
   const handleCopySessionId = () => {
     log("copySessionId: %s", sessionId.slice(0, 8));

--- a/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
@@ -3,7 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { formatDistanceToNowStrict } from "date-fns";
 import debug from "debug";
 import { Archive, Circle, Pin, PinOff } from "lucide-react";
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 
 import type { TurnResult } from "../store";
 
@@ -72,6 +72,7 @@ export const SessionItem = memo(function SessionItem({
 
   const displayTitle = title || sessionId.slice(0, 8);
   const isProcessing = isStreaming || isRestoring;
+  const relativeTime = useMemo(() => formatRelativeTime(createdAt), [createdAt]);
 
   const handlePinToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -212,7 +213,7 @@ export const SessionItem = memo(function SessionItem({
               isConfirming && "hidden",
             )}
           >
-            {formatRelativeTime(createdAt)}
+            {relativeTime}
           </span>
           {isConfirming ? (
             <button

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { SquarePen } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { SessionInfo } from "../../../../../shared/features/agent/types";
@@ -62,7 +62,7 @@ function MultiProjectSessionList() {
 
 // --- Single-project mode (existing behavior) ---
 
-function SingleProjectSessionList() {
+const SingleProjectSessionList = memo(function SingleProjectSessionList() {
   const { t } = useTranslation();
   const sessions = useAgentStore((s) => s.sessions);
   const activeSessionId = useAgentStore((s) => s.activeSessionId);
@@ -86,14 +86,24 @@ function SingleProjectSessionList() {
     }
   }, [projectPath, loadSessionPreferences]);
 
-  const handleLoad = async (sessionId: string) => {
-    setRestoring(sessionId);
-    try {
-      await loadSession(sessionId);
-    } finally {
-      setRestoring((prev) => (prev === sessionId ? null : prev));
-    }
-  };
+  const handleLoad = useCallback(
+    async (sessionId: string) => {
+      setRestoring(sessionId);
+      try {
+        await loadSession(sessionId);
+      } finally {
+        setRestoring((prev) => (prev === sessionId ? null : prev));
+      }
+    },
+    [loadSession],
+  );
+
+  const handleActivate = useCallback(
+    (sessionId: string) => {
+      setActiveSession(sessionId);
+    },
+    [setActiveSession],
+  ) as (sessionId: string, projectPath?: string) => void;
 
   const { pinnedItems, regularItems, pinned } = useMemo(() => {
     if (!projectPath) return { pinnedItems: [], regularItems: [], pinned: new Set<string>() };
@@ -178,7 +188,7 @@ function SingleProjectSessionList() {
                     activeSessionId={activeSessionId}
                     isPinned={true}
                     restoring={restoring}
-                    onActivate={setActiveSession}
+                    onActivate={handleActivate}
                     onLoad={handleLoad}
                   />
                 );
@@ -194,7 +204,7 @@ function SingleProjectSessionList() {
                 activeSessionId={activeSessionId}
                 isPinned={pinned.has(id)}
                 restoring={restoring}
-                onActivate={setActiveSession}
+                onActivate={handleActivate}
                 onLoad={handleLoad}
               />
             );
@@ -203,4 +213,4 @@ function SingleProjectSessionList() {
       )}
     </div>
   );
-}
+});

--- a/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
 
 import type { UnifiedItem } from "../hooks/use-unified-sessions";
 import type { TurnResult } from "../store";
@@ -12,56 +12,73 @@ interface UnifiedSessionItemProps {
   activeSessionId: string | null;
   isPinned: boolean;
   restoring: string | null;
-  onActivate: (sessionId: string) => void;
-  onLoad: (sessionId: string) => void;
+  onActivate: (sessionId: string, projectPath: string) => void;
+  onLoad: (sessionId: string, projectPath: string) => void;
 }
 
-export const UnifiedSessionItem = memo(function UnifiedSessionItem({
-  item,
-  activeSessionId,
-  isPinned,
-  restoring,
-  onActivate,
-  onLoad,
-}: UnifiedSessionItemProps) {
-  const sessionId = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
-  const { isStreaming, hasPendingRequests } = useSessionChatStatus(sessionId);
-  const turnResult = useAgentStore((s) => s.unseenTurnResults.get(sessionId)) as
-    | TurnResult
-    | undefined;
+export const UnifiedSessionItem = memo(
+  function UnifiedSessionItem({
+    item,
+    activeSessionId,
+    isPinned,
+    restoring,
+    onActivate,
+    onLoad,
+  }: UnifiedSessionItemProps) {
+    const sessionId = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+    const title = item.kind === "memory" ? item.session.title : item.info.title;
+    const createdAt = item.kind === "memory" ? item.session.createdAt : item.info.createdAt;
+    const { isStreaming, hasPendingRequests } = useSessionChatStatus(sessionId);
+    const turnResult = useAgentStore((s) => s.unseenTurnResults.get(sessionId)) as
+      | TurnResult
+      | undefined;
 
-  if (item.kind === "memory") {
-    const s = item.session;
+    const isActive = item.kind === "memory" && sessionId === activeSessionId;
+    const isRestoring = item.kind === "persisted" && restoring === sessionId;
+
+    const handleClick = useCallback(() => {
+      if (item.kind === "memory") {
+        onActivate(sessionId, item.projectPath);
+      } else {
+        onLoad(sessionId, item.projectPath);
+      }
+    }, [item.kind, item.projectPath, sessionId, onActivate, onLoad]);
+
     return (
       <SessionItem
-        sessionId={s.sessionId}
-        title={s.title}
-        createdAt={s.createdAt}
-        isActive={s.sessionId === activeSessionId}
+        sessionId={sessionId}
+        title={title}
+        createdAt={createdAt}
+        isActive={isActive}
         isPinned={isPinned}
-        isRestoring={false}
+        isRestoring={isRestoring}
         isStreaming={isStreaming}
         hasPendingPermission={hasPendingRequests}
         turnResult={turnResult}
-        onClick={() => onActivate(s.sessionId)}
+        onClick={handleClick}
         projectPath={item.projectPath}
       />
     );
-  }
-  const info = item.info;
-  return (
-    <SessionItem
-      sessionId={info.sessionId}
-      title={info.title}
-      createdAt={info.createdAt}
-      isActive={false}
-      isPinned={isPinned}
-      isRestoring={restoring === info.sessionId}
-      isStreaming={isStreaming}
-      hasPendingPermission={hasPendingRequests}
-      turnResult={turnResult}
-      onClick={() => onLoad(info.sessionId)}
-      projectPath={item.projectPath}
-    />
-  );
-});
+  },
+  (prev, next) =>
+    prev.activeSessionId === next.activeSessionId &&
+    prev.isPinned === next.isPinned &&
+    prev.restoring === next.restoring &&
+    prev.onActivate === next.onActivate &&
+    prev.onLoad === next.onLoad &&
+    prev.item.projectPath === next.item.projectPath &&
+    itemId(prev.item) === itemId(next.item) &&
+    itemTitle(prev.item) === itemTitle(next.item) &&
+    itemCreatedAt(prev.item) === itemCreatedAt(next.item) &&
+    prev.item.kind === next.item.kind,
+);
+
+function itemId(item: UnifiedItem) {
+  return item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+}
+function itemTitle(item: UnifiedItem) {
+  return item.kind === "memory" ? item.session.title : item.info.title;
+}
+function itemCreatedAt(item: UnifiedItem) {
+  return item.kind === "memory" ? item.session.createdAt : item.info.createdAt;
+}

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import type { SessionInfo } from "../../../../../shared/features/agent/types";
 import type { ChatSession } from "../store";
@@ -11,6 +11,38 @@ export type UnifiedItem =
   | { kind: "memory"; session: ChatSession; projectPath: string }
   | { kind: "persisted"; info: SessionInfo; projectPath: string };
 
+/** Returns true when session metadata relevant to the list hasn't changed. */
+function sessionsMetaEqual(a: Map<string, ChatSession>, b: Map<string, ChatSession>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [id, sa] of a) {
+    const sb = b.get(id);
+    if (
+      !sb ||
+      sa.sessionId !== sb.sessionId ||
+      sa.cwd !== sb.cwd ||
+      sa.title !== sb.title ||
+      sa.createdAt !== sb.createdAt ||
+      sa.isNew !== sb.isNew
+    )
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Returns a referentially stable `sessions` Map that only changes when
+ * session metadata (id, cwd, title, createdAt, isNew) actually differs.
+ * This prevents the downstream useMemo from recomputing on every chat message.
+ */
+function useStableSessions(): Map<string, ChatSession> {
+  const sessions = useAgentStore((s) => s.sessions);
+  const ref = useRef(sessions);
+  if (!sessionsMetaEqual(ref.current, sessions)) {
+    ref.current = sessions;
+  }
+  return ref.current;
+}
+
 interface UseFilteredSessionsOptions {
   /** Filter to a specific project path. If omitted, includes all registered projects. */
   projectPath?: string;
@@ -22,7 +54,7 @@ export function useFilteredSessions({
   projectPath,
   filter,
 }: UseFilteredSessionsOptions): UnifiedItem[] {
-  const sessions = useAgentStore((s) => s.sessions);
+  const sessions = useStableSessions();
   const agentSessions = useAgentStore((s) => s.agentSessions);
   const projects = useProjectStore((s) => s.projects);
   const pinnedSessions = useProjectStore((s) => s.pinnedSessions);


### PR DESCRIPTION
## Summary

- **Stable sessions selector**: Added `useStableSessions()` hook with metadata-only equality check (`sessionsMetaEqual`) that prevents the session list from recomputing on every streaming message token — only re-derives when session id/cwd/title/createdAt/isNew actually change
- **Custom memo comparator on `UnifiedSessionItem`**: Compares only rendering-relevant fields (id, title, createdAt, kind, projectPath, isPinned, restoring, activeSessionId, callback refs) so items skip re-render when parent state changes don't affect them
- **Eliminated inline closures**: Changed `onActivate`/`onLoad` to forward `projectPath` through the callback signature, so `PinnedSessionList` and `ChronologicalList` pass stable `useCallback` refs instead of creating new `(sid) => handler(sid, item.projectPath)` per item per render
- **Memoized `SingleProjectSessionList`**: Wrapped in `memo()` with `useCallback` for handlers
- **Precise store selectors in `SessionActionsMenu`**: Replaced subscription to entire `sessions` Map with primitive selectors (`?.cwd`, `?.isNew`) scoped to the specific session
- **Memoized date formatting**: `formatRelativeTime` result cached via `useMemo` keyed on `createdAt`

## Test plan

- [ ] Open app with multiple sessions in the sidebar — verify list renders correctly
- [ ] Start a streaming chat — verify sidebar session list doesn't visually flicker or lag
- [ ] Pin/unpin sessions — verify pin state updates immediately in both single and multi-project modes
- [ ] Rename a session via context menu — verify title updates in the list
- [ ] Archive a session — verify it disappears from the list
- [ ] Switch between chronological and by-project organize modes — verify correct rendering
- [ ] Drag-reorder projects in accordion view — verify reorder works
- [ ] Click "Show more" / "Show less" — verify pagination works
- [ ] Verify `bun ready` passes (format + typecheck + lint + tests)