### PR TITLE
fix: content panel tab i18n fallback for plugin views

### DIFF
--- a/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/tab-item.tsx
@@ -9,7 +9,6 @@ import { Button } from "../../../components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipPopup } from "../../../components/ui/tooltip";
 import { useRendererApp } from "../../../core";
 import { cn } from "../../../lib/utils";
-type TabName = "Editor" | "Git Diff" | "Terminal" | "Review";
 function TabButton({
   tab,
   isActive,
@@ -42,7 +41,7 @@ function TabButton({
       {isOrphan && <TriangleAlert className="size-3 text-yellow-500" />}
       <view className="flex items-center">
         <span className="mr-1">{view?.icon && <view.icon className="size-3.5" />}</span>
-        <span className="truncate font-medium">{t(`tab.${tab.name as TabName}`)}</span>
+        <span className="truncate font-medium">{t(`tab.${tab.name}`, tab.name)}</span>
       </view>
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- Plugin-registered content panel views (e.g. NeoVision, D2C) don't have corresponding `tab.*` i18n keys in the locale files
- This causes raw key strings like `tab.NeoVision` and `tab.设计稿生码` to be displayed as tab titles
- Fix: pass `tab.name` as default fallback to `t()`, so missing keys gracefully fall back to the original name

## Test plan
- [ ] Open NeoVision tab — title should show "NeoVision" (not "tab.NeoVision")
- [ ] Open D2C tab — title should show "设计稿生码" (not "tab.设计稿生码")
- [ ] Built-in tabs (Editor, Terminal, etc.) still show localized titles correctly