### PR TITLE
fix: polish message input with a11y, i18n, and visual fixes

### DIFF
--- a/packages/desktop/src/renderer/src/assets/globals.css
+++ b/packages/desktop/src/renderer/src/assets/globals.css
@@ -161,8 +161,8 @@
   }
 
   .tiptap .slash-command {
-    background: rgba(20, 184, 166, 0.15);
-    color: #14b8a6;
+    background: --alpha(var(--success) / 15%);
+    color: var(--success-foreground);
     border-radius: 0.25rem;
     padding: 0.125rem 0.375rem;
     font-size: 0.875em;

--- a/packages/desktop/src/renderer/src/features/agent/components/attachment-preview.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/attachment-preview.tsx
@@ -1,4 +1,6 @@
 import { X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { useTranslation } from "react-i18next";
 
 import type { ImageAttachment } from "../../../../../shared/features/agent/types";
 
@@ -8,26 +10,38 @@ type Props = {
 };
 
 export function AttachmentPreview({ attachments, onRemove }: Props) {
+  const { t } = useTranslation();
+
   if (attachments.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-2 border-t border-border/50 px-3 py-2">
-      {attachments.map((att) => (
-        <div key={att.id} className="attachment-thumb group relative">
-          <img
-            src={`data:${att.mediaType};base64,${att.base64}`}
-            alt={att.filename}
-            className="h-14 w-14 rounded-md object-cover"
-          />
-          <button
-            type="button"
-            className="absolute -right-1.5 -top-1.5 hidden h-4 w-4 items-center justify-center rounded-full bg-destructive text-destructive-foreground group-hover:flex"
-            onClick={() => onRemove(att.id)}
+      <AnimatePresence>
+        {attachments.map((att) => (
+          <motion.div
+            key={att.id}
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={{ duration: 0.15 }}
+            className="attachment-thumb group relative"
           >
-            <X className="h-3 w-3" />
-          </button>
-        </div>
-      ))}
+            <img
+              src={`data:${att.mediaType};base64,${att.base64}`}
+              alt={att.filename}
+              className="h-14 w-14 rounded-md object-cover"
+            />
+            <button
+              type="button"
+              aria-label={t("chat.removeAttachment", { filename: att.filename })}
+              className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-destructive-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => onRemove(att.id)}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -62,14 +62,20 @@ export function InputToolbar({
 }: Props) {
   const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
 
+  const { t } = useTranslation();
+
   return (
-    <div className="flex items-center gap-1 border-border/50 px-2 py-2 bg-background-secondary">
+    <div
+      className="flex items-center gap-1 border-border/50 px-2 py-2 bg-background-secondary"
+      role="toolbar"
+      aria-label={t("chat.messageActions")}
+    >
       <Button
         type="button"
         variant="ghost"
         size="icon"
         className="h-7 w-7"
-        title="Attach image"
+        title={t("chat.attachImage")}
         onClick={onAttach}
       >
         <Paperclip className="h-4 w-4" />
@@ -94,7 +100,7 @@ export function InputToolbar({
           className="h-7 w-7"
           disabled={disabled}
           onClick={onSend}
-          title={sendMessageWith === "cmdEnter" ? "Send (⌘+Enter)" : "Send (Enter)"}
+          title={sendMessageWith === "cmdEnter" ? t("chat.sendCmdEnter") : t("chat.sendEnter")}
         >
           <SendHorizonal className="h-4 w-4" />
         </Button>
@@ -209,6 +215,7 @@ function ConnectedModelSelect({
   chatStore: StoreApi<ClaudeCodeChatStoreState>;
   disabled: boolean;
 }) {
+  const { t } = useTranslation();
   const setCurrentModel = useAgentStore((s) => s.setCurrentModel);
   const setModelScope = useAgentStore((s) => s.setModelScope);
   const currentModel = useAgentStore((s) => s.sessions.get(activeSessionId)?.currentModel);
@@ -378,8 +385,10 @@ function ConnectedModelSelect({
                   .filter((p) => p.enabled)
                   .map((p) => (
                     <div key={p.id}>
-                      <div
-                        className={`px-3 py-1.5 text-xs font-medium ${
+                      <button
+                        type="button"
+                        disabled={hasMessages && providerId !== p.id}
+                        className={`w-full text-left px-3 py-1.5 text-xs font-medium ${
                           providerId === p.id
                             ? "text-foreground"
                             : hasMessages
@@ -388,7 +397,7 @@ function ConnectedModelSelect({
                         }`}
                         title={
                           hasMessages && providerId !== p.id
-                            ? "Provider switch requires a new session"
+                            ? t("chat.providerSwitchHint")
                             : undefined
                         }
                         onClick={() => {
@@ -399,7 +408,7 @@ function ConnectedModelSelect({
                       >
                         {providerId === p.id ? "\u2022 " : "\u25CB "}
                         {p.name}
-                      </div>
+                      </button>
                       {providerId === p.id && (
                         <MenuRadioGroup
                           value={currentModel ?? ""}
@@ -429,17 +438,17 @@ function ConnectedModelSelect({
             {/* SDK Default section */}
             <div>
               {providers.filter((p) => p.enabled).length > 0 && (
-                <div
-                  className={`px-3 py-1.5 text-xs font-medium ${
+                <button
+                  type="button"
+                  disabled={hasMessages && !!providerId}
+                  className={`w-full text-left px-3 py-1.5 text-xs font-medium ${
                     !providerId
                       ? "text-foreground"
                       : hasMessages
                         ? "text-muted-foreground/50 cursor-not-allowed"
                         : "text-muted-foreground hover:text-foreground hover:bg-accent cursor-pointer"
                   }`}
-                  title={
-                    hasMessages && providerId ? "Provider switch requires a new session" : undefined
-                  }
+                  title={hasMessages && providerId ? t("chat.providerSwitchHint") : undefined}
                   onClick={() => {
                     if (providerId && !hasMessages) {
                       handleProviderSwitch(null);
@@ -447,8 +456,8 @@ function ConnectedModelSelect({
                   }}
                 >
                   {!providerId ? "\u2022 " : "\u25CB "}
-                  SDK Default
-                </div>
+                  {t("chat.sdkDefault")}
+                </button>
               )}
               {!providerId && availableModels && (
                 <MenuRadioGroup
@@ -478,7 +487,7 @@ function ConnectedModelSelect({
               }}
             >
               <Settings className="h-3 w-3" />
-              Manage Providers...
+              {t("chat.manageProviders")}
             </button>
           </MenuPopup>
         </Menu>
@@ -486,15 +495,15 @@ function ConnectedModelSelect({
       <ContextMenuPopup>
         <ContextMenuItem onClick={() => handleScopeAction("project")}>
           <FolderOpen className="h-4 w-4" />
-          Set as project default
+          {t("chat.setProjectDefault")}
         </ContextMenuItem>
         <ContextMenuItem onClick={() => handleScopeAction("global")}>
           <Globe className="h-4 w-4" />
-          Set as global default
+          {t("chat.setGlobalDefault")}
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem onClick={() => handleScopeAction("clear")}>
-          Clear session override
+          {t("chat.clearSessionOverride")}
         </ContextMenuItem>
       </ContextMenuPopup>
     </ContextMenu>

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -3,7 +3,9 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Extension, useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import debug from "debug";
+import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { ImageAttachment, PermissionMode } from "../../../../../shared/features/agent/types";
 
@@ -46,6 +48,7 @@ export function MessageInput({
   cwd,
   dockAttached = false,
 }: Props) {
+  const { t } = useTranslation();
   const cwdRef = useLatestRef(cwd);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { createNewSession } = useNewSession();
@@ -120,7 +123,7 @@ export function MessageInput({
         blockquote: false,
       }),
       Placeholder.configure({
-        placeholder: "Type a message...",
+        placeholder: t("chat.placeholder"),
       }),
       mentionExtension,
       slashCommandsExtension,
@@ -189,7 +192,6 @@ export function MessageInput({
                     return true;
                   }
                   if (event.key === "Escape") {
-                    editor.commands.clearContent();
                     editor.commands.blur();
                     return true;
                   }
@@ -292,6 +294,7 @@ export function MessageInput({
         accept="image/*"
         multiple
         className="hidden"
+        aria-label={t("chat.attachImages")}
         onChange={handleFileSelect}
       />
       <div
@@ -315,17 +318,27 @@ export function MessageInput({
               "linear-gradient(var(--background-secondary)) padding-box,linear-gradient(0deg,color-mix(in srgb, var(--primary) 50%, transparent) 0,transparent 80%,transparent)border-box",
           }}
         >
-          {permissionMode === "plan" && (
-            <div
-              className={cn(
-                "flex items-center gap-1.5 border-b border-blue-200 bg-blue-50 px-3 py-1 text-xs text-blue-600 dark:border-blue-800/50 dark:bg-blue-950/30 dark:text-blue-400",
-                dockAttached ? "rounded-t-[18px]" : "rounded-t-lg",
-              )}
-            >
-              <span className="font-medium">Plan mode</span>
-              <span className="text-blue-500/70 dark:text-blue-400/50">Shift+Tab to exit</span>
-            </div>
-          )}
+          <AnimatePresence>
+            {permissionMode === "plan" && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.15 }}
+                className="overflow-hidden"
+              >
+                <div
+                  className={cn(
+                    "flex items-center gap-1.5 border-b border-info/20 bg-info/5 px-3 py-1 text-xs text-info-foreground",
+                    dockAttached ? "rounded-t-[18px]" : "rounded-t-lg",
+                  )}
+                >
+                  <span className="font-medium">{t("chat.planMode")}</span>
+                  <span className="text-info-foreground/50">{t("chat.planModeExit")}</span>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
           <EditorContent editor={editor} />
           <AttachmentPreview attachments={attachments} onRemove={removeAttachment} />
           <InputToolbar

--- a/packages/desktop/src/renderer/src/features/agent/components/suggestion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/suggestion-list.tsx
@@ -9,6 +9,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { cn } from "../../../lib/utils";
+
 export type SuggestionItem = {
   id?: string;
   label: string;
@@ -74,9 +76,10 @@ export const SuggestionList = forwardRef<SuggestionListHandle, Props>(
             <button
               key={item.id ?? item.label}
               ref={index === selectedIndex ? selectedRef : undefined}
-              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left ${
-                index === selectedIndex ? "bg-accent" : ""
-              }`}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left",
+                index === selectedIndex && "bg-accent",
+              )}
               onClick={() => command(item)}
               onMouseEnter={() => setSelectedIndex(index)}
               type="button"

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -296,5 +296,21 @@
   "contentPanel.noTabsOpen": "No tabs open",
 
   "error.somethingWentWrong": "Something went wrong",
-  "error.tryAgain": "Try again"
+  "error.tryAgain": "Try again",
+
+  "chat.placeholder": "Type a message...",
+  "chat.attachImage": "Attach image",
+  "chat.attachImages": "Attach images",
+  "chat.removeAttachment": "Remove {{filename}}",
+  "chat.sendEnter": "Send (Enter)",
+  "chat.sendCmdEnter": "Send (⌘Enter)",
+  "chat.planMode": "Plan mode",
+  "chat.planModeExit": "Shift+Tab to exit",
+  "chat.sdkDefault": "SDK Default",
+  "chat.manageProviders": "Manage Providers...",
+  "chat.setProjectDefault": "Set as project default",
+  "chat.setGlobalDefault": "Set as global default",
+  "chat.clearSessionOverride": "Clear session override",
+  "chat.providerSwitchHint": "Provider switch requires a new session",
+  "chat.messageActions": "Message actions"
 }

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -298,5 +298,21 @@
   "contentPanel.noTabsOpen": "暂无打开的标签页",
 
   "error.somethingWentWrong": "出错了",
-  "error.tryAgain": "重试"
+  "error.tryAgain": "重试",
+
+  "chat.placeholder": "输入消息...",
+  "chat.attachImage": "附加图片",
+  "chat.attachImages": "附加图片",
+  "chat.removeAttachment": "移除 {{filename}}",
+  "chat.sendEnter": "发送 (Enter)",
+  "chat.sendCmdEnter": "发送 (⌘Enter)",
+  "chat.planMode": "计划模式",
+  "chat.planModeExit": "Shift+Tab 退出",
+  "chat.sdkDefault": "SDK 默认",
+  "chat.manageProviders": "管理服务商...",
+  "chat.setProjectDefault": "设为项目默认",
+  "chat.setGlobalDefault": "设为全局默认",
+  "chat.clearSessionOverride": "清除会话覆盖",
+  "chat.providerSwitchHint": "切换服务商需要新建会话",
+  "chat.messageActions": "消息操作"
 }


### PR DESCRIPTION
## Summary

- **Dark mode fix**: Replaced hard-coded teal colors on `.slash-command` with `--success` design tokens so they adapt to dark mode (matching how `.mention` already uses `--primary`)
- **Accessibility**: Made attachment remove buttons keyboard-accessible (opacity-based visibility instead of `display:none`), added `aria-label` attributes, changed provider header `<div>`s to `<button>`s, added `role="toolbar"` to input toolbar
- **i18n**: Added 16 new translation keys (en-US + zh-CN) for all hard-coded strings in the message input area — placeholder, toolbar titles, context menu items, plan mode labels, provider switch hint
- **Animations**: Added `motion` enter/exit animations for plan mode banner (height + opacity) and attachment thumbnails (scale + opacity)
- **Design tokens**: Replaced raw Tailwind blue classes on plan mode banner with `info` design tokens for theme consistency
- **UX**: Escape key now only blurs the editor instead of destructively clearing content
- **Code consistency**: Replaced string interpolation with `cn()` in suggestion-list

## Test plan

- [ ] Toggle plan mode (Shift+Tab) — banner should animate in/out smoothly
- [ ] Paste/attach an image — thumbnail should scale in; remove button visible on hover and via Tab key
- [ ] Press Escape in editor with typed content — should blur without clearing
- [ ] Switch theme to dark mode — slash commands and plan mode banner should use correct colors
- [ ] Change language to Chinese — all input area labels should translate
- [ ] Right-click model selector — context menu items should be translated
- [ ] Tab to attachment remove button — should be focusable with visible ring
- [ ] Verify provider headers in model dropdown are keyboard-navigable