### PR TITLE
feat: improve review diff performance with layered optimizations

### DIFF
--- a/docs/designs/2026-03-15-review-large-diff-performance.md
+++ b/docs/designs/2026-03-15-review-large-diff-performance.md
@@ -1,0 +1,220 @@
+# Review Large Diff Performance
+
+## Overview
+
+Solve performance problems when rendering large PR diffs in the review view. Covers four scenarios: large files with small changes, massive change sets, high file counts, and combinations of all three.
+
+## Approach
+
+Four-layer defense-in-depth, pure frontend changes, no backend API modifications.
+
+| Layer | Measure                                  | Scenarios                   |
+| ----- | ---------------------------------------- | --------------------------- |
+| L1    | `@pierre/diffs` built-in options         | Large file, small change    |
+| L2    | File-level guards                        | Extreme files               |
+| L3    | Intersection Observer viewport rendering | Many files                  |
+| L4    | Progressive expand all                   | Many files expanded at once |
+
+## L1 — @pierre/diffs Options
+
+Pass performance-related options to all `MultiFileDiff` instances. Currently only `theme` and `diffStyle` are used, but the library supports:
+
+```tsx
+<MultiFileDiff
+  oldFile={...}
+  newFile={...}
+  options={{
+    theme,
+    diffStyle,
+    expandUnchanged: false,      // collapse unchanged context into clickable separators
+    expansionLineCount: 20,      // expand 20 lines per click
+    tokenizeMaxLineLength: 500,  // skip syntax highlighting for lines > 500 chars
+  }}
+/>
+```
+
+**Effect:**
+
+- 5000-line file with 3 changed lines → renders ~10 lines (changes + context), rest collapsed as separators
+- Users click separators to expand context in 20-line chunks (built-in `@pierre/diffs` behavior)
+- Minified JS/CSS won't hang on syntax highlighting of 100k-char lines
+
+**Apply to both `review-view.tsx` and `git-diff-view.tsx`.**
+
+## L2 — File-Level Guards
+
+Three guards in `renderFileDiff`, before passing data to `MultiFileDiff`:
+
+### 2a. Large file guard (>1MB)
+
+Check `diff.oldContent.length + diff.newContent.length > 1_000_000` after diff is loaded. Show placeholder instead of diff:
+
+```
+┌─ vendor/huge-bundle.min.js (M) ─────────┐
+│   File too large to display diff (2.3 MB)│
+└──────────────────────────────────────────┘
+```
+
+### 2b. Binary file guard
+
+Detect null bytes in content: `content.slice(0, 8192).includes("\0")`. Show placeholder:
+
+```
+┌─ assets/logo.png (M) ───────────────────┐
+│   Binary file changed                    │
+└──────────────────────────────────────────┘
+```
+
+### 2c. High file count warning (>200 files)
+
+Show warning banner below stats line:
+
+```
+⚠ 242 files — large diff may be slow. All files collapsed by default.
+```
+
+Show a confirmation prompt on "Expand All" when file count exceeds 200.
+
+### Locales
+
+Add guard-related strings to `en-US.json` and `zh-CN.json`.
+
+## L3 — Intersection Observer Viewport Rendering
+
+Currently, expanding a file immediately mounts `MultiFileDiff` regardless of viewport position. With expand-all on 200 files, all 200 diff components render simultaneously.
+
+### Design
+
+Introduce a `LazyDiffContent` wrapper component that uses Intersection Observer to control mounting:
+
+```tsx
+function LazyDiffContent({ file, diff, loading, ...props }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver(ref, {
+    rootMargin: "200px",  // start rendering 200px before entering viewport
+    once: false,          // allow unmount when scrolled out
+  });
+
+  return (
+    <div ref={ref} style={{ minHeight: loading ? 80 : undefined }}>
+      {loading ? (
+        <Spinner />
+      ) : isVisible ? (
+        <MultiFileDiff ... />
+      ) : (
+        <div style={{ height: lastKnownHeight }} />  {/* preserve scroll position */}
+      )}
+    </div>
+  );
+}
+```
+
+### Height measurement
+
+When `MultiFileDiff` first renders, measure its height via `ref.current.offsetHeight` and store in a `Record<string, number>` keyed by `relPath`. When the component scrolls out of viewport and unmounts, use the stored height as placeholder `div` height. This prevents scrollbar jumps during unmount/remount cycles.
+
+### scrollToFile compatibility
+
+When a user clicks a file in the file tree, `scrollIntoView` triggers before the Intersection Observer callback fires (async). This causes a flash of empty placeholder. To fix: `scrollToFile` should set a `forceVisible` flag for the target file, bypassing the observer check so `MultiFileDiff` mounts immediately on scroll.
+
+### Key details
+
+- `rootMargin: "200px"` — pre-render before entering viewport, no visible delay
+- Scrolling out preserves measured height as placeholder, preventing scrollbar jumps
+- `once: false` — unmount when out of viewport to free memory; `@pierre/diffs` has internal render cache so re-mount doesn't recompute diff
+- `useIntersectionObserver` is a simple custom hook (~20 lines), no new dependencies
+
+### New file
+
+`hooks/useIntersectionObserver.ts` — generic reusable hook.
+
+### Effect
+
+- Expand All 200 files → only ~5 `MultiFileDiff` instances in DOM at any time
+- Memory usage drops from O(n) to O(visible files)
+
+## L4 — Progressive Expand All
+
+Current `expandAll` adds all files to `expandedFiles` Set at once and fires 5 concurrent `loadDiff` requests. Even with L3 viewport protection, this sends all diff requests simultaneously.
+
+### Design
+
+Batch expansion with idle callbacks:
+
+```tsx
+const expandAll = () => {
+  const ordered = files.map((f) => f.relPath);
+  let idx = 0;
+
+  const expandBatch = () => {
+    const batch = ordered.slice(idx, idx + 10); // 10 files per batch
+    if (batch.length === 0) return;
+    idx += batch.length;
+
+    setExpandedFiles((prev) => {
+      const next = new Set(prev);
+      batch.forEach((p) => next.add(p));
+      return next;
+    });
+
+    // 5 concurrent loadDiff per batch
+    let loadIdx = 0;
+    const loadNext = () => {
+      if (loadIdx >= batch.length) return;
+      const relPath = batch[loadIdx++];
+      if (!diffs[relPath] && !loadingDiffs[relPath]) {
+        loadDiff(relPath).then(loadNext);
+      } else {
+        loadNext();
+      }
+    };
+    for (let i = 0; i < Math.min(5, batch.length); i++) loadNext();
+
+    requestIdleCallback(expandBatch);
+  };
+
+  expandBatch();
+};
+```
+
+### Key details
+
+- 10 files per batch, batches separated by `requestIdleCallback` to yield main thread
+- 5 concurrent `loadDiff` limit per batch (consistent with current behavior)
+- Combined with L3: first batch files in viewport render immediately, later files marked as expanded but `MultiFileDiff` deferred until scrolled into view
+- User perception: first few files show diff almost instantly, rest load silently in background
+- Collapse All needs no changes — clearing `expandedFiles` Set triggers L3 observer unmount
+
+## Files Changed
+
+- `plugins/review/review-view.tsx` — L1 through L4 changes
+- `plugins/git/git-diff-view.tsx` — L1 options sync
+- `plugins/review/locales/{en-US,zh-CN}.json` — L2 guard strings
+- New: `hooks/useIntersectionObserver.ts` — L3 generic hook
+
+## Performance Detail: Memoize Diff Options
+
+The `options` object passed to `MultiFileDiff` is created inline on every render, causing unnecessary re-renders. Memoize with `useMemo`:
+
+```tsx
+const diffOptions = useMemo(
+  () => ({
+    theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
+    diffStyle,
+    expandUnchanged: false,
+    expansionLineCount: 20,
+    tokenizeMaxLineLength: 500,
+  }),
+  [resolvedTheme, diffStyle],
+);
+```
+
+## Not Changed
+
+- Backend / main process
+- Shared contracts
+- `@pierre/diffs` library itself
+
+## Future Considerations
+
+If further optimization is needed, switch from `MultiFileDiff` (takes raw old/new content, computes diff in JS) to `PatchDiff` (takes unified patch string from git, naturally compact). This requires backend API changes to return `git diff` output instead of full file contents.

