### PR TITLE
feat: built-in RTK token optimization via SDK hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ playwright-report/
 docs/plans
 .claude/settings.local.json
 packages/desktop/vendor/bun/
+packages/desktop/vendor/rtk/
 .worktrees/
 /tmp

--- a/docs/design/2026-03-17-built-in-rtk-token-optimization.md
+++ b/docs/design/2026-03-17-built-in-rtk-token-optimization.md
@@ -1,0 +1,201 @@
+# Built-in RTK Token Optimization via SDK Hooks
+
+**Date:** 2026-03-17
+**Status:** Approved
+
+## Problem
+
+LLM token consumption on common developer commands (git status, cargo test, etc.) is wasteful — Claude receives full unfiltered output when it only needs a summary. RTK (Rust Token Killer) solves this with a CLI proxy that filters output for 60-90% token savings, but currently requires separate installation and manual hook configuration.
+
+## Solution
+
+Bundle the `rtk` binary inside neovate-desktop and register a `PreToolUse` SDK hook that rewrites Bash commands through RTK automatically. Zero user setup required.
+
+## Architecture
+
+```
+session-manager.ts
+  initSession() builds Options
+    options.hooks = {
+      PreToolUse: [{ matcher: "Bash", hooks: [preToolUseHook] }]
+    }
+
+preToolUseHook (TypeScript callback):
+  1. Fast skip: if command starts with "rtk " or contains "<<", return { continue: true }
+  2. Call bundled `rtk rewrite <cmd>` (5s timeout, graceful fallback on error)
+  3. If rewrite differs: return { permissionDecision: "allow", updatedInput: { command: rewrittenCmd } }
+  4. If no rewrite or error: return { continue: true }
+
+permissionDecision: "allow" is required because the rewrite changes the command
+prefix (e.g. "git status" -> "rtk git status"), which breaks settings-based
+allow-lists like Bash(git:*). The rewritten command is functionally identical
+to the original — same operation, just filtered output — so auto-allowing is safe.
+Without this, every rewritten command would trigger a permission prompt in the UI.
+```
+
+## Data Flow
+
+```
+1. Claude decides: Bash({ command: "git status" })
+2. SDK fires PreToolUse hook (matcher: "Bash")
+3. Hook calls: rtk rewrite "git status" -> "rtk git status"
+4. Hook returns updatedInput with rewritten command
+5. SDK executes: "rtk git status" (rtk runs git, filters output)
+6. Filtered output returned to Claude (60-90% fewer tokens)
+7. UI shows the filtered output in BashTool component
+```
+
+## Components
+
+### 1. Binary Bundling (mirrors bun pattern)
+
+| Item             | Path                           | Details                                                                         |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------------------- |
+| Download script  | `scripts/download-rtk.ts`      | Fetch from GitHub releases, verify SHA256, place in `vendor/rtk/rtk`            |
+| Vendor dir       | `vendor/rtk/`                  | `.gitignored`, populated by download script                                     |
+| electron-builder | `configs/electron-builder.mjs` | `extraResources: [{ from: "vendor/rtk", to: "rtk", filter: ["rtk"] }]`          |
+| Path resolver    | `claude-code-utils.ts`         | `resolveRtkPath()`: dev -> `"rtk"` from PATH, prod -> `{resourcesPath}/rtk/rtk` |
+
+### 2. SDK Hook Registration (session-manager.ts)
+
+The hook is constructed in `initSession()` (not `queryOptions()`) because it closes over the resolved `env` object built there.
+
+```typescript
+// In initSession(), after building env:
+const rtkPath = resolveRtkPath();
+const rtkLog = debug("neovate:rtk");
+
+const rtkHook: HookCallback = async (input) => {
+  const cmd = (input.tool_input as any)?.command;
+  if (!cmd) return { continue: true };
+
+  // Fast skip: commands RTK never rewrites
+  if (cmd.startsWith("rtk ") || cmd.includes("<<")) {
+    return { continue: true };
+  }
+
+  try {
+    const { stdout } = await execFileAsync(rtkPath, ["rewrite", cmd], {
+      timeout: 5000,
+      env, // full session env (includes merged PATH, HOME, etc.)
+    });
+    const rewritten = stdout.trim();
+
+    if (!rewritten || rewritten === cmd) {
+      rtkLog("no rewrite: %s", cmd);
+      return { continue: true };
+    }
+
+    rtkLog("rewrite: %s -> %s", cmd, rewritten);
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse" as const,
+        permissionDecision: "allow" as const,
+        updatedInput: { command: rewritten },
+      },
+    };
+  } catch (err: any) {
+    if (err?.code === 1 || err?.status === 1) {
+      // Normal: rtk rewrite exits 1 when no rewrite applies
+      rtkLog("no rewrite: %s", cmd);
+    } else {
+      // Actual error: binary missing (ENOENT), timeout (ETIMEDOUT), crash
+      rtkLog("fallback (error): %s — %s", cmd, err?.message ?? err);
+    }
+    return { continue: true };
+  }
+};
+
+// Add to options.hooks only if enabled and no file-based RTK hook exists
+const options: Options = {
+  ...queryOpts,
+  hooks: registerRtkHook ? { PreToolUse: [{ matcher: "Bash", hooks: [rtkHook] }] } : undefined,
+  // ... rest of options
+};
+```
+
+### 3. Settings Toggle
+
+- New config key: `tokenOptimization: boolean` (default: `true`)
+- When `false`, the `PreToolUse` hook is not registered
+- UI toggle in Settings > Chat panel (default enabled)
+
+### 4. Deduplication with File-Based RTK Hooks
+
+Users who previously installed RTK via `rtk init` have a file-based hook in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "~/.claude/hooks/rtk-rewrite.sh" }]
+      }
+    ]
+  }
+}
+```
+
+The SDK loads both programmatic hooks and file-based hooks. To avoid double-rewriting (two subprocess spawns, fragile ordering), the hook registration logic checks for existing RTK hooks:
+
+```typescript
+// In initSession(), before building options:
+const hasFileBasedRtkHook = await detectRtkHookInSettings(cwd);
+const registerRtkHook = configStore.get("tokenOptimization") !== false && !hasFileBasedRtkHook;
+```
+
+`detectRtkHookInSettings()` reads `~/.claude/settings.json` and checks if any PreToolUse hook command contains `rtk`. If found, the programmatic hook is skipped — the user's existing file-based hook handles rewriting.
+
+### 5. RTK Environment
+
+The hook ensures RTK inherits the session's merged PATH (bundled bun dir + shell env + process env) so it can find git, cargo, etc.
+
+RTK also needs its own PATH entry so `rtk git status` works. The bundled rtk binary directory is prepended to PATH alongside bun's directory in `initSession()`.
+
+RTK reads user config from `~/.config/rtk/config.toml` (e.g. `exclude_commands`) and writes analytics to `~/.local/share/rtk/history.db`. Both paths are respected automatically by the bundled binary — no special handling needed. The shared analytics database means `rtk gain` from the CLI shows unified stats across CLI and desktop usage.
+
+### 6. Dev Mode Fallback
+
+In dev mode, `resolveRtkPath()` returns `"rtk"` (system PATH lookup). If a developer doesn't have RTK installed, the `try/catch` around `execFileAsync` ensures the hook silently falls back to passthrough — no errors, no degraded experience, just no token optimization.
+
+### 7. Debug Logging
+
+Use `debug("neovate:rtk")` for observability:
+
+- Hook registration: `"rtk hook registered"` / `"rtk hook skipped (disabled)"` / `"rtk hook skipped (file-based hook detected)"`
+- Each rewrite: `"rewrite: git status -> rtk git status"` / `"no rewrite: echo hello"`
+- Errors: `"fallback (error): git status — Error: rtk not found"`
+
+## What We're NOT Doing
+
+- No PostToolUse hook (RTK filters during execution, not after)
+- No TOML filter porting to TypeScript (use RTK's built-in filters)
+- No RTK analytics UI in v1 (can add later via `rtk gain --format json`)
+- No `rtk init` or settings.json patching (we use SDK programmatic hooks, not file-based hooks)
+- No conflict with user's own RTK hooks (detected at session init and programmatic hook is skipped — see section 4)
+
+## Implementation Order
+
+1. `scripts/download-rtk.ts` — download script (model after `download-bun.ts`)
+2. `claude-code-utils.ts` — add `resolveRtkPath()` + `detectRtkHookInSettings()`
+3. `configs/electron-builder.mjs` — add rtk to `extraResources`
+4. `session-manager.ts` — register PreToolUse hook in `initSession()` (with dedup check, fast skip, timeout, error handling)
+5. `initSession()` — prepend rtk binary dir to merged PATH
+6. Config types + store — add `tokenOptimization` boolean
+7. Settings UI — add toggle in Agent panel
+
+## RTK Release Tracking
+
+RTK releases at https://github.com/rtk-ai/rtk/releases. The download script should pin a specific version (like bun pins via `packageManager` field). Store the RTK version in `package.json` under a custom field or in the download script itself.
+
+## Platform Support
+
+RTK provides binaries for:
+
+- `darwin/arm64` (Apple Silicon)
+- `darwin/x64` (Intel Mac)
+- `linux/x64`
+- `linux/arm64`
+
+Match against neovate-desktop's current platform support (darwin only for now).

--- a/packages/desktop/configs/electron-builder.mjs
+++ b/packages/desktop/configs/electron-builder.mjs
@@ -11,20 +11,29 @@ async function beforePack(context) {
   const path = await import("node:path");
 
   const projectDir = context.packager.projectDir;
-  const bunBin = path.join(projectDir, "vendor", "bun", "bun");
-
-  if (existsSync(bunBin)) return;
 
   // electron-builder Arch enum: 0=ia32, 1=x64, 2=armv7l, 3=arm64, 4=universal
   const archMap = { 1: "x64", 3: "arm64" };
   const arch = archMap[context.arch];
   if (!arch) throw new Error(`Unsupported arch: ${context.arch}`);
 
-  console.log(`  • downloading bun for ${context.packager.platform.name}/${arch}...`);
-  execSync(`bun scripts/download-bun.ts --platform darwin --arch ${arch}`, {
-    cwd: projectDir,
-    stdio: "inherit",
-  });
+  const bunBin = path.join(projectDir, "vendor", "bun", "bun");
+  if (!existsSync(bunBin)) {
+    console.log(`  • downloading bun for ${context.packager.platform.name}/${arch}...`);
+    execSync(`bun scripts/download-bun.ts --platform darwin --arch ${arch}`, {
+      cwd: projectDir,
+      stdio: "inherit",
+    });
+  }
+
+  const rtkBin = path.join(projectDir, "vendor", "rtk", "rtk");
+  if (!existsSync(rtkBin)) {
+    console.log(`  • downloading rtk for ${context.packager.platform.name}/${arch}...`);
+    execSync(`bun scripts/download-rtk.ts --platform darwin --arch ${arch}`, {
+      cwd: projectDir,
+      stdio: "inherit",
+    });
+  }
 }
 
 const config = {
@@ -56,7 +65,10 @@ const config = {
 
   beforePack,
 
-  extraResources: [{ from: "vendor/bun", to: "bun", filter: ["bun"] }],
+  extraResources: [
+    { from: "vendor/bun", to: "bun", filter: ["bun"] },
+    { from: "vendor/rtk", to: "rtk", filter: ["rtk"] },
+  ],
 
   files: [
     "dist/**/*",

--- a/packages/desktop/scripts/download-rtk.ts
+++ b/packages/desktop/scripts/download-rtk.ts
@@ -1,0 +1,136 @@
+/**
+ * Download the RTK (Rust Token Killer) binary for the target platform into vendor/rtk/.
+ *
+ * Usage:
+ *   bun scripts/download-rtk.ts                              # current platform
+ *   bun scripts/download-rtk.ts --platform darwin --arch arm64
+ */
+import { chmodSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT_DIR = import.meta.dirname!;
+const DESKTOP_DIR = join(SCRIPT_DIR, "..");
+const VENDOR_DIR = join(DESKTOP_DIR, "vendor", "rtk");
+const RTK_PATH = join(VENDOR_DIR, "rtk");
+
+/** Pinned RTK version — update this when upgrading. */
+const RTK_VERSION = "0.30.0";
+
+const RTK_TARGETS: Record<string, Record<string, string>> = {
+  darwin: {
+    arm64: "rtk-aarch64-apple-darwin",
+    x64: "rtk-x86_64-apple-darwin",
+  },
+};
+
+function readFlag(args: string[], flag: string, fallback: string): string {
+  const index = args.indexOf(flag);
+  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+function parseArgs(): { platform: string; arch: string } {
+  const args = process.argv.slice(2);
+  return {
+    platform: readFlag(args, "--platform", process.platform),
+    arch: readFlag(args, "--arch", process.arch),
+  };
+}
+
+function verifyRtk(binaryPath: string, expectedVersion?: string): string {
+  const result = Bun.spawnSync([binaryPath, "--version"]);
+  const output = result.stdout.toString().trim();
+  const error = result.stderr.toString().trim();
+
+  if (result.exitCode !== 0 || !output) {
+    throw new Error(`rtk verification failed: ${error || output || "no output"}`);
+  }
+
+  // rtk --version outputs "rtk X.Y.Z"
+  const version = output.replace(/^rtk\s+/, "");
+
+  if (expectedVersion && version !== expectedVersion) {
+    throw new Error(`rtk version mismatch: expected ${expectedVersion}, got ${version}`);
+  }
+
+  console.log(`  Verified rtk ${version}`);
+  return version;
+}
+
+async function main() {
+  const { platform, arch } = parseArgs();
+  const target = RTK_TARGETS[platform]?.[arch];
+  if (!target) throw new Error(`Unsupported platform/arch: ${platform}/${arch}`);
+
+  if (await Bun.file(RTK_PATH).exists()) {
+    try {
+      const existingVersion = verifyRtk(RTK_PATH);
+      if (existingVersion === RTK_VERSION) {
+        console.log(`rtk ${RTK_VERSION} already exists at ${RTK_PATH}, skipping download`);
+        return;
+      }
+      console.log(`rtk ${existingVersion} exists at ${RTK_PATH}, replacing with ${RTK_VERSION}`);
+    } catch {
+      console.log(`Existing rtk binary invalid, re-downloading ${RTK_VERSION}`);
+    }
+  }
+
+  const tarName = `${target}.tar.gz`;
+  const baseUrl = `https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}`;
+
+  console.log(`Downloading rtk v${RTK_VERSION} for ${platform}/${arch}...`);
+
+  const [tarRes, shaRes] = await Promise.all([
+    fetch(`${baseUrl}/${tarName}`),
+    fetch(`${baseUrl}/checksums.txt`),
+  ]);
+
+  if (!tarRes.ok) throw new Error(`Failed to download ${tarName}: ${tarRes.status}`);
+  if (!shaRes.ok) throw new Error(`Failed to download checksums.txt: ${shaRes.status}`);
+
+  const tarBuffer = await tarRes.arrayBuffer();
+  const shaText = await shaRes.text();
+  const expected = shaText
+    .split("\n")
+    .find((line) => line.includes(tarName))
+    ?.trim()
+    .split(/\s+/)[0];
+
+  if (!expected) {
+    throw new Error(`No checksum found for ${tarName} in checksums.txt`);
+  }
+
+  const actual = new Bun.CryptoHasher("sha256").update(tarBuffer).digest("hex");
+  if (actual !== expected) {
+    throw new Error(`SHA256 mismatch: expected ${expected}, got ${actual}`);
+  }
+  console.log("  SHA256 verified");
+
+  mkdirSync(VENDOR_DIR, { recursive: true });
+  const tmpTar = join(VENDOR_DIR, tarName);
+  await Bun.write(tmpTar, tarBuffer);
+
+  try {
+    const proc = Bun.spawnSync(["tar", "-xzf", tmpTar, "-C", VENDOR_DIR]);
+    if (proc.exitCode !== 0) {
+      throw new Error(
+        `tar extract failed: ${proc.stderr.toString().trim() || proc.stdout.toString().trim()}`,
+      );
+    }
+  } finally {
+    rmSync(tmpTar, { force: true });
+  }
+
+  chmodSync(RTK_PATH, 0o755);
+
+  // Only verify when building for the current architecture
+  if (platform === process.platform && arch === process.arch) {
+    verifyRtk(RTK_PATH, RTK_VERSION);
+  }
+
+  console.log(`  Done: ${RTK_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/desktop/src/main/features/agent/claude-code-utils.ts
+++ b/packages/desktop/src/main/features/agent/claude-code-utils.ts
@@ -1,5 +1,7 @@
 import { is } from "@electron-toolkit/utils";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { homedir } from "node:os";
 import path from "node:path";
 
 const require = createRequire(import.meta.url);
@@ -29,4 +31,35 @@ export function resolveSDKCliPath(): string {
 export function resolveBunPath(): string {
   if (is.dev) return "bun";
   return path.join(process.resourcesPath, "bun", "bun");
+}
+
+/**
+ * Resolve the path to the bundled RTK binary.
+ *
+ * In dev mode, uses the system rtk from PATH (silent no-op if not installed).
+ * In production, uses the rtk binary bundled via electron-builder extraResources.
+ */
+export function resolveRtkPath(): string {
+  if (is.dev) return "rtk";
+  return path.join(process.resourcesPath, "rtk", "rtk");
+}
+
+/**
+ * Check if a file-based RTK PreToolUse hook already exists in ~/.claude/settings.json.
+ * Returns true if found, so the programmatic hook can be skipped to avoid double-rewriting.
+ */
+export function detectRtkHookInSettings(): boolean {
+  try {
+    const settingsPath = path.join(homedir(), ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    const preToolUse = settings?.hooks?.PreToolUse;
+    if (!Array.isArray(preToolUse)) return false;
+    return preToolUse.some(
+      (matcher: any) =>
+        Array.isArray(matcher?.hooks) &&
+        matcher.hooks.some((h: any) => typeof h?.command === "string" && h.command.includes("rtk")),
+    );
+  } catch {
+    return false;
+  }
 }

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -34,7 +34,12 @@ import type { Provider } from "../../../shared/features/provider/types";
 import type { ConfigStore } from "../config/config-store";
 import type { ProjectStore } from "../project/project-store";
 
-import { resolveBunPath, resolveSDKCliPath } from "./claude-code-utils";
+import {
+  resolveBunPath,
+  resolveRtkPath,
+  resolveSDKCliPath,
+  detectRtkHookInSettings,
+} from "./claude-code-utils";
 import { readModelSetting, readProviderSetting, readProviderModelSetting } from "./claude-settings";
 import { Pushable } from "./pushable";
 import { SDKMessageTransformer, toUIEvent } from "./sdk-message-transformer";
@@ -42,6 +47,7 @@ import { getShellEnvironment } from "./shell-env";
 import { sessionMessagesToUIMessages } from "./utils/session-messages-to-ui-messages";
 
 const log = debug("neovate:session-manager");
+const rtkLog = debug("neovate:rtk");
 
 /** List .jsonl files one level deep under `~/.claude/projects/` */
 function listSessionFiles(filter?: string): string[] {
@@ -369,7 +375,9 @@ export class SessionManager {
     const shellEnv = await getShellEnvironment();
     const bunPath = resolveBunPath();
     const bunDir = bunPath !== "bun" ? path.dirname(bunPath) : undefined;
-    const mergedPath = [bunDir, shellEnv.PATH, process.env.PATH].filter(Boolean).join(":");
+    const rtkPath = resolveRtkPath();
+    const rtkDir = rtkPath !== "rtk" ? path.dirname(rtkPath) : undefined;
+    const mergedPath = [rtkDir, bunDir, shellEnv.PATH, process.env.PATH].filter(Boolean).join(":");
     const env: Record<string, string | undefined> = {
       ...process.env,
       ...shellEnv,
@@ -423,6 +431,61 @@ export class SessionManager {
 
     const agentLanguage = this.configStore.get("agentLanguage");
 
+    // RTK token optimization hook
+    const tokenOptimization = this.configStore.get("tokenOptimization") !== false;
+    const hasFileBasedRtkHook = detectRtkHookInSettings();
+    const registerRtkHook = tokenOptimization && !hasFileBasedRtkHook;
+
+    if (!tokenOptimization) {
+      rtkLog("hook skipped (disabled)");
+    } else if (hasFileBasedRtkHook) {
+      rtkLog("hook skipped (file-based hook detected in ~/.claude/settings.json)");
+    } else {
+      rtkLog("hook registered rtkPath=%s", rtkPath);
+    }
+
+    type HookCallback = import("@anthropic-ai/claude-agent-sdk").HookCallback;
+    const rtkHook: HookCallback = async (input) => {
+      if (input.hook_event_name !== "PreToolUse") return { continue: true };
+      const cmd = (input.tool_input as Record<string, unknown>)?.command;
+      if (typeof cmd !== "string" || !cmd) return { continue: true };
+
+      // Fast skip: commands RTK never rewrites
+      if (cmd.startsWith("rtk ") || cmd.includes("<<")) {
+        return { continue: true };
+      }
+
+      try {
+        const { stdout } = await execFileAsync(rtkPath, ["rewrite", cmd], {
+          timeout: 5000,
+          env: env as Record<string, string>,
+        });
+        const rewritten = stdout.trim();
+
+        if (!rewritten || rewritten === cmd) {
+          rtkLog("no rewrite: %s", cmd);
+          return { continue: true };
+        }
+
+        rtkLog("rewrite: %s -> %s", cmd, rewritten);
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse" as const,
+            permissionDecision: "allow" as const,
+            updatedInput: { command: rewritten },
+          },
+        };
+      } catch (err: any) {
+        if (err?.code === 1 || err?.status === 1) {
+          // Normal: rtk rewrite exits 1 when no rewrite applies
+          rtkLog("no rewrite: %s", cmd);
+        } else {
+          rtkLog("fallback (error): %s — %s", cmd, err?.message ?? err);
+        }
+        return { continue: true };
+      }
+    };
+
     const queryOpts = this.queryOptions({
       sessionId,
       cwd,
@@ -435,6 +498,9 @@ export class SessionManager {
         ...(settingsEnv ? { env: settingsEnv } : {}),
         ...(agentLanguage !== "English" ? { language: agentLanguage.toLowerCase() } : {}),
       },
+      ...(registerRtkHook
+        ? { hooks: { PreToolUse: [{ matcher: "Bash", hooks: [rtkHook] }] } }
+        : {}),
       ...(opts?.resume ? { resume: opts.resume, sessionId: undefined } : {}),
     };
 

--- a/packages/desktop/src/main/features/config/config-store.ts
+++ b/packages/desktop/src/main/features/config/config-store.ts
@@ -33,6 +33,7 @@ const DEFAULT_APP_CONFIG: AppConfig = {
   agentLanguage: "English",
   permissionMode: "default",
   notificationSound: "default",
+  tokenOptimization: true,
 
   // Keybindings
   keybindings: {},

--- a/packages/desktop/src/renderer/src/features/config/store.ts
+++ b/packages/desktop/src/renderer/src/features/config/store.ts
@@ -40,6 +40,7 @@ const DEFAULT_CONFIG: AppConfig = {
   agentLanguage: "English",
   permissionMode: "default",
   notificationSound: "default",
+  tokenOptimization: true,
 
   // Keybindings
   keybindings: {},

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -27,6 +27,7 @@ import {
   SelectValue,
 } from "../../../../components/ui/select";
 import { Spinner } from "../../../../components/ui/spinner";
+import { Switch } from "../../../../components/ui/switch";
 import { ToggleOptions } from "../../../../components/ui/toggle-options";
 import { client } from "../../../../orpc";
 import { claudeCodeChatManager } from "../../../agent/chat-manager";
@@ -140,6 +141,17 @@ export const ChatPanel = () => {
               </SelectItem>
             </SelectPopup>
           </Select>
+        </SettingsRow>
+
+        {/* Token Optimization */}
+        <SettingsRow
+          title={t("settings.chat.tokenOptimization")}
+          description={t("settings.chat.tokenOptimization.description")}
+        >
+          <Switch
+            checked={config.tokenOptimization}
+            onCheckedChange={(v) => setConfig("tokenOptimization", v)}
+          />
         </SettingsRow>
 
         {/* Send Message With */}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -61,6 +61,8 @@
   "settings.chat.notification.ping": "Ping",
   "settings.chat.notification.pop": "Pop",
   "settings.chat.notification.funk": "Funk",
+  "settings.chat.tokenOptimization": "Token Optimization",
+  "settings.chat.tokenOptimization.description": "Reduce token usage by filtering command output (via RTK)",
   "settings.chat.sendMessage": "Send Message",
   "settings.chat.sendMessage.description": "Keyboard shortcut to send messages",
   "settings.chat.model.auto": "Default (auto)",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -61,6 +61,8 @@
   "settings.chat.notification.ping": "Ping",
   "settings.chat.notification.pop": "Pop",
   "settings.chat.notification.funk": "Funk",
+  "settings.chat.tokenOptimization": "Token 优化",
+  "settings.chat.tokenOptimization.description": "通过过滤命令输出减少 Token 用量（基于 RTK）",
   "settings.chat.sendMessage": "发送消息",
   "settings.chat.sendMessage.description": "发送消息的键盘快捷键",
   "settings.chat.model.auto": "默认（自动）",

--- a/packages/desktop/src/shared/features/config/contract.ts
+++ b/packages/desktop/src/shared/features/config/contract.ts
@@ -54,6 +54,7 @@ export const configContract = {
         z.object({ key: z.literal("notificationSound"), value: notificationSoundValueSchema }),
         z.object({ key: z.literal("keybindings"), value: keybindingsValueSchema }),
         z.object({ key: z.literal("sidebarOrganize"), value: sidebarOrganizeValueSchema }),
+        z.object({ key: z.literal("tokenOptimization"), value: booleanValueSchema }),
         z.object({ key: z.literal("sidebarSortBy"), value: sidebarSortByValueSchema }),
         z.object({
           key: z.literal("skillsRegistryUrls"),

--- a/packages/desktop/src/shared/features/config/types.ts
+++ b/packages/desktop/src/shared/features/config/types.ts
@@ -26,6 +26,7 @@ export type AppConfig = {
   agentLanguage: AgentLanguage;
   permissionMode: ConfigPermissionMode;
   notificationSound: NotificationSound;
+  tokenOptimization: boolean;
 
   // Keybindings
   keybindings: Record<string, string>;


### PR DESCRIPTION
## Summary

- Bundle RTK binary inside neovate-desktop (same pattern as bundled bun) and register a `PreToolUse` SDK hook that automatically rewrites Bash commands through RTK for 60-90% token savings
- Add `tokenOptimization` toggle in Settings > Chat (default enabled)
- Detect existing file-based RTK hooks in `~/.claude/settings.json` to avoid double-rewriting
- Include design doc at `docs/design/2026-03-17-built-in-rtk-token-optimization.md`

### How it works

1. SDK fires `PreToolUse` hook when Claude invokes the Bash tool
2. Hook calls `rtk rewrite <cmd>` to check if the command can be optimized
3. If rewrite available (e.g. `git status` → `rtk git status`), returns `updatedInput` with `permissionDecision: "allow"`
4. RTK executes the real command and filters the output before returning to Claude

### Files changed

| Area | Files |
|------|-------|
| Binary bundling | `scripts/download-rtk.ts`, `configs/electron-builder.mjs`, `.gitignore` |
| Utilities | `claude-code-utils.ts` (`resolveRtkPath`, `detectRtkHookInSettings`) |
| Hook wiring | `session-manager.ts` (PreToolUse hook in `initSession`) |
| Config | `types.ts`, `contract.ts`, `config-store.ts`, renderer `store.ts` |
| Settings UI | `chat-panel.tsx`, `en-US.json`, `zh-CN.json` |

## Test plan

- [x] `bun ready` passes (format + typecheck + lint + tests)
- [ ] Enable `DEBUG=neovate:rtk` and verify hook registration logs on session create
- [ ] Verify `git status` gets rewritten to `rtk git status` in debug logs
- [ ] Toggle off token optimization in Settings > Chat, restart session, verify "hook skipped (disabled)" log
- [ ] With existing RTK file-based hook in `~/.claude/settings.json`, verify "hook skipped (file-based hook detected)" log
- [ ] Production build: verify `vendor/rtk/rtk` is included in app resources