### PR TITLE
fix: polish settings pages with a11y, i18n, and visual fixes

### DIFF
--- a/packages/desktop/src/renderer/src/assets/globals.css
+++ b/packages/desktop/src/renderer/src/assets/globals.css
@@ -117,8 +117,8 @@
   --success-foreground: var(--color-emerald-400);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-400);
-  --color-chat: #f5f7fa;
-  --color-chat-foreground: var(--color-neutral-800);
+  --color-chat: color-mix(in srgb, var(--color-neutral-950) 95%, var(--color-white));
+  --color-chat-foreground: var(--color-neutral-100);
 }
 @layer base {
   * {

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -106,7 +106,7 @@ export const ChatPanel = () => {
             value={config.agentLanguage}
             onValueChange={(val) => setConfig("agentLanguage", val as AgentLanguage)}
           >
-            <SelectTrigger size="sm" className="w-36">
+            <SelectTrigger size="sm" className="min-w-36">
               <SelectValue placeholder={t("settings.chat.selectPlaceholder")}>
                 {t(agentLanguageKeys[config.agentLanguage])}
               </SelectValue>
@@ -127,7 +127,7 @@ export const ChatPanel = () => {
             value={config.permissionMode}
             onValueChange={(val) => setConfig("permissionMode", val as ConfigPermissionMode)}
           >
-            <SelectTrigger size="sm" className="w-36">
+            <SelectTrigger size="sm" className="min-w-36">
               <SelectValue>{t(permissionModeKeys[config.permissionMode])}</SelectValue>
             </SelectTrigger>
             <SelectPopup>
@@ -152,7 +152,10 @@ export const ChatPanel = () => {
             onChange={(val) => setConfig("sendMessageWith", val as SendMessageWith)}
             options={[
               { value: "enter", label: "Enter" },
-              { value: "cmdEnter", label: "⌘+Enter" },
+              {
+                value: "cmdEnter",
+                label: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘+Enter" : "Ctrl+Enter",
+              },
             ]}
           />
         </SettingsRow>

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
@@ -1,5 +1,6 @@
 import createDebug from "debug";
 import { Settings } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Input } from "../../../../components/ui/input";
@@ -32,6 +33,24 @@ export const GeneralPanel = () => {
     setConfig("locale", newLocale as Locales);
     app.i18nManager.applyUILocale(newLocale as Locales);
   };
+
+  // Debounced terminal font input
+  const [localTerminalFont, setLocalTerminalFont] = useState(config.terminalFont);
+  const terminalFontTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    setLocalTerminalFont(config.terminalFont);
+  }, [config.terminalFont]);
+
+  useEffect(() => {
+    if (localTerminalFont === config.terminalFont) return;
+    terminalFontTimerRef.current = setTimeout(() => {
+      setConfig("terminalFont", localTerminalFont);
+    }, 500);
+    return () => {
+      if (terminalFontTimerRef.current) clearTimeout(terminalFontTimerRef.current);
+    };
+  }, [localTerminalFont]);
 
   const handleRunOnStartupChange = async (enabled: boolean) => {
     setConfig("runOnStartup", enabled);
@@ -113,7 +132,7 @@ export const GeneralPanel = () => {
             max={32}
             value={config.terminalFontSize}
             onChange={(e) => setConfig("terminalFontSize", Number(e.target.value))}
-            className="w-20"
+            className="w-24"
           />
         </SettingsRow>
 
@@ -124,8 +143,8 @@ export const GeneralPanel = () => {
         >
           <Input
             type="text"
-            value={config.terminalFont}
-            onChange={(e) => setConfig("terminalFont", e.target.value)}
+            value={localTerminalFont}
+            onChange={(e) => setLocalTerminalFont(e.target.value)}
             placeholder={t("settings.general.terminalFont.default")}
             className="w-40"
           />

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -268,7 +268,7 @@ export const ProvidersPanel = () => {
       }
       cancel();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save");
+      setError(e instanceof Error ? e.message : t("settings.providers.saveFailed"));
     }
   }, [form, isCreating, editingId, addProvider, updateProvider, cancel]);
 
@@ -286,7 +286,7 @@ export const ProvidersPanel = () => {
       setDeleteConfirmOpen(false);
       setProviderToDelete(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to delete");
+      setError(e instanceof Error ? e.message : t("settings.providers.deleteFailed"));
     }
   }, [editingId, providerToDelete, removeProvider, cancel]);
 
@@ -296,7 +296,7 @@ export const ProvidersPanel = () => {
       try {
         await updateProvider(p.id, { enabled: !p.enabled });
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to toggle");
+        setError(e instanceof Error ? e.message : t("settings.providers.toggleFailed"));
       }
     },
     [updateProvider],
@@ -513,32 +513,35 @@ export const ProvidersPanel = () => {
           )}
 
           {/* Name */}
