### PR TITLE
fix: use APP_NAME constant for welcome message

### DIFF
--- a/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/welcome-panel.tsx
@@ -16,7 +16,9 @@ export function WelcomePanel() {
         className="w-[120px]"
         alt={`${APP_NAME} Logo`}
       />
-      <p className="text-lg text-center font-bold text-foreground">{t("chat.guideMessage")}</p>
+      <p className="text-lg text-center font-bold text-foreground">
+        {t("chat.guideMessage", { APP_NAME })}
+      </p>
       <div className="mt-2">
         <ProjectSelector variant="select" />
       </div>

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -307,7 +307,7 @@
   "tab.Terminal": "Terminal",
   "tab.Review": "Review",
 
-  "chat.guideMessage": "Hi, I am NeoSwift. Let's create something together!",
+  "chat.guideMessage": "Hi, I am {{APP_NAME}}. Let's create something together!",
   "chat.placeholder": "Type a message...",
   "chat.attachImage": "Attach image",
   "chat.attachImages": "Attach images",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -309,7 +309,7 @@
   "tab.Terminal": "终端",
   "tab.Review": "评审",
 
-  "chat.guideMessage": "嗨，我是 NeoSwift。让我们一起创造点什么吧！",
+  "chat.guideMessage": "嗨，我是 {{APP_NAME}}。让我们一起创造点什么吧！",
   "chat.placeholder": "输入消息...",
   "chat.attachImage": "附加图片",
   "chat.attachImages": "附加图片",


### PR DESCRIPTION
Replace hardcoded 'NeoSwift' with dynamic APP_NAME constant in welcome message. Supports i18n by using react-i18next interpolation syntax {{APP_NAME}} in locale JSON files.