### PR TITLE
feat(providers): add configurable badges to provider templates

### DIFF
--- a/docs/designs/2026-03-16-provider-badges.md
+++ b/docs/designs/2026-03-16-provider-badges.md
@@ -1,0 +1,79 @@
+# Provider Template Badges
+
+## Summary
+
+Add a `badges` field to `ProviderTemplate` so plugin authors can tag templates with predefined semantic badges (e.g., "recommended", "internal", "new"). Badges display as small pills in the template picker grid. Templates are sorted by badge priority.
+
+## Data Model
+
+Add to `ProviderTemplate` in `src/shared/features/provider/built-in.ts`:
+
+```ts
+export type ProviderBadgeType = "recommended" | "internal" | "new" | "deprecated";
+
+export type ProviderTemplate = {
+  // ... existing fields ...
+  badges?: ProviderBadgeType[];
+};
+```
+
+Simple string array — no wrapper object, max 2 entries. Badge labels are resolved via i18n keys (`settings.providers.badge.<type>`).
+
+## Semantic Badge Styles
+
+| Type          | Label (en-US / zh-CN) | Badge Variant            | Sort Priority |
+| ------------- | --------------------- | ------------------------ | ------------- |
+| `internal`    | Internal / 内部       | `info` (blue tint)       | 1 (highest)   |
+| `recommended` | Recommended / 推荐    | `success` (green tint)   | 2             |
+| `new`         | New / 新              | `default` (primary pink) | 3             |
+| `deprecated`  | Deprecated / 已弃用   | `warning` (amber tint)   | 4 (lowest)    |
+
+## Template Sorting
+
+Templates in the picker grid are sorted by highest-priority badge:
+
+1. Templates with `internal` badge first
+2. Then `recommended`
+3. Then `new`
+4. Then templates with no badges
+5. Then `deprecated` last
+
+Within the same priority tier, original order is preserved (stable sort).
+
+The "Custom" card is always pinned last — it is not part of the sorted template list.
+
+## Deprecated Visual Treatment
+
+Templates with the `deprecated` badge are visually dimmed (`opacity-60`) to steer users toward active providers — still clickable unlike disabled cards.
+
+**Opacity precedence:** If a template is both deprecated and already used (`isUsed`), the `isUsed` treatment wins (`opacity-40 cursor-not-allowed`) since it's a stronger constraint (disabled > dimmed).
+
+## UI Change
+
+In the template picker grid (~line 391 of `providers-panel.tsx`), render badges (max 2) next to the template name:
+
+```
+┌─────────────────────┐
+│ OpenRouter  [推荐]   │
+│ Compatible models    │
+│ openrouter.ai        │
+└─────────────────────┘
+```
+
+Badges use the existing `<Badge>` component with `size="sm"`.
+
+## Files Changed
+
+1. `src/shared/features/provider/built-in.ts` — add `ProviderBadgeType`, `badges` field to `ProviderTemplate`
+2. `src/renderer/src/features/settings/components/panels/providers-panel.tsx` — render badges, sort templates, dim deprecated
+3. i18n files — add `settings.providers.badge.*` keys
+
+## Design Notes
+
+- **Max 2 badges per template.** At `grid-cols-3`, cards are ~200px wide. More than 2 badges would wrap or overflow the name row.
+- **i18n keys, not L10nText.** Other `ProviderTemplate` fields (`name`, `description`) use `L10nText` because they're defined by plugin authors who don't have access to the app's i18n files. Badge types are app-defined with a fixed set of labels, so standard i18n keys are cleaner and avoid redundant translations across every plugin.
+
+## Scope
+
+- No backend/IPC changes needed
+- No persistence changes — badges are static template metadata defined by plugin authors

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -20,6 +20,7 @@ import type { Provider, ProviderModelMap } from "../../../../../../shared/featur
 
 import {
   resolveL10n,
+  type ProviderBadgeType,
   type ProviderTemplate,
 } from "../../../../../../shared/features/provider/built-in";
 import {
@@ -74,6 +75,27 @@ const emptyForm: ProviderFormData = {
   envOverrides: {},
   enabled: true,
 };
+
+const badgeVariantMap: Record<ProviderBadgeType, "success" | "info" | "default" | "warning"> = {
+  recommended: "success",
+  internal: "info",
+  new: "default",
+  deprecated: "warning",
+};
+
+const badgeSortPriority: Record<ProviderBadgeType, number> = {
+  internal: 1,
+  recommended: 2,
+  new: 3,
+  deprecated: 5,
+};
+
+const NO_BADGE_PRIORITY = 4;
+
+function getTemplateSortPriority(t: ProviderTemplate): number {
+  if (!t.badges || t.badges.length === 0) return NO_BADGE_PRIORITY;
+  return Math.min(...t.badges.map((b) => badgeSortPriority[b]));
+}
 
 function providerToForm(p: Provider): ProviderFormData {
   return {
@@ -152,6 +174,14 @@ export const ProvidersPanel = () => {
   const usedBuiltInIds = useMemo(
     () => new Set(providers.map((p) => p.builtInId).filter(Boolean)),
     [providers],
+  );
+
+  const sortedTemplates = useMemo(
+    () =>
+      [...providerTemplates].sort(
+        (a, b) => getTemplateSortPriority(a) - getTemplateSortPriority(b),
+      ),
+    [providerTemplates],
   );
 
   const canCheck = useMemo(() => {
@@ -388,9 +418,10 @@ export const ProvidersPanel = () => {
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">{t("settings.providers.chooseTemplate")}</p>
           <div className="grid grid-cols-3 gap-3">
-            {providerTemplates.map((template) => {
+            {sortedTemplates.map((template) => {
               const hostname = new URL(template.baseURL).hostname;
               const isUsed = usedBuiltInIds.has(template.id);
+              const isDeprecated = template.badges?.includes("deprecated") ?? false;
               return (
                 <button
                   key={template.id}
@@ -399,12 +430,19 @@ export const ProvidersPanel = () => {
                     "flex flex-col items-start gap-1 rounded-lg border border-input p-3 text-left transition-colors",
                     isUsed
                       ? "opacity-40 cursor-not-allowed"
-                      : "hover:border-primary hover:bg-accent",
+                      : isDeprecated
+                        ? "opacity-60 hover:border-primary hover:bg-accent"
+                        : "hover:border-primary hover:bg-accent",
                   )}
                   onClick={() => !isUsed && selectTemplate(template)}
                 >
-                  <span className="text-sm font-medium">
+                  <span className="text-sm font-medium flex items-center gap-1.5 flex-wrap">
                     {resolveL10n(template.name, i18n.language, template.nameLocalized)}
+                    {template.badges?.slice(0, 2).map((badge) => (
+                      <Badge key={badge} variant={badgeVariantMap[badge]} size="sm">
+                        {t(`settings.providers.badge.${badge}`)}
+                      </Badge>
+                    ))}
                   </span>
                   <span className="text-xs text-muted-foreground">
                     {resolveL10n(template.description, i18n.language)}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -144,6 +144,10 @@
   "settings.providers.removeModel": "Remove model {{model}}",
   "settings.providers.removeEnvOverride": "Remove environment override {{key}}",
   "settings.providers.toggleFailed": "Failed to toggle provider",
+  "settings.providers.badge.recommended": "Recommended",
+  "settings.providers.badge.internal": "Internal",
+  "settings.providers.badge.new": "New",
+  "settings.providers.badge.deprecated": "Deprecated",
 
   "settings.skills": "Skills",
   "settings.skills.addSkill": "Add Skill",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -144,6 +144,10 @@
   "settings.providers.removeModel": "移除模型 {{model}}",
   "settings.providers.removeEnvOverride": "移除环境变量 {{key}}",
   "settings.providers.toggleFailed": "切换服务商失败",
+  "settings.providers.badge.recommended": "推荐",
+  "settings.providers.badge.internal": "内部",
+  "settings.providers.badge.new": "新",
+  "settings.providers.badge.deprecated": "已弃用",
 
   "settings.mcp.title": "MCP",
   "settings.mcp.comingSoon": "MCP 配置即将推出...",

--- a/packages/desktop/src/shared/features/provider/built-in.ts
+++ b/packages/desktop/src/shared/features/provider/built-in.ts
@@ -2,6 +2,8 @@ import type { ProviderModelMap } from "./types";
 
 export type L10nText = Record<string, string>;
 
+export type ProviderBadgeType = "recommended" | "internal" | "new" | "deprecated";
+
 export type ProviderTemplate = {
   id: string;
   name: string;
@@ -14,6 +16,7 @@ export type ProviderTemplate = {
   modelMap: ProviderModelMap;
   envOverrides: Record<string, string>;
   apiFormat?: "anthropic";
+  badges?: ProviderBadgeType[];
 };
 
 /** @deprecated Use `ProviderTemplate` instead */


### PR DESCRIPTION
## Summary

- Add `ProviderBadgeType` (`"recommended"` | `"internal"` | `"new"` | `"deprecated"`) to `ProviderTemplate`
- Render badges as `<Badge>` pills next to template names in the provider picker grid (max 2 per template)
- Sort templates by badge priority: internal → recommended → new → (no badge) → deprecated
- Dim deprecated templates with `opacity-60` (isUsed `opacity-40` takes precedence)
- Add localized badge labels for en-US and zh-CN
- Include design doc at `docs/designs/2026-03-16-provider-badges.md`

## Test plan

- [ ] Open Settings → Providers → Add Provider and verify template picker renders correctly
- [ ] Add `badges: ["recommended"]` to a provider template and verify the badge appears with green tint
- [ ] Add `badges: ["deprecated"]` and verify the card is dimmed
- [ ] Add `badges: ["internal", "recommended"]` and verify sorting (internal templates appear first)
- [ ] Verify already-used templates still show `opacity-40` disabled state over deprecated dimming
- [ ] Switch language to zh-CN and verify badge labels are localized
- [ ] Run `bun ready` — passes