--- a/packages/desktop/src/renderer/src/hooks/use-intersection-observer.ts
+++ b/packages/desktop/src/renderer/src/hooks/use-intersection-observer.ts
@@ -1,0 +1,23 @@
+import { type RefObject, useEffect, useState } from "react";
+
+export function useIntersectionObserver(
+  ref: RefObject<Element | null>,
+  options: { rootMargin?: string; threshold?: number } = {},
+): boolean {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(([entry]) => setIsVisible(entry.isIntersecting), {
+      rootMargin: options.rootMargin ?? "0px",
+      threshold: options.threshold ?? 0,
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, options.rootMargin, options.threshold]);
+
+  return isVisible;
+}

--- a/packages/desktop/src/renderer/src/plugins/git/git-diff-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/git/git-diff-view.tsx
@@ -2,7 +2,7 @@ import { MultiFileDiff } from "@pierre/diffs/react";
 import debug from "debug";
 import { Columns2, AlignJustify, File, FilePlus, GitBranch, GitCommit } from "lucide-react";
 import { useTheme } from "next-themes";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 
 const log = debug("neovate:git:diff");
 
@@ -33,6 +33,17 @@ export default memo(function GitDiffView() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [diffStyle, setDiffStyle] = useState<DiffStyle>("unified");
+
+  const diffOptions = useMemo(
+    () => ({
+      theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
+      diffStyle,
+      expandUnchanged: false,
+      expansionLineCount: 20,
+      tokenizeMaxLineLength: 500,
+    }),
+    [resolvedTheme, diffStyle],
+  );
 
   const oldFile = {
     name: diffData?.fileName || "",
@@ -211,29 +222,16 @@ export default memo(function GitDiffView() {
           <MultiFileDiff
             oldFile={{ name: "(empty)", contents: "" }}
             newFile={newFile}
-            options={{
-              theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
-              diffStyle,
-            }}
+            options={diffOptions}
           />
         ) : isDeletedFile ? (
           <MultiFileDiff
             oldFile={oldFile}
             newFile={{ name: "(empty)", contents: "" }}
-            options={{
-              theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
-              diffStyle,
-            }}
+            options={diffOptions}
           />
         ) : (
-          <MultiFileDiff
-            oldFile={oldFile}
-            newFile={newFile}
-            options={{
-              theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
-              diffStyle,
-            }}
-          />
+          <MultiFileDiff oldFile={oldFile} newFile={newFile} options={diffOptions} />
         )}
       </div>
     </div>

--- a/packages/desktop/src/renderer/src/plugins/review/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/plugins/review/locales/en-US.json
@@ -33,5 +33,7 @@
   "review.menu.showFileTree": "Show File Tree",
   "review.menu.hideFileTree": "Hide File Tree",
   "review.menu.expandAll": "Expand All",
-  "review.menu.collapseAll": "Collapse All"
+  "review.menu.collapseAll": "Collapse All",
+  "review.highFileCount": "{{count}} files — large diff may be slow. All files collapsed by default.",
+  "review.expandAllConfirm": "This will expand {{count}} files. This may be slow. Continue?"
 }

--- a/packages/desktop/src/renderer/src/plugins/review/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/plugins/review/locales/zh-CN.json
@@ -33,5 +33,7 @@
   "review.menu.showFileTree": "显示文件树",
   "review.menu.hideFileTree": "隐藏文件树",
   "review.menu.expandAll": "全部展开",
-  "review.menu.collapseAll": "全部折叠"
+  "review.menu.collapseAll": "全部折叠",
+  "review.highFileCount": "{{count}} 个文件 — 大量差异可能导致卡顿。所有文件默认折叠。",
+  "review.expandAllConfirm": "即将展开 {{count}} 个文件，可能会比较慢。是否继续？"
 }