-          <div>
-            <label className="text-sm font-medium">{t("settings.providers.name")}</label>
+          <label className="block">
+            <span className="text-sm font-medium">{t("settings.providers.name")}</span>
             <Input
               value={form.name}
               onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
               placeholder="OpenRouter"
               className="mt-1"
             />
-          </div>
+          </label>
 
           {/* Base URL */}
-          <div>
-            <label className="text-sm font-medium">{t("settings.providers.baseURL")}</label>
+          <label className="block">
+            <span className="text-sm font-medium">{t("settings.providers.baseURL")}</span>
             <Input
               value={form.baseURL}
               onChange={(e) => setForm((f) => ({ ...f, baseURL: e.target.value }))}
               placeholder="https://openrouter.ai/api"
               className="mt-1"
             />
-          </div>
+          </label>
 
           {/* API Key */}
           <div>
-            <label className="text-sm font-medium">{t("settings.providers.apiKey")}</label>
+            <label htmlFor="provider-apikey" className="text-sm font-medium">
+              {t("settings.providers.apiKey")}
+            </label>
             <div className="mt-1 flex items-center gap-1.5">
               <Input
+                id="provider-apikey"
                 type={showApiKey ? "text" : "password"}
                 value={form.apiKey}
                 onChange={(e) => setForm((f) => ({ ...f, apiKey: e.target.value }))}
