### PR TITLE
fix: i18n fallback for new tab menu items

### DIFF
--- a/packages/desktop/src/renderer/src/features/content-panel/components/new-tab-menu.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/new-tab-menu.tsx
@@ -10,7 +10,6 @@ import { Menu, MenuTrigger, MenuPopup, MenuItem } from "../../../components/ui/m
 import { useRendererApp } from "../../../core";
 import { useProjectStore } from "../../project/store";
 
-type TabName = "Editor" | "Git Diff" | "Terminal" | "Review";
 const EMPTY_TABS: Tab[] = [];
 
 export function NewTabMenu() {
@@ -40,7 +39,7 @@ export function NewTabMenu() {
               onClick={() => contentPanel.openView(view.viewType)}
             >
               {view.icon && <view.icon className="size-3.5" />}
-              {t(`tab.${view.name as TabName}`)}
+              {t(`tab.${view.name}`, view.name)}
             </MenuItem>
           );
         })}


### PR DESCRIPTION
## Summary
- Same issue as #210: new tab menu (`+` dropdown) uses `t(`tab.${view.name}`)` without fallback
- Plugin-registered views show raw i18n keys like `tab.NeoVision` in the dropdown
- Fix: pass `view.name` as default fallback to `t()`

## Test plan
- [ ] Click `+` button next to tabs — plugin views (NeoVision, D2C) show correct names
- [ ] Built-in views (Editor, Terminal, etc.) still show localized names