--- a/packages/desktop/src/renderer/src/plugins/review/review-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/review/review-view.tsx
@@ -1,5 +1,6 @@
 import { MultiFileDiff } from "@pierre/diffs/react";
 import {
+  AlertTriangle,
   Bot,
   ChevronDown,
   ChevronRight,
@@ -11,7 +12,7 @@ import {
   AlignJustify,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Popover, PopoverTrigger, PopoverPopup } from "../../components/ui/popover";
 import {
@@ -24,11 +25,57 @@ import {
 import { usePluginContext } from "../../core/app";
 import { useContentPanelViewContext } from "../../features/content-panel";
 import { useProjectStore } from "../../features/project/store";
+import { useIntersectionObserver } from "../../hooks/use-intersection-observer";
 import { useActiveSession } from "../../hooks/useActiveSession";
 import { useReview, type ReviewCategory, type ReviewFile } from "./hooks/useReview";
 import { useReviewTranslation } from "./i18n";
 
 type DiffStyle = "unified" | "split";
+
+const FILE_SIZE_LIMIT = 1_000_000; // 1MB
+const HIGH_FILE_COUNT = 200;
+
+// L3: Viewport-aware diff rendering — only mounts MultiFileDiff when visible
+function LazyDiffContent({
+  file,
+  diff,
+  options,
+  forceVisible,
+  lastHeight,
+  onHeightChange,
+}: {
+  file: ReviewFile;
+  diff: { oldContent: string; newContent: string };
+  options: Record<string, unknown>;
+  forceVisible: boolean;
+  lastHeight?: number;
+  onHeightChange: (height: number) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isInViewport = useIntersectionObserver(containerRef, { rootMargin: "200px" });
+  const shouldRender = forceVisible || isInViewport;
+
+  useEffect(() => {
+    if (shouldRender && containerRef.current) {
+      const height = containerRef.current.offsetHeight;
+      if (height > 0) onHeightChange(height);
+    }
+  }, [shouldRender, diff]);
+
+  return (
+    <div ref={containerRef}>
+      {shouldRender ? (
+        <MultiFileDiff
+          oldFile={{ name: file.fileName, contents: diff.oldContent }}
+          newFile={{ name: file.fileName, contents: diff.newContent }}
+          options={options}
+        />
+      ) : (
+        <div style={{ height: lastHeight ?? 80 }} />
+      )}
+    </div>
+  );
+}
 
 export default memo(function ReviewView() {
   const { t } = useReviewTranslation();
@@ -46,9 +93,23 @@ export default memo(function ReviewView() {
   );
   const [showFileTree, setShowFileTree] = useState(!!savedState.showFileTree);
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
+  const [forceVisibleFiles, setForceVisibleFiles] = useState<Set<string>>(new Set());
+  const [diffHeights, setDiffHeights] = useState<Record<string, number>>({});
 
   const { files, loading, error, branchInfo, diffs, loadingDiffs, refresh, loadDiff } =
     useReview(category);
+
+  // L1: Memoize diff options to avoid unnecessary MultiFileDiff re-renders
+  const diffOptions = useMemo(
+    () => ({
+      theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
+      diffStyle,
+      expandUnchanged: false,
+      expansionLineCount: 20,
+      tokenizeMaxLineLength: 500,
+    }),
+    [resolvedTheme, diffStyle],
+  );
 
   // Fetch branch info for the select label even when not on branch category
   const [selectBranchLabel, setSelectBranchLabel] = useState<string | null>(null);
@@ -114,19 +175,43 @@ export default memo(function ReviewView() {
     });
   };
 
+  // L4: Progressive expand all — batch 10 files at a time with idle callbacks
   const expandAll = () => {
-    const allPaths = new Set(files.map((f) => f.relPath));
-    setExpandedFiles(allPaths);
-    // Batch load diffs with concurrency limit
-    const toLoad = files.filter((f) => !diffs[f.relPath] && !loadingDiffs[f.relPath]);
+    if (files.length > HIGH_FILE_COUNT) {
+      if (!window.confirm(t("review.expandAllConfirm", { count: files.length }))) return;
+    }
+
+    const ordered = files.map((f) => f.relPath);
     let idx = 0;
-    const loadNext = () => {
-      if (idx >= toLoad.length) return;
-      const file = toLoad[idx++];
-      loadDiff(file.relPath).then(loadNext);
+
+    const expandBatch = () => {
+      const batch = ordered.slice(idx, idx + 10);
+      if (batch.length === 0) return;
+      idx += batch.length;
+
+      setExpandedFiles((prev) => {
+        const next = new Set(prev);
+        for (const p of batch) next.add(p);
+        return next;
+      });
+
+      // 5 concurrent loadDiff per batch
+      let loadIdx = 0;
+      const loadNext = () => {
+        if (loadIdx >= batch.length) return;
+        const relPath = batch[loadIdx++];
+        if (!diffs[relPath] && !loadingDiffs[relPath]) {
+          loadDiff(relPath).then(loadNext);
+        } else {
+          loadNext();
+        }
+      };
+      for (let i = 0; i < Math.min(5, batch.length); i++) loadNext();
+
+      requestIdleCallback(expandBatch);
     };
-    // Start 5 concurrent loaders
-    for (let i = 0; i < Math.min(5, toLoad.length); i++) loadNext();
+
+    expandBatch();
   };
 
   const collapseAll = () => {
@@ -145,9 +230,14 @@ export default memo(function ReviewView() {
     return () => window.removeEventListener("neovate:open-review", handler);
   }, []);
 
-  // Scroll to file from file tree
+  // Scroll to file from file tree — force visible to bypass intersection observer
   const diffContainerRef = useRef<HTMLDivElement>(null);
   const scrollToFile = (relPath: string) => {
+    setForceVisibleFiles((prev) => {
+      const next = new Set(prev);
+      next.add(relPath);
+      return next;
+    });
     if (!expandedFiles.has(relPath)) {
       toggleFile(relPath);
     }
@@ -233,6 +323,11 @@ export default memo(function ReviewView() {
     return null;
   };
 
+  // L2: File-level guards
+  const isBinary = (content: string) => content.slice(0, 8192).includes("\0");
+  const isFileTooLarge = (diff: { oldContent: string; newContent: string }) =>
+    diff.oldContent.length + diff.newContent.length > FILE_SIZE_LIMIT;
+
   const renderFileDiff = (file: ReviewFile) => {
     const isExpanded = expandedFiles.has(file.relPath);
     const diff = diffs[file.relPath];
@@ -268,18 +363,26 @@ export default memo(function ReviewView() {
                 <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
               </div>
             ) : diff ? (
-              diff.oldContent === "" && diff.newContent === "" ? (
+              isBinary(diff.oldContent) || isBinary(diff.newContent) ? (
+                <div className="py-4 text-center text-sm text-muted-foreground">
+                  {t("review.binaryFile")}
+                </div>
+              ) : isFileTooLarge(diff) ? (
+                <div className="py-4 text-center text-sm text-muted-foreground">
+                  {t("review.fileTooLarge")}
+                </div>
+              ) : diff.oldContent === "" && diff.newContent === "" ? (
                 <div className="py-4 text-center text-sm text-muted-foreground">
                   {t("review.noChanges")}
                 </div>
               ) : (
-                <MultiFileDiff
-                  oldFile={{ name: file.fileName, contents: diff.oldContent }}
-                  newFile={{ name: file.fileName, contents: diff.newContent }}
-                  options={{
-                    theme: resolvedTheme === "dark" ? "pierre-dark" : "pierre-light",
-                    diffStyle,
-                  }}
+                <LazyDiffContent
+                  file={file}
+                  diff={diff}
+                  options={diffOptions}
+                  forceVisible={forceVisibleFiles.has(file.relPath)}
+                  lastHeight={diffHeights[file.relPath]}
+                  onHeightChange={(h) => setDiffHeights((prev) => ({ ...prev, [file.relPath]: h }))}
                 />
               )
             ) : null}
@@ -402,6 +505,14 @@ export default memo(function ReviewView() {
       {!loading && !error && files.length > 0 && (
         <div className="px-3 py-1 text-xs text-muted-foreground border-b shrink-0">
           {statsLine()}
+        </div>
+      )}
+
+      {/* L2: High file count warning */}
+      {!loading && !error && files.length > HIGH_FILE_COUNT && (
+        <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-950 border-b shrink-0">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+          {t("review.highFileCount", { count: files.length })}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **L1**: Enable `@pierre/diffs` built-in performance options (`expandUnchanged: false`, `expansionLineCount: 20`, `tokenizeMaxLineLength: 500`) on all `MultiFileDiff` instances in both review and git-diff views. Memoize options object with `useMemo`.
- **L2**: Add file-level guards — binary file detection (null byte in first 8KB), large file placeholder (>1MB), high file count warning banner (>200 files) with expand-all confirmation prompt.
- **L3**: Introduce `LazyDiffContent` wrapper with Intersection Observer (`rootMargin: 200px`) for viewport-aware rendering. Unmounted diffs use measured-height placeholders to prevent scroll jumps. `scrollToFile` bypasses observer via `forceVisible` flag.
- **L4**: Replace one-shot `expandAll` with progressive batching — 10 files per batch via `requestIdleCallback`, 5 concurrent `loadDiff` per batch.

Design doc: `docs/designs/2026-03-15-review-large-diff-performance.md`

## Test plan

- [ ] Open review panel with a large file that has small changes — verify unchanged context is collapsed into expandable separators
- [ ] Open a binary file diff — verify "Binary file changed" placeholder shown
- [ ] Open a diff with file >1MB — verify "File too large" placeholder shown
- [ ] Load a category with >200 files — verify warning banner appears and expand-all shows confirmation
- [ ] Expand all on 50+ files — verify diffs render progressively as you scroll, not all at once
- [ ] Click a file in the file tree sidebar — verify it scrolls to and renders immediately without flash
- [ ] Collapse all after expand all — verify all diffs unmount cleanly
- [ ] Toggle diff style (unified/split) — verify memoized options update correctly