### PR TITLE
feat: add updater timeout and error feedback in about panel

### DIFF
--- a/docs/design/2026-03-17-updater-timeout-error-feedback.md
+++ b/docs/design/2026-03-17-updater-timeout-error-feedback.md
@@ -1,0 +1,57 @@
+# Update Timeout + About Panel Error Feedback
+
+## Problem
+
+1. **No timeout on update check**: `UpdaterService.check()` calls `autoUpdater.checkForUpdates()` with no timeout. If the update server is unreachable, the UI stays stuck in "checking" state indefinitely and `isChecking` remains `true`, blocking all future check attempts (both manual and hourly interval).
+
+2. **No error feedback in about panel**: Version fetches (`getVersion`, `getClaudeCodeSDKVersion`) silently fail, leaving empty strings. The `client.updater.check()` IPC call has no `.catch()`, so IPC-level failures produce no user feedback.
+
+## Design
+
+### 1. Check timeout — `src/main/features/updater/service.ts`
+
+- Define `CHECK_TIMEOUT_MS = 30_000` constant (consistent with existing `CHECK_INTERVAL_MS` naming)
+- Add a `setTimeout` using `CHECK_TIMEOUT_MS` after calling `autoUpdater.checkForUpdates()` in the `check()` method
+- Store the timer ID in a private field (`private checkTimeout: ReturnType<typeof setTimeout> | null = null`)
+- If the timer fires: set `isChecking = false`, and if `surfaceUI` is true, call `setState({ status: "error", message: "TIMEOUT" })` (sentinel value — see i18n section below)
+- Extract a private `clearCheckTimeout()` helper to avoid repeating `clearTimeout` + null assignment in 4 places
+- Call `clearCheckTimeout()` in every electron-updater event handler (`update-available`, `update-not-available`, `error`) and in `dispose()`
+- **Auto-recovery**: In `update-not-available` and `update-available` handlers, if current state is `"error"`, clear it regardless of `surfaceUI` — this ensures a successful background check after a timeout auto-clears the stale error
+
+**Scope**: Check only. Download timeout not needed — electron-updater already emits error events for download failures, and download duration varies by connection speed.
+
+### 2. Version fetch fallback — `src/renderer/src/features/settings/components/panels/about-panel.tsx`
+
+- Add `.catch()` to both `client.updater.getVersion()` and `client.updater.getClaudeCodeSDKVersion()`
+- On failure, set the version to `t("settings.about.unknownVersion")` (e.g. `"Unknown"`) instead of leaving it as empty string
+
+### 3. Check IPC error handling — `src/renderer/src/features/settings/components/panels/about-panel.tsx`
+
+- Add `.catch()` to `client.updater.check()` in `handleCheckForUpdates`
+- On rejection, set a local error state (`const [checkError, setCheckError] = useState<string | null>(null)`)
+- Display `checkError` as red text in the update row (same style as existing `state.status === "error"` display)
+- Clear `checkError` at the start of each new check attempt
+- **Error precedence**: Show `checkError` only when `state.status !== "error"` — subscription errors (timeout, electron-updater) take priority over the local IPC error
+- **Auto-clear on subscription activity**: Clear `checkError` whenever a new subscription event arrives (meaning IPC has recovered)
+
+### 4. i18n for timeout message
+
+- The service emits `"TIMEOUT"` as the error message sentinel (not a user-facing English string)
+- In the about panel, map the sentinel to a translated string: if `state.message === "TIMEOUT"`, display `t("settings.about.checkTimeout")` instead of the raw message
+- Other error messages (from electron-updater) pass through as-is — these are English-only, consistent with current behavior
+- Add the `settings.about.checkTimeout` key to i18n resources (e.g. `"Update check timed out"`)
+- Add the `settings.about.unknownVersion` key to i18n resources (e.g. `"Unknown"`) — used by version fetch fallback in section 2
+
+## Files Changed
+
+| File                                                                   | Change                                                                                          |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/main/features/updater/service.ts`                                 | Add 30s timeout with `clearCheckTimeout()` helper, auto-recovery on background success          |
+| `src/renderer/src/features/settings/components/panels/about-panel.tsx` | `.catch()` on version fetches, `.catch()` on check IPC, error precedence logic, TIMEOUT mapping |
+| i18n resources                                                         | Add `settings.about.checkTimeout` and `settings.about.unknownVersion` keys                      |
+
+No contract, type, or hook changes needed. The timeout error flows through the existing `UpdaterState` error status via the subscription.
+
+## Known Edge Cases
+
+**Late event race condition**: If the timeout fires and the user immediately starts a new check, a late `update-not-available` from the _first_ check could clear the new check's timeout and set `isChecking = false` prematurely. This is a pre-existing limitation of electron-updater being a singleton — there's no way to correlate events with specific `checkForUpdates()` calls. The timeout makes it slightly more observable but doesn't introduce it. Not worth solving (would require a generation counter or wrapper) given how unlikely the timing is.

--- a/packages/desktop/src/main/features/updater/service.ts
+++ b/packages/desktop/src/main/features/updater/service.ts
@@ -15,11 +15,13 @@ export interface UpdaterOptions {
 }
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const CHECK_TIMEOUT_MS = 30_000;
 
 export class UpdaterService {
   private state: UpdaterState = { status: "idle" };
   readonly publisher = new EventPublisher<{ state: UpdaterState }>();
   private checkInterval: ReturnType<typeof setInterval> | null = null;
+  private checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Internal concurrency-control state (not directly exposed to UI)
   private isChecking = false;
@@ -37,6 +39,13 @@ export class UpdaterService {
   private setState(newState: UpdaterState) {
     this.state = newState;
     this.publisher.publish("state", newState);
+  }
+
+  private clearCheckTimeout() {
+    if (this.checkTimeout) {
+      clearTimeout(this.checkTimeout);
+      this.checkTimeout = null;
+    }
   }
 
   check(manual = false) {
@@ -80,6 +89,14 @@ export class UpdaterService {
       this.setState({ status: "checking" });
     }
     autoUpdater.checkForUpdates().catch(() => {});
+    this.checkTimeout = setTimeout(() => {
+      log("check timed out");
+      this.checkTimeout = null;
+      this.isChecking = false;
+      if (this.surfaceUI) {
+        this.setState({ status: "error", message: "TIMEOUT" });
+      }
+    }, CHECK_TIMEOUT_MS);
   }
 
   install() {
@@ -110,17 +127,19 @@ export class UpdaterService {
 
     autoUpdater.on("update-not-available", () => {
       log("update not available", { surfaceUI: this.surfaceUI });
+      this.clearCheckTimeout();
       this.isChecking = false;
-      if (this.surfaceUI) {
+      if (this.surfaceUI || this.state.status === "error") {
         this.setState({ status: "up-to-date" });
       }
     });
 
     autoUpdater.on("update-available", (info) => {
       log("update available", { version: info.version, surfaceUI: this.surfaceUI });
+      this.clearCheckTimeout();
       this.isChecking = false;
       this.pendingUpdate = { version: info.version, status: "downloading", percent: 0 };
-      if (this.surfaceUI) {
+      if (this.surfaceUI || this.state.status === "error") {
         this.setState({ status: "downloading", version: info.version, percent: 0 });
       }
       autoUpdater.downloadUpdate().catch(() => {});
@@ -150,6 +169,7 @@ export class UpdaterService {
 
     autoUpdater.on("error", (err) => {
       log("update error", { message: err.message });
+      this.clearCheckTimeout();
       this.isChecking = false;
       this.pendingUpdate = null;
       if (this.surfaceUI) {
@@ -163,6 +183,7 @@ export class UpdaterService {
 
   dispose() {
     if (this.checkInterval) clearInterval(this.checkInterval);
+    this.clearCheckTimeout();
     autoUpdater.removeAllListeners();
   }
 }

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/about-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/about-panel.tsx
@@ -14,10 +14,25 @@ export const AboutPanel = () => {
 
   const [appVersion, setAppVersion] = useState("");
   const [sdkVersion, setSdkVersion] = useState("");
+  const [checkError, setCheckError] = useState<string | null>(null);
+
   useEffect(() => {
-    client.updater.getVersion().then(setAppVersion);
-    client.updater.getClaudeCodeSDKVersion().then(setSdkVersion);
-  }, []);
+    client.updater
+      .getVersion()
+      .then(setAppVersion)
+      .catch(() => setAppVersion(t("settings.about.unknownVersion")));
+    client.updater
+      .getClaudeCodeSDKVersion()
+      .then(setSdkVersion)
+      .catch(() => setSdkVersion(t("settings.about.unknownVersion")));
+  }, [t]);
+
+  // Auto-clear local IPC error when subscription recovers
+  useEffect(() => {
+    if (checkError && state.status !== "idle") {
+      setCheckError(null);
+    }
+  }, [state]);
 
   const getUpdateStatusText = (): string => {
     switch (state.status) {
@@ -32,6 +47,7 @@ export const AboutPanel = () => {
       case "downloading":
         return t("settings.about.downloading", { version: state.version });
       case "error":
+        if (state.message === "TIMEOUT") return t("settings.about.checkTimeout");
         return state.message ?? t("settings.about.error");
       case "idle":
       default:
@@ -42,7 +58,10 @@ export const AboutPanel = () => {
   const isBusy = state.status === "checking" || state.status === "downloading";
 
   const handleCheckForUpdates = () => {
-    client.updater.check();
+    setCheckError(null);
+    client.updater.check().catch(() => {
+      setCheckError(t("settings.about.unableToCheck"));
+    });
   };
 
   const handleSendFeedback = () => {
@@ -62,7 +81,9 @@ export const AboutPanel = () => {
           title={t("settings.about.checkForUpdates")}
           description={
             state.status === "error" ? (
-              <span className="text-destructive">{state.message ?? t("settings.about.error")}</span>
+              <span className="text-destructive">{getUpdateStatusText()}</span>
+            ) : checkError ? (
+              <span className="text-destructive">{checkError}</span>
             ) : (
               t("settings.about.currentVersion", {
                 version: appVersion,

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -82,6 +82,8 @@
   "settings.about.sendFeedback": "Send Feedback",
   "settings.about.error": "Error",
   "settings.about.unableToCheck": "Unable to check updates",
+  "settings.about.checkTimeout": "Update check timed out",
+  "settings.about.unknownVersion": "Unknown",
   "settings.about.sdkVersion": "Claude Code SDK",
   "settings.about.sdkVersion.description": "Agent SDK version: {{version}}",
 

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -82,6 +82,8 @@
   "settings.about.sendFeedback": "发送反馈",
   "settings.about.error": "错误",
   "settings.about.unableToCheck": "无法检查更新",
+  "settings.about.checkTimeout": "更新检查超时",
+  "settings.about.unknownVersion": "未知",
   "settings.about.sdkVersion": "Claude Code SDK",
   "settings.about.sdkVersion.description": "Agent SDK 版本：{{version}}",
 


### PR DESCRIPTION
Added a 30-second timeout for update checks to prevent indefinite "checking" state, and improved error feedback in the about panel for version fetch failures and IPC errors. Includes i18n support for timeout and unknown version messages.