### PR TITLE
refactor: extract product name and data dir as global constants

### DIFF
--- a/docs/designs/2026-03-16-extract-product-name-config.md
+++ b/docs/designs/2026-03-16-extract-product-name-config.md
@@ -1,0 +1,71 @@
+# Extract Product Name as Global Config
+
+## Goal
+
+Centralize hardcoded product name strings, directory paths, and storage key prefixes so they're defined once and shared across processes.
+
+## New Files
+
+### `src/shared/constants.ts`
+
+Importable by both main and renderer:
+
+```ts
+export const APP_NAME = "Neovate";
+export const APP_ID = "neovate-desktop";
+```
+
+### `src/main/core/app-paths.ts`
+
+Main process only (needs `os.homedir()`):
+
+```ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { APP_ID } from "../../shared/constants";
+
+export const APP_DATA_DIR = join(homedir(), `.${APP_ID}`);
+```
+
+## Changes
+
+### Renderer — UI strings (import `APP_NAME` from `shared/constants`)
+
+| File                                             | Before                                               | After                                                        |
+| ------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
+| `features/agent/components/welcome-panel.tsx:14` | `alt="Neovate Logo"`                                 | ``alt={`${APP_NAME} Logo`}``                                 |
+| `features/agent/components/welcome-panel.tsx:17` | `"Hi, I'm Neovate. Let's start chatting!"`           | `` `Hi, I'm ${APP_NAME}. Let's start chatting!` ``           |
+| `features/updater/updater-toast.tsx:65`          | `"Neovate will quit and reopen to finish updating."` | `` `${APP_NAME} will quit and reopen to finish updating.` `` |
+
+### Main — UI strings (import `APP_NAME` from `shared/constants`)
+
+| File              | Before             | After             |
+| ----------------- | ------------------ | ----------------- |
+| `core/menu.ts:17` | `label: "Neovate"` | `label: APP_NAME` |
+
+### Main — App identity (`index.ts`)
+
+| File          | Before                                          | After                                                    |
+| ------------- | ----------------------------------------------- | -------------------------------------------------------- |
+| `index.ts:56` | `electronApp.setAppUserModelId("com.electron")` | `electronApp.setAppUserModelId("com.neovateai.desktop")` |
+
+### Main — Directory paths (import `APP_DATA_DIR` from `core/app-paths`)
+
+| File                                   | Before                                              | After                            |
+| -------------------------------------- | --------------------------------------------------- | -------------------------------- |
+| `core/logger.ts:8`                     | `join(homedir(), ".neovate-desktop", "logs")`       | `join(APP_DATA_DIR, "logs")`     |
+| `core/browser-window-manager.ts:30`    | `path.join(os.homedir(), ".neovate-desktop")`       | `APP_DATA_DIR`                   |
+| `core/storage-service.ts:5`            | `path.join(os.homedir(), ".neovate-desktop")`       | `APP_DATA_DIR`                   |
+| `features/config/config-store.ts:57`   | `path.join(os.homedir(), ".neovate-desktop")`       | `APP_DATA_DIR`                   |
+| `features/project/project-store.ts:20` | `path.join(os.homedir(), ".neovate-desktop")`       | `APP_DATA_DIR`                   |
+| `features/agent/claude-settings.ts:13` | `join(homedir(), ".neovate-desktop", "sessions")`   | `join(APP_DATA_DIR, "sessions")` |
+| `features/agent/router.ts:89`          | `path.join(homedir(), ".neovate-desktop", "plans")` | `join(APP_DATA_DIR, "plans")`    |
+
+## Not Touched
+
+- Debug namespaces (`debug("neovate:...")`) — internal logging, not user-facing
+- Editor plugin paths (`~/.neovate/code-server`, `~/.local/share/neovate-code/`) — left as-is per decision
+- Code identifiers (`NeovateApi` interface) — code symbols, not product name strings
+- Custom events (`neovate:log-event`) — internal plumbing
+- Storage keys (`neovate:defaultOpenApp`) — only one occurrence, not worth extracting

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -1,8 +1,15 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "electron-vite";
+
+const appDefine = {
+  __APP_NAME__: JSON.stringify("Neovate"),
+  __APP_ID__: JSON.stringify("neovate-desktop"),
+};
+
 export default defineConfig({
   main: {
+    define: appDefine,
     build: {
       outDir: "dist/main",
       // TODO: fix this
@@ -20,6 +27,7 @@ export default defineConfig({
     },
   },
   renderer: {
+    define: appDefine,
     plugins: [react(), tailwindcss()],
     build: {
       outDir: "dist/renderer",

--- a/packages/desktop/src/main/core/app-paths.ts
+++ b/packages/desktop/src/main/core/app-paths.ts
@@ -1,0 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { APP_ID } from "../../shared/constants";
+
+export const APP_DATA_DIR = join(homedir(), `.${APP_ID}`);

--- a/packages/desktop/src/main/core/browser-window-manager.ts
+++ b/packages/desktop/src/main/core/browser-window-manager.ts
@@ -2,13 +2,12 @@ import { is } from "@electron-toolkit/utils";
 import { shell, screen, BrowserWindow } from "electron";
 import Store from "electron-store";
 import { randomUUID } from "node:crypto";
-import os from "node:os";
-import path from "node:path";
 import { join } from "path";
 
 import type { IBrowserWindowManager, OpenWindowOptions } from "./types";
 
 import icon from "../../../resources/icon.png?asset";
+import { APP_DATA_DIR } from "./app-paths";
 import log from "./logger";
 
 type WindowStore = { bounds: Electron.Rectangle };
@@ -26,7 +25,7 @@ export class BrowserWindowManager implements IBrowserWindowManager {
   #windows = new Map<string, { win: BrowserWindow; windowType: string }>();
   #store = new Store<WindowStore>({
     name: "window-state",
-    cwd: path.join(os.homedir(), ".neovate-desktop"),
+    cwd: APP_DATA_DIR,
     serialize: (value) => JSON.stringify(value, null, 2) + "\n",
   });
 

--- a/packages/desktop/src/main/core/logger.ts
+++ b/packages/desktop/src/main/core/logger.ts
@@ -2,10 +2,11 @@ import { is } from "@electron-toolkit/utils";
 import debug from "debug";
 import log from "electron-log/main";
 import { readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
-const LOGS_DIR = join(homedir(), ".neovate-desktop", "logs");
+import { APP_DATA_DIR } from "./app-paths";
+
+const LOGS_DIR = join(APP_DATA_DIR, "logs");
 const DEV_LOG = "/tmp/dev.log";
 const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB
 const RETENTION_DAYS = 7;

--- a/packages/desktop/src/main/core/menu.ts
+++ b/packages/desktop/src/main/core/menu.ts
@@ -1,5 +1,7 @@
 import { Menu, BrowserWindow, MenuItemConstructorOptions, app } from "electron";
 
+import { APP_NAME } from "../../shared/constants";
+
 const isDev = !app.isPackaged;
 
 export function setupApplicationMenu(mainWindow: BrowserWindow | null): void {
@@ -14,7 +16,7 @@ export function setupApplicationMenu(mainWindow: BrowserWindow | null): void {
     ...(isMac
       ? [
           {
-            label: "Neovate",
+            label: APP_NAME,
             submenu: [
               { role: "about" as const },
               { type: "separator" as const },

--- a/packages/desktop/src/main/core/storage-service.ts
+++ b/packages/desktop/src/main/core/storage-service.ts
@@ -1,8 +1,7 @@
 import Store from "electron-store";
-import os from "node:os";
 import path from "node:path";
 
-const DEFAULT_BASE_DIR = path.join(os.homedir(), ".neovate-desktop");
+import { APP_DATA_DIR } from "./app-paths";
 
 // TODO: support generic type parameter for dot-notation type safety — scoped<T>(namespace) → Store<T>
 export interface IStorageService {
@@ -15,7 +14,7 @@ export class StorageService implements IStorageService {
   private instances = new Map<string, Store>();
 
   constructor(options: { baseDir?: string } = {}) {
-    this.baseDir = options.baseDir ?? DEFAULT_BASE_DIR;
+    this.baseDir = options.baseDir ?? APP_DATA_DIR;
   }
 
   scoped(namespace: string): Store {

--- a/packages/desktop/src/main/features/agent/claude-settings.ts
+++ b/packages/desktop/src/main/features/agent/claude-settings.ts
@@ -8,9 +8,11 @@ import type { Provider } from "../../../shared/features/provider/types";
 import type { ConfigStore } from "../config/config-store";
 import type { ProjectStore } from "../project/project-store";
 
+import { APP_DATA_DIR } from "../../core/app-paths";
+
 const log = debug("neovate:claude-settings");
 
-const SESSIONS_DIR = join(homedir(), ".neovate-desktop", "sessions");
+const SESSIONS_DIR = join(APP_DATA_DIR, "sessions");
 
 function sessionConfigPath(sessionId: string): string {
   return join(SESSIONS_DIR, `${sessionId}.json`);

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -1,12 +1,12 @@
 import { ORPCError, implement } from "@orpc/server";
 import debug from "debug";
 import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import path from "node:path";
+import { join } from "node:path";
 
 import type { AppContext } from "../../router";
 
 import { agentContract } from "../../../shared/features/agent/contract";
+import { APP_DATA_DIR } from "../../core/app-paths";
 import { readModelSetting, writeModelSetting } from "./claude-settings";
 
 const agentLog = debug("neovate:agent-router");
@@ -86,9 +86,9 @@ export const agentRouter = os.agent.router({
           .slice(0, 50)
       : input.sessionId.slice(0, 8);
     const filename = `${new Date().toISOString().slice(0, 10)}-${slug}.md`;
-    const dir = path.join(homedir(), ".neovate-desktop", "plans");
+    const dir = join(APP_DATA_DIR, "plans");
     await mkdir(dir, { recursive: true });
-    const filePath = path.join(dir, filename);
+    const filePath = join(dir, filename);
     await writeFile(filePath, input.plan, "utf8");
     agentLog("savePlan: saved to %s", filePath);
     return { path: filePath };

--- a/packages/desktop/src/main/features/config/config-store.ts
+++ b/packages/desktop/src/main/features/config/config-store.ts
@@ -1,10 +1,10 @@
 import debug from "debug";
 import Store from "electron-store";
-import os from "node:os";
-import path from "node:path";
 
 import type { AppConfig } from "../../../shared/features/config/types";
 import type { Provider } from "../../../shared/features/provider/types";
+
+import { APP_DATA_DIR } from "../../core/app-paths";
 
 const log = debug("neovate:config-store");
 
@@ -52,7 +52,7 @@ export class ConfigStore {
   constructor() {
     this.store = new Store<ConfigStoreSchema>({
       name: "config",
-      cwd: path.join(os.homedir(), ".neovate-desktop"),
+      cwd: APP_DATA_DIR,
       defaults: STORE_DEFAULTS,
       serialize: (value) => JSON.stringify(value, null, 2) + "\n",
     });

--- a/packages/desktop/src/main/features/project/project-store.ts
+++ b/packages/desktop/src/main/features/project/project-store.ts
@@ -1,9 +1,5 @@
 import debug from "debug";
 import Store from "electron-store";
-import os from "node:os";
-import path from "node:path";
-
-const log = debug("neovate:project:store");
 
 import type {
   Project,
@@ -11,13 +7,17 @@ import type {
 } from "../../../shared/features/project/types";
 import type { ProjectProviderConfig } from "../../../shared/features/provider/types";
 
+import { APP_DATA_DIR } from "../../core/app-paths";
+
+const log = debug("neovate:project:store");
+
 export class ProjectStore {
   private store: Store<ProjectStoreSchema>;
 
   constructor() {
     this.store = new Store<ProjectStoreSchema>({
       name: "projects",
-      cwd: path.join(os.homedir(), ".neovate-desktop"),
+      cwd: APP_DATA_DIR,
       defaults: {
         projects: [],
         activeProjectId: null,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -53,7 +53,7 @@ const appContext: AppContext = {
 };
 
 app.whenReady().then(async () => {
-  electronApp.setAppUserModelId("com.electron");
+  electronApp.setAppUserModelId("com.neovateai.desktop");
 
   await mainApp.start();
   void updaterService.init();

--- a/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "next-themes";
 
+import { APP_NAME } from "../../../../../shared/constants";
 import { getLogoUrl } from "../../../assets/images";
 import { ProjectSelector } from "../../project/components/project-selector";
 
@@ -11,10 +12,10 @@ export function WelcomePanel() {
       <img
         src={getLogoUrl(resolvedTheme as "dark" | "light" | undefined)}
         className="w-[120px]"
-        alt="Neovate Logo"
+        alt={`${APP_NAME} Logo`}
       />
       <p className="text-lg text-center font-bold text-foreground">
-        Hi, I'm Neovate. Let's start chatting!
+        {`Hi, I'm ${APP_NAME}. Let's start chatting!`}
       </p>
       <div className="mt-2">
         <ProjectSelector variant="select" />

--- a/packages/desktop/src/renderer/src/features/updater/updater-toast.tsx
+++ b/packages/desktop/src/renderer/src/features/updater/updater-toast.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 
+import { APP_NAME } from "../../../../shared/constants";
 import { toastManager } from "../../components/ui/toast";
 import { client } from "../../orpc";
 import { useUpdaterState } from "./hooks";
@@ -62,7 +63,7 @@ export function UpdaterToast() {
       const readyToast = {
         type: "success",
         title: `Update ${state.version} ready to install`,
-        description: "Neovate will quit and reopen to finish updating.",
+        description: `${APP_NAME} will quit and reopen to finish updating.`,
         actionProps: {
           children: "Restart",
           onClick: () => client.updater.install(),

--- a/packages/desktop/src/shared/constants.ts
+++ b/packages/desktop/src/shared/constants.ts
@@ -1,0 +1,2 @@
+export const APP_NAME: string = __APP_NAME__;
+export const APP_ID: string = __APP_ID__;

--- a/packages/desktop/src/shared/globals.d.ts
+++ b/packages/desktop/src/shared/globals.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_NAME__: string;
+declare const __APP_ID__: string;

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineProject } from "vitest/config";
 
 export default defineProject({
+  define: {
+    __APP_NAME__: JSON.stringify("Neovate"),
+    __APP_ID__: JSON.stringify("neovate-desktop"),
+  },
   test: {
     environment: "node",
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "test/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
## Summary

- Add `src/shared/constants.ts` with build-time injected `APP_NAME` and `APP_ID` (via Vite `define` in `electron.vite.config.ts`)
- Add `src/main/core/app-paths.ts` with `APP_DATA_DIR` derived from `APP_ID` — replaces 7 hardcoded `~/.neovate-desktop` path constructions
- Replace hardcoded "Neovate" strings in 4 user-facing locations: welcome panel, updater toast, macOS app menu
- Fix `setAppUserModelId` from Electron boilerplate `"com.electron"` to `"com.neovateai.desktop"`

## Test plan

- [ ] `bun ready` passes (format, typecheck, lint, tests)
- [ ] Dev server starts and welcome panel shows product name
- [ ] macOS app menu shows "Neovate" label
- [ ] Updater toast shows product name in description
- [ ] Config/project data still persists in `~/.neovate-desktop/`