@@ -619,7 +622,7 @@ export const ProvidersPanel = () => {
           {/* Models */}
           <div>
             <div className="flex items-center justify-between">
-              <label className="text-sm font-medium">{t("settings.providers.models")}</label>
+              <span className="text-sm font-medium">{t("settings.providers.models")}</span>
               {canCheck && (
                 <BenchmarkButton
                   baseURL={form.baseURL}
@@ -705,7 +708,7 @@ export const ProvidersPanel = () => {
 
           {/* Model Map */}
           <div>
-            <label className="text-sm font-medium">{t("settings.providers.modelMap")}</label>
+            <span className="text-sm font-medium">{t("settings.providers.modelMap")}</span>
             <div className="mt-1 grid grid-cols-2 gap-2">
               {(["model", "haiku", "opus", "sonnet"] as const).map((slot) => (
                 <div key={slot}>
@@ -741,7 +744,7 @@ export const ProvidersPanel = () => {
 
           {/* Env Overrides */}
           <div>
-            <label className="text-sm font-medium">{t("settings.providers.envOverrides")}</label>
+            <span className="text-sm font-medium">{t("settings.providers.envOverrides")}</span>
             <div className="mt-1 space-y-1">
               {Object.entries(form.envOverrides).map(([key, value]) => (
                 <div key={key} className="flex items-center gap-2 text-sm">

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/rules-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/rules-panel.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import type { ResolvedReference } from "../../../../../../shared/features/rules/contract";
 
 import { Button } from "../../../../components/ui/button";
+import { Spinner } from "../../../../components/ui/spinner";
 import { client } from "../../../../orpc";
 import { useSettingsStore } from "../../store";
 
@@ -215,7 +216,7 @@ export const RulesPanel = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="text-sm text-muted-foreground">Loading...</div>
+        <Spinner className="h-6 w-6" />
       </div>
     );
   }
@@ -279,6 +280,7 @@ export const RulesPanel = () => {
         onChange={(e) => setContent(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={t("settings.rules.placeholder")}
+        aria-label={t("settings.rules.globalRules")}
         spellCheck={false}
       />
 

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-menu.tsx
@@ -52,7 +52,7 @@ export const SettingsMenu = ({
 
   return (
     <div
-      className="w-56 h-full flex flex-col pt-8 border-r border-border bg-background"
+      className="w-56 h-full flex flex-col pt-8 px-3 border-r border-border bg-background"
       style={{
         // @ts-expect-error - Electron specific CSS property
         WebkitAppRegion: "drag",
@@ -60,7 +60,7 @@ export const SettingsMenu = ({
     >
       {/* Back to app button */}
       <button
-        className="flex items-center text-muted-foreground gap-3 mx-2 px-4 py-3 text-sm transition-colors cursor-pointer hover:text-foreground border-b border-border"
+        className="flex items-center text-muted-foreground gap-3 px-3 py-3 text-sm transition-colors cursor-pointer hover:text-foreground border-b border-border"
         style={{
           // @ts-expect-error - Electron specific CSS property
           WebkitAppRegion: "no-drag",
@@ -80,10 +80,11 @@ export const SettingsMenu = ({
           return (
             <button
               key={item.id}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
-                "w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors cursor-pointer rounded-[6px] mx-2",
+                "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors cursor-pointer rounded-[6px] border",
                 isActive
-                  ? "bg-accent text-accent-foreground border-border"
+                  ? "bg-accent text-accent-foreground border-border font-medium"
                   : "text-muted-foreground hover:text-foreground border-transparent",
               )}
               style={{

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-page.tsx
@@ -52,7 +52,7 @@ export const SettingsPage = () => {
             WebkitAppRegion: "drag",
           }}
         />
-        <div className="px-8 pb-8">
+        <div className="mx-auto max-w-3xl px-8 pb-8">
           {activeMenu === "chat" && <ChatPanel />}
           {activeMenu === "rules" && <RulesPanel />}
           {activeMenu === "general" && <GeneralPanel />}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -138,6 +138,9 @@
   "settings.providers.validation.apiKeyRequired": "API key is required",
   "settings.providers.validation.modelRequired": "At least one model is required",
   "settings.providers.validation.modelMapInvalid": "Model map \"{{slot}}\" references \"{{modelId}}\" which is not in models",
+  "settings.providers.saveFailed": "Failed to save provider",
+  "settings.providers.deleteFailed": "Failed to delete provider",
+  "settings.providers.toggleFailed": "Failed to toggle provider",
 
   "settings.skills": "Skills",
   "settings.skills.addSkill": "Add Skill",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -138,6 +138,9 @@
   "settings.providers.validation.apiKeyRequired": "API 密钥不能为空",
   "settings.providers.validation.modelRequired": "至少需要一个模型",
   "settings.providers.validation.modelMapInvalid": "模型映射 \"{{slot}}\" 引用了不存在的模型 \"{{modelId}}\"",
+  "settings.providers.saveFailed": "保存服务商失败",
+  "settings.providers.deleteFailed": "删除服务商失败",
+  "settings.providers.toggleFailed": "切换服务商失败",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP 配置即将推出...",


### PR DESCRIPTION
## Summary

- **Dark mode bug**: Fixed `--color-chat` and `--color-chat-foreground` in dark theme using light theme values (copy-paste oversight in `globals.css`)
- **Terminal font debounce**: Added 500ms debounce to terminal font input to prevent hammering IPC on every keystroke
- **i18n**: Translated 3 hardcoded English error strings in providers panel, replaced hardcoded "Loading..." in rules panel with `<Spinner>` matching other panels
- **Accessibility**: Fixed provider form labels (`<label>` wrapping for Name/Base URL, `htmlFor`/`id` for API Key), changed decorative section headers from `<label>` to `<span>`, added `aria-label` to rules textarea, added `aria-current="page"` to active settings menu item
- **Platform-aware shortcut**: "⌘+Enter" now shows "Ctrl+Enter" on non-Mac platforms
- **Layout**: Added `max-w-3xl` to settings content area for readability on wide screens, fixed sidebar menu button overflow (`w-full` + `mx-2` bug)
- **Visual**: Strengthened active menu item with `font-medium` + visible border, widened font size input, changed select triggers from `w-36` to `min-w-36` to prevent truncation

## Test plan

- [ ] Verify settings pages render correctly in both light and dark mode
- [ ] Confirm chat area uses dark background in dark mode (not light blue)
- [ ] Type in terminal font input — changes should debounce (not update on every keystroke)
- [ ] Toggle provider errors (e.g., save with empty name) — messages should be translated in Chinese locale
- [ ] Check rules panel loading state shows spinner, not "Loading..." text
- [ ] Verify provider form fields are accessible (screen reader or tab navigation)
- [ ] Check "Send Message" option shows "Ctrl+Enter" on Linux/Windows, "⌘+Enter" on Mac
- [ ] Resize window to ultra-wide — settings content should be constrained to max width
- [ ] Verify active settings menu item is visually distinct (font weight + border)
- [ ] Verify search icon is visible in skills panel search input