### PR TITLE
feat: add network inspector panel for API request observability

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,5 @@
 {
-  "ignorePatterns": [".claude/**"],
+  "ignorePatterns": [".claude/**", "packages/desktop/resources/**"],
   "sortImports": {
     "groups": [
       "type-import",

--- a/docs/design/2026-03-17-request-observability-panel.md
+++ b/docs/design/2026-03-17-request-observability-panel.md
@@ -1,0 +1,1156 @@
+# Request Observability Panel
+
+**Date:** 2026-03-17
+**Status:** Draft
+
+## Summary
+
+Add a dev observability panel to Neovate Desktop that shows every HTTP request Claude Code makes to the Anthropic API in real-time. Inspired by cc-viewer's interceptor architecture, adapted to work within the Electron + Agent SDK subprocess model.
+
+## Motivation
+
+The Agent SDK exposes aggregated usage data (total cost, tokens per turn) but not individual HTTP requests. Developers need visibility into:
+
+- Per-request latency and token breakdown
+- Retry behavior and error responses
+- What system prompt / tools / messages are sent in each request
+- Sub-agent vs main-agent request classification
+- Streaming vs non-streaming request mix
+- Full request/response bodies for debugging
+- Context window utilization approaching limits
+
+## Architecture
+
+### Data Flow
+
+```
+CLI subprocess (bun --preload fetch-interceptor.js cli.js)
+|
+|  globalThis.fetch monkey-patched
+|  |-- Before fetch: emitSync "start" (summary only, ~1-5KB)
+|  |-- After fetch: emitAsync "end" (summary + full request & response bodies)
+|  |-- For streams: per-request StreamAssembler accumulates chunks
+|  |-- Request body forwarded as raw string (zero-copy, no re-serialize)
+|
+|  fd 3: __NV_REQ:<json>\n  (single message type, dedicated IPC pipe)
+|        __NV_READY\n       (handshake on init)
+|  stdout: unchanged (SDK protocol)
+|  stderr: unchanged (debug/error output)
+|
+v
+spawnClaudeCodeProcess (session-manager.ts)
+|
+|  Custom spawn wrapper (only when networkInspector enabled):
+|  |-- Inserts --preload before script path in bun args
+|  |-- Sets NV_SESSION_ID env var
+|  |-- Opens fd 3 as dedicated IPC pipe
+|  |-- Waits for __NV_READY handshake (5s timeout, warns on failure)
+|  |-- Reads fd 3: parse __NV_REQ lines -> RequestTracker
+|  |-- stdout/stderr: untouched, forwarded to SDK as normal
+|
+v
+RequestTracker (new service, main process)
+|
+|  In-memory store with dual cap (500 entries OR 50MB body size)
+|  |-- Splits incoming messages: summary fields -> list, detail -> bodies Map
+|  |-- Correlates requests to turns via SessionManager
+|  |-- Tracks per-session inspector state (enabled / failed / not enabled)
+|  |-- Exposes oRPC: listRequests, getRequestDetail, subscribeRequests
+|  |-- EventPublisher for real-time push to renderer
+|
+v
+Renderer (oRPC client)
+|
+|  "Network" plugin (content panel)
+|  |-- Zustand store merges start/end phases into unified request rows
+|  |-- Request list grouped by turn (left)
+|  |-- Request detail with context utilization (right)
+|  |-- Copy as cURL / Copy as JSON actions
+|  |-- Session-aware: switches data on active session change
+```
+
+### Injection Mechanism
+
+The interceptor runs inside the CLI subprocess via `bun --preload`. This is the cleanest injection point because:
+
+- Bun natively supports `--preload` (runs before the main script)
+- No changes to the ENV_BLOCKLIST (NODE_OPTIONS stays blocked)
+- The interceptor patches `globalThis.fetch` before the Anthropic SDK initializes
+- Zero interference with the SDK's stdout protocol
+
+The `spawnClaudeCodeProcess` option in the Agent SDK lets us customize how the CLI process is spawned. We insert `--preload` into the args array.
+
+**Arg ordering:** The SDK constructs args as `[cliPath, ...sdkFlags]`. Bun reads runtime flags (`--preload`) before the script argument, so `--preload` must be inserted before the script path:
+
+```ts
+// spawnOpts.args = ["/path/to/cli.js", "--sdk-flag1", ...]
+// bun --preload interceptor.js /path/to/cli.js --sdk-flag1 ...
+const child = spawn(spawnOpts.command, [
+  "--preload",
+  interceptorPath,
+  ...spawnOpts.args, // cli.js comes first, bun sees --preload before it
+]);
+```
+
+This ordering was verified experimentally — bun parses `--preload` as a runtime flag regardless of position before the script path.
+
+### IPC Channel: File Descriptor 3
+
+The `SpawnedProcess` interface only exposes `stdin` and `stdout`. The SDK accesses `.stderr` directly on the returned ChildProcess via duck-typing and forwards it to the `stderr` callback. Using stderr for interceptor IPC would require fragile line buffering and prefix filtering, risking interference with the SDK's stderr handling.
+
+Instead, we use **file descriptor 3** as a dedicated IPC channel:
+
+```ts
+// In spawnClaudeCodeProcess:
+const child = spawn(command, args, {
+  stdio: ["pipe", "pipe", "pipe", "pipe"], // fd 0=stdin, 1=stdout, 2=stderr, 3=ipc
+});
+
+// fd 3 is a dedicated pipe, invisible to the SDK
+const rl = createInterface({ input: child.stdio[3] });
+rl.on("line", (line) => {
+  /* parse messages */
+});
+```
+
+**Advantages over stderr:**
+
+- No interference with SDK's stderr handling
+- No line-buffering needed (dedicated stream, no interleaving)
+- No prefix filtering ambiguity (only interceptor data arrives on fd 3)
+- stderr remains clean for real errors and debug output
+
+**Verified:** Bun supports `fs.writeSync(3, ...)` when fd 3 is opened by the parent via `stdio: ["pipe","pipe","pipe","pipe"]`. Tested end-to-end: Node parent spawns bun child with `--preload`, interceptor writes to fd 3, parent reads lines correctly. stdout and stderr remain independent.
+
+### IPC Protocol
+
+Two message types over fd 3:
+
+- `__NV_READY\n` — handshake, emitted once on interceptor init
+- `__NV_REQ:<json>\n` — request data, one per phase (start/end)
+
+Each `__NV_REQ` message contains summary fields and an optional `detail` object. The `RequestTracker` splits them on receipt.
+
+```ts
+type InterceptorMessage = {
+  id: string;
+  phase: "start" | "end";
+  // ... summary fields (see RequestSummary) ...
+  detail?: {
+    request?: { headers: Record<string, string>; rawBody: string };
+    response?: { headers: Record<string, string>; body: unknown };
+  };
+};
+```
+
+**"start" phase:** Summary fields only. No `detail`. Small (~1-5KB). Provides immediate in-flight indicator in the UI.
+
+**"end" phase:** Summary fields + `detail` containing both the full request body (`rawBody` as string) and the full response body (assembled for streams). This is the only message that carries body data.
+
+One message per phase, one parse per message, one handler in the spawn wrapper.
+
+### Ready Handshake
+
+The interceptor emits `__NV_READY\n` on fd 3 immediately after patching `globalThis.fetch`. The spawn wrapper sets a 5-second timeout to detect silent failures (file not found, syntax error in bundle, bun version incompatibility):
+
+```ts
+let interceptorReady = false;
+
+rl.on("line", (line) => {
+  if (line === "__NV_READY") {
+    interceptorReady = true;
+    return;
+  }
+  if (!line.startsWith("__NV_REQ:")) return;
+  // ... parse request message ...
+});
+
+setTimeout(() => {
+  if (!interceptorReady) {
+    log("WARNING: network interceptor did not initialize within 5s — sessionId=%s", sessionId);
+    this.requestTracker.markInspectorFailed(sessionId);
+  }
+}, 5000);
+```
+
+Without this, a broken interceptor silently produces no data, and the Network panel shows "Waiting for API requests..." forever. With the handshake, the panel can show "Network Inspector failed to initialize" and suggest checking the logs.
+
+### Write Strategy: Sync Start, Async End
+
+The "start" phase is summary-only (~1-5KB) and must arrive immediately for the in-flight indicator. It uses **synchronous** `fs.writeSync(3, ...)`.
+
+The "end" phase includes full request + response bodies and can be large (10KB-1MB+). It uses **asynchronous** `fs.write(3, data, callback)` to avoid blocking the CLI's event loop.
+
+```ts
+const originalFetch = globalThis.fetch;
+let ipcAlive = true;
+const fd3 = 3;
+
+// Emit ready handshake
+try {
+  fs.writeSync(fd3, "__NV_READY\n");
+} catch {
+  ipcAlive = false;
+}
+
+// Sync write for small, time-critical messages (start phase, summary only)
+function emitSync(data: InterceptorMessage) {
+  if (!ipcAlive) return;
+  try {
+    fs.writeSync(fd3, `__NV_REQ:${JSON.stringify(data)}\n`);
+  } catch {
+    ipcAlive = false;
+    globalThis.fetch = originalFetch;
+  }
+}
+
+// Async write for large messages (end phase with full bodies)
+function emitAsync(data: InterceptorMessage) {
+  if (!ipcAlive) return;
+  try {
+    fs.write(fd3, `__NV_REQ:${JSON.stringify(data)}\n`, (err) => {
+      if (err) {
+        ipcAlive = false;
+        globalThis.fetch = originalFetch;
+      }
+    });
+  } catch {
+    ipcAlive = false;
+    globalThis.fetch = originalFetch;
+  }
+}
+```
+
+**Why "start" carries no body:** The request body for a long conversation can be 500KB+ (full message history + system prompt + tools). A synchronous write of that size blocks the CLI event loop before every API call, adding latency. By deferring all body data to the async "end" phase, the interceptor never blocks on large payloads. The trade-off: clicking an in-flight request in the detail panel shows "Request details available when complete" — acceptable since requests complete in 1-10 seconds.
+
+### Graceful Pipe Close Handling
+
+If the Electron main process crashes or closes the fd 3 pipe while the CLI is still running, `fs.writeSync` / `fs.write` throws `EBADF` or `EPIPE`. Both `emitSync` and `emitAsync` catch this and silently disable interception by restoring the original `globalThis.fetch`. Claude Code continues unaffected.
+
+### Zero-Copy Request Body Forwarding
+
+The Anthropic SDK already calls `JSON.stringify()` on the request body before passing it to `fetch(url, { body: stringifiedBody })`. The interceptor avoids a wasteful parse-then-re-stringify round-trip by forwarding the raw string:
+
+```ts
+// In the patched fetch:
+const rawBody = typeof options.body === "string" ? options.body : JSON.stringify(options.body);
+
+// Parse once to extract summary fields (model, message count, tool names)
+let parsed: any;
+try {
+  parsed = JSON.parse(rawBody);
+} catch {
+  parsed = null;
+}
+
+const summaryFields = {
+  model: parsed?.model,
+  isStream: parsed?.stream === true,
+  messageCount: Array.isArray(parsed?.messages) ? parsed.messages.length : undefined,
+  toolNames: Array.isArray(parsed?.tools) ? parsed.tools.map((t: any) => t.name) : undefined,
+  maxTokens: parsed?.max_tokens,
+  systemPromptLength:
+    typeof parsed?.system === "string"
+      ? parsed.system.length
+      : Array.isArray(parsed?.system)
+        ? JSON.stringify(parsed.system).length
+        : undefined,
+};
+
+// "start" phase: summary only (sync, small)
+emitSync({ id, phase: "start", ...summaryFields, url, method, headers: maskedHeaders });
+
+const response = await originalFetch.apply(this, arguments);
+
+// "end" phase: summary + detail with raw body string (async, can be large)
+emitAsync({
+  id,
+  phase: "end",
+  ...summaryFields,
+  ...responseFields,
+  detail: {
+    request: { headers: maskedHeaders, rawBody }, // raw string, no re-serialize
+    response: { headers: responseHeaders, body: assembledResponse },
+  },
+});
+```
+
+On the parent side, `RequestDetail.request.rawBody` is a string. The renderer parses it lazily with `JSON.parse()` only when the user opens the Request tab. This avoids **two full serialization round-trips** (parse + stringify) of 500KB+ on every intercepted request.
+
+## Configuration
+
+### `networkInspector` Setting
+
+The interceptor is **opt-in** to avoid overhead when not needed. A new `networkInspector` boolean config field controls it.
+
+**Config type** (`shared/features/config/types.ts`):
+
+```ts
+export type AppConfig = {
+  // ... existing fields ...
+  /** Enable the network inspector to see API requests in the Network panel. */
+  networkInspector: boolean;
+};
+```
+
+Default: `false`.
+
+**Settings UI** (`features/settings/components/panels/chat-panel.tsx`):
+
+Add a `<Switch>` in the Chat settings panel (alongside `tokenOptimization`):
+
+```tsx
+<SettingsRow
+  title="Network Inspector"
+  description="Show API requests in the Network panel. Requires starting a new session to take effect."
+>
+  <Switch checked={networkInspector} onCheckedChange={(v) => setConfig("networkInspector", v)} />
+</SettingsRow>
+```
+
+**Persistence:** Uses the existing config flow — `electron-store` writes to `~/.neovate-desktop/config.json`, same as all other config fields. The renderer store's `setConfig()` optimistically updates local state and calls `client.config.set()` to persist.
+
+**Behavior when toggled:**
+
+- Toggling the setting takes effect on the **next session** (since `--preload` is a spawn-time decision).
+- The Network panel is always visible in the content panel list but shows context-appropriate states (see Session Switching Behavior below).
+- No session restart prompt — the user naturally starts new sessions.
+
+**Session manager reads the config** (`session-manager.ts`):
+
+```ts
+const networkInspector = this.configStore.get("networkInspector") === true;
+const options: Options = {
+  ...queryOpts,
+  ...(networkInspector ? { spawnClaudeCodeProcess: buildInspectorSpawn(sessionId) } : {}),
+};
+```
+
+## In-Memory Data Model
+
+All intercepted data is stored **entirely in memory** in the `RequestTracker`. No temp files, no disk I/O.
+
+The "start" phase message carries summary fields only. The "end" phase message carries summary fields plus the `detail` object (full request + response bodies). The `RequestTracker` stores summaries in an array (for list queries) and details in a Map (for detail queries).
+
+### Eviction: Dual Cap
+
+The ring buffer uses two caps to prevent unbounded memory growth:
+
+```ts
+const MAX_ENTRIES = 500;
+const MAX_BODY_BYTES = 50 * 1024 * 1024; // 50MB
+
+// In onMessage():
+while (session.summaries.length > MAX_ENTRIES || session.totalBodyBytes > MAX_BODY_BYTES) {
+  const evicted = session.summaries.shift()!;
+  const bodySize = session.bodySizes.get(evicted.id) ?? 0;
+  session.totalBodyBytes -= bodySize;
+  session.bodySizes.delete(evicted.id);
+  session.bodies.delete(evicted.id);
+}
+```
+
+**Why dual cap:** Entry count alone isn't enough. In long conversations, each successive request carries a larger message history. Request #50 might have a 300KB body. With count-only eviction, 500 large entries could consume 100MB+. The byte cap ensures memory stays bounded regardless of per-entry size.
+
+- **Short sessions:** hit the 500-entry cap first (~25MB typical)
+- **Long sessions with big contexts:** hit the 50MB cap first (fewer entries retained)
+
+### Per-Session Inspector State
+
+The `RequestTracker` tracks per-session inspector state with three possible values:
+
+```ts
+type InspectorState = "enabled" | "failed" | "not-enabled";
+
+class RequestTracker {
+  private inspectorState = new Map<string, InspectorState>();
+
+  markInspectorEnabled(sessionId: string): void {
+    this.inspectorState.set(sessionId, "enabled");
+  }
+
+  markInspectorFailed(sessionId: string): void {
+    this.inspectorState.set(sessionId, "failed");
+  }
+
+  getInspectorState(sessionId: string): InspectorState {
+    return this.inspectorState.get(sessionId) ?? "not-enabled";
+  }
+}
+```
+
+Called by `session-manager.ts`: `markInspectorEnabled` when `spawnClaudeCodeProcess` is used, `markInspectorFailed` when the ready handshake times out. The renderer queries this to determine panel state (see Session Switching Behavior).
+
+### RequestSummary (list rendering)
+
+```ts
+type RequestSummary = {
+  id: string; // crypto.randomUUID()
+  sessionId: string; // from NV_SESSION_ID env var
+  phase: "start" | "end"; // two messages per request
+  timestamp: number; // Date.now()
+  turnIndex: number; // assigned by RequestTracker on receipt
+
+  // Request info (both phases)
+  url: string;
+  method: string;
+  model?: string;
+  isStream?: boolean;
+  headers: Record<string, string>; // credentials masked
+
+  // Request body summary (start phase)
+  messageCount?: number;
+  toolNames?: string[];
+  systemPromptLength?: number;
+  maxTokens?: number;
+
+  // Response info (end phase only)
+  status?: number;
+  duration?: number; // ms from fetch start to response complete
+  responseHeaders?: Record<string, string>;
+  stopReason?: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+  };
+  contentBlockTypes?: string[]; // ["text", "thinking", "tool_use"]
+  error?: string;
+};
+```
+
+### RequestDetail (on-demand detail)
+
+Stored in the bodies Map, keyed by request ID. Only present for "end" phase messages. Sent to renderer via `getRequestDetail()` when the user selects a completed request.
+
+```ts
+type RequestDetail = {
+  id: string;
+  request: {
+    headers: Record<string, string>;
+    rawBody: string; // raw JSON string from fetch options.body (zero-copy)
+  };
+  response?: {
+    headers: Record<string, string>;
+    body: unknown; // assembled response (for streams: reconstructed message)
+  };
+};
+```
+
+Note: `request.rawBody` is a string, not a parsed object. The renderer parses it lazily when the user opens the Request tab.
+
+## Cost Estimation
+
+Per-request and per-turn cost is estimated using a static price table:
+
+```ts
+const MODEL_PRICING: Record<
+  string,
+  {
+    inputPer1M: number;
+    outputPer1M: number;
+    cacheReadPer1M: number;
+  }
+> = {
+  "claude-opus-4-6": { inputPer1M: 15, outputPer1M: 75, cacheReadPer1M: 1.5 },
+  "claude-sonnet-4-6": { inputPer1M: 3, outputPer1M: 15, cacheReadPer1M: 0.3 },
+  "claude-haiku-4-5": { inputPer1M: 0.8, outputPer1M: 4, cacheReadPer1M: 0.08 },
+};
+
+function estimateCost(model: string, usage: RequestSummary["usage"]): number {
+  const pricing = MODEL_PRICING[model] ?? MODEL_PRICING["claude-sonnet-4-6"];
+  if (!usage) return 0;
+  return (
+    (usage.inputTokens * pricing.inputPer1M +
+      usage.outputTokens * pricing.outputPer1M +
+      (usage.cacheReadInputTokens ?? 0) * pricing.cacheReadPer1M) /
+    1_000_000
+  );
+}
+```
+
+- Price table is updated with app releases. Unknown models fall back to Sonnet pricing.
+- Per-request cost shown in the detail panel usage breakdown.
+- Per-turn cost shown in the turn header subtotals.
+- Session total shown in the footer.
+- The SDK's `total_cost_usd` from result messages serves as ground truth for turn-level totals — when available, it overrides the estimate.
+
+## Interceptor Design
+
+### Build Strategy
+
+The interceptor is written in **TypeScript** alongside the rest of the codebase and **bundled separately** with esbuild into a single standalone file. This is better than writing raw JS with no imports because:
+
+- Proper TypeScript with type checking
+- Reusable, tested SSE stream assembly function (~100 lines of stateful parsing)
+- Unit-testable with vitest
+- Can share type definitions with `request-types.ts`
+
+**Build pipeline:**
+
+```ts
+// In electron-builder or vite config:
+esbuild.build({
+  entryPoints: ["src/main/features/agent/interceptor/fetch-interceptor.ts"],
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  outfile: "resources/fetch-interceptor.js",
+  external: [], // fully self-contained
+});
+```
+
+**Source location:** `packages/desktop/src/main/features/agent/interceptor/`
+
+```
+interceptor/
+  fetch-interceptor.ts    # Entry point: patch + URL matching + emit
+  stream-assembler.ts     # SSE event -> complete message reconstruction (class, instantiated per request)
+  credential-mask.ts      # API key / auth header masking
+  types.ts                # Shared types (imported from request-types.ts at build)
+  __tests__/
+    stream-assembler.test.ts
+    credential-mask.test.ts
+    fetch-interceptor.test.ts
+    integration.test.ts     # End-to-end: spawn bun with --preload, verify fd 3 output
+```
+
+### Fetch Patch Logic
+
+```
+globalThis.fetch (patched)
+  |
+  |-- Is URL an Anthropic API call?
+  |   (URL contains "anthropic" or "claude",
+  |    or hostname matches ANTHROPIC_BASE_URL,
+  |    or path matches /v1/messages)
+  |
+  |-- NO  -> call original fetch, return unchanged
+  |-- YES ->
+  |     1. Generate request ID
+  |     2. Grab raw request body string (zero-copy from fetch options.body)
+  |     3. Parse body once for summary extraction (model, message count, tool names)
+  |     4. Extract & mask credentials from headers
+  |     5. emitSync "start" (summary only, no detail)
+  |     6. Call original fetch
+  |     7. If stream response:
+  |        a. Create new StreamAssembler() for THIS request
+  |        b. Wrap ReadableStream with pass-through that feeds assembler
+  |        c. On stream end: get assembled message from assembler
+  |        d. emitAsync "end" (summary + detail: rawBody + assembled response)
+  |        e. Return new Response with pass-through stream
+  |     8. If non-stream response:
+  |        a. Clone response, read body
+  |        b. emitAsync "end" (summary + detail: rawBody + response body)
+  |        c. Return original response
+```
+
+### SSE Stream Assembly
+
+For streaming responses, the interceptor creates a **new `StreamAssembler` instance per request**. This is critical because the Anthropic SDK can have multiple concurrent in-flight requests (main agent + sub-agents making parallel tool calls). A shared/singleton assembler would corrupt data when concurrent streams interleave.
+
+```ts
+class StreamAssembler {
+  private message: any = {};
+  private contentBlocks: any[] = [];
+  private currentBlockInputJson = "";
+
+  processEvent(event: { type: string; [key: string]: any }): void {
+    switch (event.type) {
+      case "message_start": // initialize envelope
+      case "content_block_start": // create block
+      case "content_block_delta": // append to block
+      case "content_block_stop": // finalize block
+      case "message_delta": // set stop_reason, merge usage
+      case "message_stop": // no-op
+    }
+  }
+
+  finalize(): any {
+    return { ...this.message, content: this.contentBlocks };
+  }
+}
+```
+
+Each patched fetch call creates its own `StreamAssembler`, feeds it chunks from that request's stream, and calls `finalize()` when the stream ends. No shared state between concurrent requests.
+
+Event handling follows cc-viewer's `assembleStreamMessage()`:
+
+- `message_start` -> initialize message envelope (id, model, usage)
+- `content_block_start` -> create content block (text, thinking, tool_use)
+- `content_block_delta` -> append to block (text_delta, thinking_delta, input_json_delta)
+- `content_block_stop` -> finalize block (parse accumulated JSON for tool_use)
+- `message_delta` -> set stop_reason, merge usage
+- `message_stop` -> no-op
+
+### Credential Masking
+
+API keys masked before any output: `sk-ant-api03-abcdef...xyz` -> `sk-ant-****xyz`. Authorization headers masked similarly, preserving the scheme.
+
+### URL Matching
+
+A request is captured if ANY of these match:
+
+- URL contains `anthropic` or `claude`
+- URL hostname matches `ANTHROPIC_BASE_URL` env var
+- URL path matches `/v1/messages` or `/api/eval/sdk-*`
+
+## Main Process Changes
+
+### a) Interceptor Source
+
+**Location:** `packages/desktop/src/main/features/agent/interceptor/fetch-interceptor.ts`
+
+Built to: `packages/desktop/resources/fetch-interceptor.js` (added to electron-builder `extraResources`). In dev mode, built on-the-fly or referenced from the build output.
+
+### b) session-manager.ts
+
+Add `spawnClaudeCodeProcess` to the query options, gated by the `networkInspector` config:
+
+```ts
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+// In initSession():
+const networkInspector = this.configStore.get("networkInspector") === true;
+
+if (networkInspector) {
+  this.requestTracker.markInspectorEnabled(sessionId);
+}
+
+const options: Options = {
+  ...queryOpts,
+  ...(networkInspector
+    ? {
+        spawnClaudeCodeProcess: (spawnOpts) => {
+          const interceptorPath = resolveInterceptorPath();
+
+          // --preload must appear before the script path in bun args.
+          // spawnOpts.args = ["/path/to/cli.js", ...sdkFlags]
+          // Result: bun --preload interceptor.js /path/to/cli.js ...sdkFlags
+          const child = spawn(
+            spawnOpts.command,
+            ["--preload", interceptorPath, ...spawnOpts.args],
+            {
+              cwd: spawnOpts.cwd,
+              env: {
+                ...spawnOpts.env,
+                NV_SESSION_ID: sessionId,
+              },
+              signal: spawnOpts.signal,
+              stdio: ["pipe", "pipe", "pipe", "pipe"], // fd 3 = IPC
+            },
+          );
+
+          // Read interceptor data from fd 3
+          let interceptorReady = false;
+          const ipcStream = child.stdio[3];
+          if (ipcStream && "on" in ipcStream) {
+            const rl = createInterface({ input: ipcStream as NodeJS.ReadableStream });
+            rl.on("line", (line) => {
+              if (line === "__NV_READY") {
+                interceptorReady = true;
+                return;
+              }
+              if (!line.startsWith("__NV_REQ:")) return;
+              try {
+                const msg = JSON.parse(line.slice("__NV_REQ:".length));
+                this.requestTracker.onMessage(sessionId, msg);
+              } catch {
+                /* malformed, skip */
+              }
+            });
+          }
+
+          // Detect interceptor init failure
+          setTimeout(() => {
+            if (!interceptorReady) {
+              log("WARNING: network interceptor did not initialize — sessionId=%s", sessionId);
+              this.requestTracker.markInspectorFailed(sessionId);
+            }
+          }, 5000);
+
+          return child; // satisfies SpawnedProcess interface
+        },
+      }
+    : {}),
+};
+```
+
+Also, in `SessionManager.stream()`, call `startTurn()` before pushing the user message:
+
+```ts
+this.requestTracker.startTurn(sessionId);
+session.input.push({ type: "user", ... });
+```
+
+### c) RequestTracker service
+
+**Location:** `packages/desktop/src/main/features/agent/request-tracker.ts`
+
+```ts
+const MAX_ENTRIES = 500;
+const MAX_BODY_BYTES = 50 * 1024 * 1024; // 50MB
+
+type InspectorState = "enabled" | "failed" | "not-enabled";
+
+class RequestTracker {
+  private sessions = new Map<
+    string,
+    {
+      summaries: RequestSummary[];
+      bodies: Map<string, RequestDetail>;
+      bodySizes: Map<string, number>;
+      totalBodyBytes: number;
+    }
+  >();
+  private currentTurn = new Map<string, number>();
+  private inspectorState = new Map<string, InspectorState>();
+  readonly eventPublisher = new EventPublisher<Record<string, RequestSummary>>();
+
+  /** Record that a session was spawned with the interceptor. */
+  markInspectorEnabled(sessionId: string): void {
+    this.inspectorState.set(sessionId, "enabled");
+  }
+
+  /** Record that the interceptor failed to initialize (ready timeout). */
+  markInspectorFailed(sessionId: string): void {
+    this.inspectorState.set(sessionId, "failed");
+  }
+
+  /** Check per-session inspector state. */
+  getInspectorState(sessionId: string): InspectorState {
+    return this.inspectorState.get(sessionId) ?? "not-enabled";
+  }
+
+  /**
+   * Called by spawn wrapper when a message arrives on fd 3.
+   * Splits the message: summary fields -> summaries array, detail -> bodies Map.
+   */
+  onMessage(sessionId: string, msg: InterceptorMessage): void {
+    const session = this.ensureSession(sessionId);
+
+    // Extract and store detail separately
+    const { detail, ...summaryFields } = msg;
+    const summary: RequestSummary = {
+      ...summaryFields,
+      turnIndex: this.currentTurn.get(sessionId) ?? 0,
+    };
+
+    session.summaries.push(summary);
+
+    if (detail) {
+      const byteSize =
+        (detail.request?.rawBody?.length ?? 0) +
+        (typeof detail.response?.body === "string"
+          ? detail.response.body.length
+          : JSON.stringify(detail.response?.body ?? "").length);
+      session.bodies.set(msg.id, detail as RequestDetail);
+      session.bodySizes.set(msg.id, byteSize);
+      session.totalBodyBytes += byteSize;
+    }
+
+    // Dual-cap eviction
+    while (session.summaries.length > MAX_ENTRIES || session.totalBodyBytes > MAX_BODY_BYTES) {
+      const evicted = session.summaries.shift()!;
+      const evictedSize = session.bodySizes.get(evicted.id) ?? 0;
+      session.totalBodyBytes -= evictedSize;
+      session.bodySizes.delete(evicted.id);
+      session.bodies.delete(evicted.id);
+    }
+
+    this.eventPublisher.publish(sessionId, summary);
+  }
+
+  /** Mark the start of a new turn (called by SessionManager.stream()). */
+  startTurn(sessionId: string): void {
+    this.currentTurn.set(sessionId, (this.currentTurn.get(sessionId) ?? 0) + 1);
+  }
+
+  /** Get all request summaries for a session. */
+  getRequests(sessionId: string): RequestSummary[] {
+    return this.sessions.get(sessionId)?.summaries ?? [];
+  }
+
+  /** Get full body for a specific request (from memory). */
+  getRequestDetail(sessionId: string, requestId: string): RequestDetail | null {
+    return this.sessions.get(sessionId)?.bodies.get(requestId) ?? null;
+  }
+
+  /** Clear request data for a session (user clicked [clear]). */
+  clearRequests(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.summaries = [];
+      session.bodies.clear();
+      session.bodySizes.clear();
+      session.totalBodyBytes = 0;
+    }
+  }
+
+  /** Full cleanup on session close. */
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.currentTurn.delete(sessionId);
+    this.inspectorState.delete(sessionId);
+  }
+}
+```
+
+### d) oRPC Contract
+
+New methods in the agent contract:
+
+```ts
+// shared/features/agent/contract.ts
+listRequests: oc.input(z.object({ sessionId: z.string() })).output(z.array(requestSummarySchema));
+getRequestDetail: oc.input(z.object({ sessionId: z.string(), requestId: z.string() })).output(
+  requestDetailSchema.nullable(),
+);
+getInspectorState: oc.input(z.object({ sessionId: z.string() })).output(
+  z.enum(["enabled", "failed", "not-enabled"]),
+);
+clearRequests: oc.input(z.object({ sessionId: z.string() })).output(z.void());
+subscribeRequests: oc.input(z.object({ sessionId: z.string() })).output(z.void()); // via EventPublisher
+```
+
+## Renderer UI
+
+### Network Plugin
+
+The Network panel is implemented as a **plugin**, following the same pattern as existing content panels (`plugins/terminal/`, `plugins/git/`, `plugins/files/`):
+
+```
+plugins/network/
+  index.tsx           # Plugin registration: contributes content panel view
+  network-view.tsx    # Main panel component (split list + detail)
+  components/
+    turn-group.tsx    # Collapsible turn section with subtotals
+    request-row.tsx   # Single request row with context bar
+    detail-panel.tsx  # Tabbed detail view (Headers / Request / Response)
+    usage-table.tsx   # Token + cost breakdown table
+    context-bar.tsx   # Inline context window utilization bar
+    empty-state.tsx   # Placeholder for disabled / failed / waiting states
+  store.ts            # Zustand store for request list + selected request
+```
+
+This keeps the feature modular, consistent with the existing plugin architecture, and independently testable.
+
+### Renderer Store: Request Lifecycle
+
+The network store merges the two-phase (`start` + `end`) protocol into unified request rows for rendering:
+
+```ts
+type MergedRequest = {
+  id: string;
+  requestState: "in-flight" | "complete" | "error";
+  turnIndex: number;
+  timestamp: number;
+
+  // From "start" phase
+  url: string;
+  method: string;
+  model?: string;
+  isStream?: boolean;
+  headers: Record<string, string>;
+  messageCount?: number;
+  toolNames?: string[];
+  maxTokens?: number;
+
+  // From "end" phase (filled when end arrives)
+  httpStatus?: number;
+  duration?: number;
+  stopReason?: string;
+  usage?: RequestSummary["usage"];
+  contentBlockTypes?: string[];
+  error?: string;
+};
+
+type NetworkState = {
+  // Merged request entries keyed by request ID
+  requests: Map<string, MergedRequest>;
+  // Turn index -> ordered request IDs for grouped rendering
+  turns: Map<number, string[]>;
+  // Currently selected request
+  selectedRequestId: string | null;
+  selectedDetail: RequestDetail | null;
+  // Inspector state for current session
+  inspectorState: InspectorState;
+
+  // Actions
+  onSummary: (summary: RequestSummary) => void;
+  selectRequest: (requestId: string) => void;
+  clear: () => void;
+  switchSession: (sessionId: string) => void;
+};
+```
+
+**Phase merging logic:**
+
+```
+When "start" summary arrives:
+  1. Create new MergedRequest with requestState "in-flight"
+  2. Fill request-side fields (url, model, headers, messageCount, etc.)
+  3. Add to turns Map under the summary's turnIndex
+  4. UI shows row with animated dot, no duration/tokens yet
+
+When "end" summary arrives with matching ID:
+  1. Find existing MergedRequest by ID
+  2. Merge response-side fields (httpStatus, duration, usage, stopReason, etc.)
+  3. Set requestState to "complete" (or "error" if error field present)
+  4. UI row updates in-place: dot turns green, duration/tokens fill in
+
+When "end" arrives without a prior "start" (e.g., non-stream fast response):
+  1. Create a complete MergedRequest directly with requestState "complete"
+  2. Fill all fields from the single message
+```
+
+### Session Switching Behavior
+
+When the user switches between sessions in the sidebar, the Network panel transitions between four states:
+
+**State 1: Inspector enabled, has data**
+
+- Fetch request list via `listRequests(sessionId)`
+- Subscribe to new requests via `subscribeRequests(sessionId)`
+- Show full request list + detail panel
+
+**State 2: Inspector enabled, no data yet**
+
+- Show "Waiting for API requests..." with a subtle animated indicator
+- Requests appear as they arrive via subscription
+
+**State 3: Inspector failed to initialize**
+
+- Show "Network Inspector failed to initialize for this session. Check logs for details."
+- Suggests restarting the session
+
+**State 4: Inspector not enabled for this session**
+
+- Show placeholder: "Network Inspector was not enabled when this session started."
+- If the global `networkInspector` config is currently ON: "New sessions will have the inspector enabled."
+- If the global config is OFF: "Enable Network Inspector in Settings > Chat" with a button to open settings.
+
+The panel queries `getInspectorState(sessionId)` to determine which state to show. This is important because the global config might be ON now, but a session started before it was enabled won't have the interceptor.
+
+**On switch:**
+
+1. Unsubscribe from previous session's event stream
+2. Clear current store state
+3. Query `getInspectorState(newSessionId)` for panel state
+4. If enabled: fetch `listRequests(newSessionId)`, subscribe to `subscribeRequests(newSessionId)`
+5. Render appropriate state
+
+### Content Panel Registration
+
+Always visible when a session is active. The panel uses the four states above to render context-appropriate content.
+
+### Layout: Turn-Grouped Request List
+
+Requests are grouped by conversation turn. Each turn is a collapsible section showing the user message that triggered it and all API calls within that turn.
+
+```
++-----------------------------------------------------+
+| Network                            [filter] [clear]  |
+| +----------------------+----------------------------+|
+| | Turn 3: "Fix the auth bug"                        ||
+| |   Total: 57.8k tok | $0.42 | 11.7s               ||
+| | |-----------------------------------------|        ||
+| | | #  Model   Tok   Ctx    ms | Headers    |        ||
+| | |  1 opus    45k   22%  8.1s | [selected] |        ||
+| | |     * stream  main         |            |        ||
+| | |  2 haiku   800   4%  0.4s  | Request    |        ||
+| | |     * stream  sub          |            |        ||
+| | |  3 opus    12k  28%  3.2s  | Response   |        ||
+| | |     * stream  main         |            |        ||
+| | |-----------------------------------------|        ||
+| |                                |                   ||
+| | Turn 2: "Add tests for..."    | POST /v1/messages  ||
+| |   Total: 23k tok | $0.18     | x-api-key: sk-**** ||
+| |  [collapsed]                  | model: opus-4-6    ||
+| |                                | stream: true      ||
+| +----------------------+----------------------------+|
+| Session: 12 reqs | 120k tokens | $0.95 | 32s API    |
++-----------------------------------------------------+
+```
+
+### Left Panel: Turn-Grouped Request List
+
+**Turn headers:**
+
+- User message preview (first ~60 chars)
+- Turn subtotals: token count, estimated cost, total API time
+- Collapsible (click to expand/collapse)
+- Most recent turn expanded by default
+
+**Request rows (within a turn):**
+
+- **Columns:** #, Model (short name), Tokens (input+output), Context %, Duration
+- **Context %:** thin inline progress bar showing `inputTokens / maxContextTokens`
+- **Badges:** `stream`/`non-stream`, `main`/`sub` agent
+- **Status:** green dot (complete), animated dot (in-flight), red dot (error/retry)
+- **Auto-scroll:** new requests scroll into view unless user has scrolled up
+
+**Filter bar:**
+
+- Free text search (matches model, URL)
+- Toggles: errors-only, main-agent-only
+
+**[clear] button:**
+
+- Calls `clearRequests(sessionId)` via oRPC, then clears the renderer store
+- Useful to focus on a specific interaction without noise from earlier turns
+
+**Footer:**
+
+- Session-level totals: total requests, total tokens, total estimated cost, total API time
+
+### Right Panel: Request Detail (3 tabs)
+
+**Headers tab:**
+
+- Request headers in key-value grid (monospace)
+- Response headers below, separated by a divider
+- Masked credentials shown as-is (user can see the masking)
+
+**Request tab:**
+
+- Full request body fetched via `getRequestDetail()` on first selection (from memory, fast)
+- `rawBody` string parsed lazily by the renderer with `JSON.parse()`
+- Collapsible JSON tree viewer
+- Sections: Model config, System prompt, Messages (collapsible per message), Tools
+- Syntax highlighting for code blocks within messages
+- For in-flight requests: "Request details available when complete"
+
+**Response tab:**
+
+- Full response body fetched alongside request
+- For assembled stream responses: shows the reconstructed message
+- Content blocks rendered by type: text, thinking (collapsible), tool_use (with parsed input)
+- Usage breakdown table: input tokens, output tokens, cache read, cache creation, estimated cost
+
+### Copy Actions
+
+The detail panel toolbar includes two copy actions:
+
+**Copy as cURL:**
+Generates a cURL command from the captured request with masked API key:
+
+```bash
+curl -X POST 'https://api.anthropic.com/v1/messages' \
+  -H 'x-api-key: sk-ant-****xyz' \
+  -H 'content-type: application/json' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{"model":"claude-opus-4-6","max_tokens":16384,...}'
+```
+
+Developers can replace the masked key with their own and reproduce the exact request.
+
+**Copy as JSON:**
+Copies the full `RequestDetail` object (request + response) as formatted JSON. Useful for pasting into bug reports or log analysis.
+
+Both actions copy to clipboard with a brief toast notification ("Copied to clipboard").
+
+### Context Window Utilization
+
+Each request row shows a compact context utilization indicator:
+
+```
+| opus  45k/200k [########______] 22%  8.1s |
+```
+
+- Thin bar (4px height) below the token count
+- Color grades: green (0-60%), yellow (60-80%), red (80-100%)
+- Helps developers spot when conversations approach context limits before compaction kicks in
+- `maxContextTokens` derived from static model lookup table; unknown models default to 200k
+
+### Styling
+
+- Follows existing design system: neutral surfaces, `#fa216e` for selected/active states
+- Monospace font (JetBrains Mono / system monospace) for headers and JSON
+- Compact row height for information density (dev tool aesthetic)
+- Full dark/light theme support
+- Resizable split between list and detail panels
+
+## Implementation Phases
+
+### Phase 1: Core Pipeline
+
+Get data flowing end-to-end. Validates the architecture before investing in UI polish.
+
+- `fetch-interceptor.ts`: patch, URL matching, credential masking, stream assembly, fd 3 emit
+- `spawnClaudeCodeProcess`: `--preload` injection, fd 3 reading, ready handshake
+- `RequestTracker`: in-memory store, dual-cap eviction, inspector state tracking
+- `networkInspector` config: type, default, `<Switch>` in chat panel, persistence
+- oRPC: `listRequests`, `getRequestDetail`, `getInspectorState`, `subscribeRequests`
+- Network plugin: basic **flat** request list (no turn grouping), detail panel with 3 tabs
+- Session switching with four panel states
+- Integration test: spawn bun with `--preload`, mock fetch, verify fd 3 output
+
+### Phase 2: Polish
+
+UI features that improve usability.
+
+- Turn grouping (wire `startTurn()` in `SessionManager.stream()`, group by `turnIndex`)
+- Context window utilization bar
+- Cost estimation with static price table
+- Copy as cURL / Copy as JSON
+- Filter bar + [clear] button
+
+### Phase 3: Advanced
+
+Nice-to-have features for power users.
+
+- Sub-agent classification heuristic (`isMainAgentRequest()`)
+- Error-only / main-agent-only filter toggles
+- Session-level totals footer using SDK `total_cost_usd` as ground truth
+- Export session requests as JSON file
+
+## File Changes Summary
+
+### New Files
+
+| File                                                                        | Description                                                              |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `packages/desktop/src/main/features/agent/interceptor/fetch-interceptor.ts` | Fetch monkey-patch entry point                                           |
+| `packages/desktop/src/main/features/agent/interceptor/stream-assembler.ts`  | Per-request SSE event reconstruction class                               |
+| `packages/desktop/src/main/features/agent/interceptor/credential-mask.ts`   | API key / auth header masking                                            |
+| `packages/desktop/src/main/features/agent/interceptor/__tests__/`           | Unit + integration tests                                                 |
+| `packages/desktop/src/main/features/agent/request-tracker.ts`               | In-memory request store + EventPublisher                                 |
+| `packages/desktop/src/shared/features/agent/request-types.ts`               | RequestSummary + RequestDetail + InterceptorMessage type definitions     |
+| `packages/desktop/src/renderer/src/plugins/network/index.tsx`               | Plugin registration (contributes content panel)                          |
+| `packages/desktop/src/renderer/src/plugins/network/network-view.tsx`        | Main panel component                                                     |
+| `packages/desktop/src/renderer/src/plugins/network/components/`             | Turn group, request row, detail panel, context bar, empty state          |
+| `packages/desktop/src/renderer/src/plugins/network/store.ts`                | Zustand store: MergedRequest lifecycle, session switching, turn grouping |
+
+### Modified Files
+
+| File                                                                                   | Change                                                                                                                     |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `packages/desktop/src/shared/features/config/types.ts`                                 | Add `networkInspector: boolean` to `AppConfig`                                                                             |
+| `packages/desktop/src/renderer/src/features/config/store.ts`                           | Add `networkInspector` default (`false`)                                                                                   |
+| `packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx` | Add Network Inspector switch                                                                                               |
+| `packages/desktop/src/main/features/agent/session-manager.ts`                          | Add conditional `spawnClaudeCodeProcess`, fd 3 reading, ready handshake, `startTurn()` call, `markInspectorEnabled()` call |
+| `packages/desktop/src/shared/features/agent/contract.ts`                               | Add listRequests, getRequestDetail, getInspectorState, clearRequests, subscribeRequests                                    |
+| `packages/desktop/src/main/features/agent/router.ts`                                   | Implement new oRPC handlers                                                                                                |
+| `electron-builder.yml` (or equivalent)                                                 | Add `resources/fetch-interceptor.js` to extraResources                                                                     |
+| esbuild / vite config                                                                  | Add interceptor bundle step                                                                                                |
+
+## Edge Cases
+
+1. **Double-patch guard:** Set `globalThis.__nvInterceptorInstalled = true` to prevent double-patching if the interceptor loads twice.
+2. **Non-Anthropic requests:** Only intercept matching URLs. All other fetch calls pass through untouched.
+3. **fd 3 pipe closed:** If the parent process crashes, both sync and async writes catch the error and restore the original `globalThis.fetch`, silently disabling interception without affecting Claude Code.
+4. **Interceptor init failure:** Ready handshake times out after 5s. `RequestTracker` marks session as `"failed"`. Panel shows clear error instead of waiting forever.
+5. **Provider custom URLs:** The interceptor reads `ANTHROPIC_BASE_URL` from env to match custom provider endpoints.
+6. **Retries:** The Anthropic SDK retries failed requests internally. Each retry appears as a separate intercepted request, giving visibility into retry behavior.
+7. **Concurrent requests:** Main agent + sub-agents can have multiple in-flight requests simultaneously. Each patched fetch call creates its own `StreamAssembler` instance — no shared state between concurrent streams.
+8. **Sub-agent classification:** Derived from the request body (presence of "You are Claude Code" in system, tool count, ToolSearch) using the same heuristic as cc-viewer's `isMainAgentRequest()`.
+9. **Inspector toggled mid-session:** Setting change only takes effect on new sessions. The per-session `getInspectorState()` lets the UI show the correct state.
+10. **Memory bounds:** Dual-cap eviction (500 entries OR 50MB body size). Short sessions hit entry cap; long sessions with large contexts hit byte cap. Multiple concurrent sessions have independent buffers.
+11. **Context window limits:** Model-to-context-size mapping maintained as a static lookup table. Unknown models default to 200k.
+12. **Cost estimation accuracy:** Static price table may drift from actual pricing. The SDK's `total_cost_usd` from result messages is used as ground truth for turn-level totals when available.
+13. **JSON.stringify failures:** The interceptor wraps all serialization in try/catch. Circular references or BigInts in request/response bodies are caught; the body field is set to `"[serialization error]"` and the summary is still emitted.
+14. **Orphaned "start" messages:** If the CLI crashes mid-request, a "start" with no matching "end" remains in the store as an "in-flight" row. The row persists until session close or eviction — no special cleanup needed.
+15. **In-flight detail view:** Clicking an in-flight request shows "Request details available when complete" in the Request/Response tabs, since body data only arrives with the "end" phase.

--- a/docs/design/2026-03-18-interceptor-provider-url-fix.md
+++ b/docs/design/2026-03-18-interceptor-provider-url-fix.md
@@ -1,0 +1,118 @@
+# Interceptor: Provider URL Matching Fix
+
+**Date:** 2026-03-18
+**Status:** Draft
+
+## Problem
+
+The network interceptor fails to capture API requests when using a custom provider (e.g., `zenmux`). The 403 error response is visible in the chat UI but never appears in the Network panel.
+
+## Root Cause
+
+The interceptor's `isAnthropicURL()` function decides whether to capture a fetch call. It checks:
+
+1. Hostname contains `anthropic` or `claude`
+2. Path starts with `/v1/messages` or `/api/eval/sdk-`
+3. Hostname+port matches `process.env.ANTHROPIC_BASE_URL`
+
+For custom providers, the URL is something like `https://api.zenmux.com/...` — hostname doesn't match check 1. Path might match check 2, but only if the provider URL doesn't include a path prefix (e.g., `https://gateway.example.com/proxy/anthropic/v1/messages` would fail).
+
+Check 3 fails because the provider's `ANTHROPIC_BASE_URL` is set via the SDK's `options.settings.env` (flag settings layer), not in the spawned process's `process.env`. The spawn wrapper only passes:
+
+```typescript
+env: { ...spawnOpts.env, NV_SESSION_ID: sessionId }
+```
+
+If the SDK doesn't merge `settings.env` into `spawnOpts.env`, the interceptor's `process.env.ANTHROPIC_BASE_URL` is empty.
+
+## Evidence
+
+From `/tmp/dev.log` (session `48bb0629`, provider `zenmux`):
+
+```
+09:12:40.496  interceptor ready: sessionId=48bb0629
+09:12:42.823  startTurn: sid=48bb0629 turn=1
+              (no onMessage after this — interceptor didn't capture the request)
+09:12:54.336  updater check timed out (end of log)
+```
+
+The interceptor loaded successfully (ready handshake received), but `isAnthropicURL()` returned false for the provider's URL, so the request passed through uncaptured.
+
+## Fix
+
+Two changes, in priority order:
+
+### 1. Header-based matching with URL-first fast path (primary fix)
+
+**File:** `packages/desktop/src/main/features/agent/interceptor/fetch-interceptor.ts`
+
+The Anthropic SDK always sends `anthropic-version` and/or `x-api-key` headers on every API request, regardless of the base URL. Add a header-based check as a fallback when URL matching fails.
+
+**Case-insensitive header matching:** `extractHeaders()` only normalizes keys to lowercase when the input is a `Headers` instance (`.forEach` yields lowercase). When the SDK passes a plain object, original casing is preserved (`"Anthropic-Version"`, `"X-Api-Key"`). The check must be case-insensitive:
+
+```typescript
+function hasAnthropicHeaders(headers: Record<string, string>): boolean {
+  for (const key of Object.keys(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === "anthropic-version" || lower === "x-api-key") return true;
+  }
+  return false;
+}
+```
+
+**URL-first, headers as fallback:** Most requests are non-Anthropic (npm, web fetches). Extracting headers on every fetch call is unnecessary overhead. Check URL first (fast path), only extract+check headers when URL doesn't match:
+
+```typescript
+// Before:
+if (!ipcAlive || !isAnthropicURL(url)) {
+  return originalFetch.apply(this, arguments as any);
+}
+
+// After:
+if (!ipcAlive) {
+  return originalFetch.apply(this, arguments as any);
+}
+
+// Fast path: URL matches known Anthropic patterns
+if (!isAnthropicURL(url)) {
+  // Slow path: custom provider URL — check for Anthropic-specific headers
+  if (!hasAnthropicHeaders(extractHeaders(init))) {
+    return originalFetch.apply(this, arguments as any);
+  }
+}
+```
+
+This keeps the hot path (non-Anthropic fetches) fast — no header extraction. Only custom provider URLs pay the header check cost.
+
+### 2. Pass provider base URL in spawn env (defense-in-depth)
+
+**File:** `packages/desktop/src/main/features/agent/session-manager.ts`
+
+Pass the provider's `ANTHROPIC_BASE_URL` from `settingsEnv` into the spawn env so the interceptor's `customBaseURL` matching also works:
+
+```typescript
+// Before:
+env: { ...spawnOpts.env, NV_SESSION_ID: sessionId },
+
+// After:
+env: {
+  ...spawnOpts.env,
+  NV_SESSION_ID: sessionId,
+  ...(settingsEnv?.ANTHROPIC_BASE_URL
+    ? { ANTHROPIC_BASE_URL: settingsEnv.ANTHROPIC_BASE_URL }
+    : {}),
+},
+```
+
+The `settingsEnv` variable is already in scope (captured from the outer `initSession` closure). This makes the URL-based `customBaseURL` check work as a secondary match and provides accurate URL display in the Network panel.
+
+Note: if `spawnOpts.env` already contains `ANTHROPIC_BASE_URL` (SDK passes it through), this is a no-op since the spread order puts `settingsEnv` value last. If it doesn't, this fills the gap.
+
+## Scope
+
+| File                   | Change                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `fetch-interceptor.ts` | Add `hasAnthropicHeaders()` with case-insensitive check, URL-first guard with header fallback |
+| `session-manager.ts`   | Pass `settingsEnv.ANTHROPIC_BASE_URL` in spawn env                                            |
+
+Rebuild interceptor bundle after changes: `bun scripts/build-interceptor.ts`

--- a/packages/desktop/configs/electron-builder.mjs
+++ b/packages/desktop/configs/electron-builder.mjs
@@ -68,6 +68,7 @@ const config = {
   extraResources: [
     { from: "vendor/bun", to: "bun", filter: ["bun"] },
     { from: "vendor/rtk", to: "rtk", filter: ["rtk"] },
+    { from: "resources/fetch-interceptor.js", to: "fetch-interceptor.js" },
   ],
 
   files: [

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,9 +12,10 @@
   },
   "main": "./dist/main/index.js",
   "scripts": {
-    "dev": "electron-vite dev",
+    "build:interceptor": "bun scripts/build-interceptor.ts",
+    "dev": "bun run build:interceptor && electron-vite dev",
     "start": "electron-vite preview",
-    "build": "electron-vite build",
+    "build": "bun run build:interceptor && electron-vite build",
     "typecheck": "tsgo --noEmit -p tsconfig.node.json && tsgo --noEmit -p tsconfig.web.json",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "bun run build && electron-builder --dir --config configs/electron-builder.mjs",

--- a/packages/desktop/resources/fetch-interceptor.js
+++ b/packages/desktop/resources/fetch-interceptor.js
@@ -1,0 +1,484 @@
+// src/main/features/agent/interceptor/fetch-interceptor.ts
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+
+// src/main/features/agent/interceptor/credential-mask.ts
+var SENSITIVE_HEADERS = new Set(["x-api-key", "authorization"]);
+function maskCredential(value) {
+  if (value.startsWith("Bearer ")) {
+    return `Bearer ${maskCredential(value.slice(7))}`;
+  }
+  if (value.startsWith("sk-")) {
+    const prefix = value.slice(0, 6);
+    const suffix = value.slice(-3);
+    return `${prefix}****${suffix}`;
+  }
+  return value;
+}
+function maskHeaders(headers) {
+  const masked = {};
+  for (const [key, val] of Object.entries(headers)) {
+    masked[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? maskCredential(val) : val;
+  }
+  return masked;
+}
+
+// src/main/features/agent/interceptor/stream-assembler.ts
+class StreamAssembler {
+  message = {};
+  contentBlocks = [];
+  activeBlockIndex = -1;
+  inputJsonBuffer = "";
+  processEvent(event) {
+    switch (event.type) {
+      case "message_start":
+        this.handleMessageStart(event);
+        break;
+      case "content_block_start":
+        this.handleContentBlockStart(event);
+        break;
+      case "content_block_delta":
+        this.handleContentBlockDelta(event);
+        break;
+      case "content_block_stop":
+        this.handleContentBlockStop(event);
+        break;
+      case "message_delta":
+        this.handleMessageDelta(event);
+        break;
+      case "message_stop":
+        break;
+    }
+  }
+  finalize() {
+    return { ...this.message, content: this.contentBlocks };
+  }
+  handleMessageStart(event) {
+    const msg = event.message;
+    if (msg == null || typeof msg !== "object")
+      return;
+    this.message = {
+      id: msg.id,
+      type: msg.type ?? "message",
+      role: msg.role ?? "assistant",
+      model: msg.model,
+      stop_reason: msg.stop_reason ?? null,
+      stop_sequence: msg.stop_sequence ?? null,
+      usage: msg.usage ? { ...msg.usage } : { input_tokens: 0, output_tokens: 0 }
+    };
+    this.contentBlocks = [];
+  }
+  handleContentBlockStart(event) {
+    const block = event.content_block;
+    if (block == null || typeof block !== "object")
+      return;
+    const index = typeof event.index === "number" ? event.index : this.contentBlocks.length;
+    switch (block.type) {
+      case "text":
+        this.setBlock(index, { type: "text", text: block.text ?? "" });
+        break;
+      case "thinking":
+        this.setBlock(index, {
+          type: "thinking",
+          thinking: block.thinking ?? "",
+          signature: block.signature ?? ""
+        });
+        break;
+      case "redacted_thinking":
+        this.setBlock(index, { type: "redacted_thinking", data: block.data ?? "" });
+        break;
+      case "tool_use":
+        this.setBlock(index, {
+          type: "tool_use",
+          id: block.id ?? "",
+          name: block.name ?? "",
+          input: {}
+        });
+        this.inputJsonBuffer = "";
+        break;
+      default:
+        this.setBlock(index, { ...block });
+        break;
+    }
+    this.activeBlockIndex = index;
+  }
+  handleContentBlockDelta(event) {
+    const delta = event.delta;
+    if (delta == null || typeof delta !== "object")
+      return;
+    const index = typeof event.index === "number" ? event.index : this.activeBlockIndex;
+    const block = this.contentBlocks[index];
+    if (block == null)
+      return;
+    switch (delta.type) {
+      case "text_delta":
+        if (block.type === "text" && typeof delta.text === "string") {
+          block.text += delta.text;
+        }
+        break;
+      case "thinking_delta":
+        if (block.type === "thinking" && typeof delta.thinking === "string") {
+          block.thinking += delta.thinking;
+        }
+        break;
+      case "input_json_delta":
+        if (block.type === "tool_use" && typeof delta.partial_json === "string") {
+          this.inputJsonBuffer += delta.partial_json;
+        }
+        break;
+      case "signature_delta":
+        if (block.type === "thinking" && typeof delta.signature === "string") {
+          block.signature = delta.signature;
+        }
+        break;
+    }
+  }
+  handleContentBlockStop(event) {
+    const index = typeof event.index === "number" ? event.index : this.activeBlockIndex;
+    const block = this.contentBlocks[index];
+    if (block != null && block.type === "tool_use") {
+      if (this.inputJsonBuffer.length > 0) {
+        try {
+          block.input = JSON.parse(this.inputJsonBuffer);
+        } catch {
+          block.input = this.inputJsonBuffer;
+        }
+      }
+      this.inputJsonBuffer = "";
+    }
+    this.activeBlockIndex = -1;
+  }
+  handleMessageDelta(event) {
+    const delta = event.delta;
+    if (delta != null && typeof delta === "object") {
+      if (delta.stop_reason !== undefined) {
+        this.message.stop_reason = delta.stop_reason;
+      }
+      if (delta.stop_sequence !== undefined) {
+        this.message.stop_sequence = delta.stop_sequence;
+      }
+    }
+    const usage = event.usage;
+    if (usage != null && typeof usage === "object") {
+      if (this.message.usage == null) {
+        this.message.usage = {};
+      }
+      for (const key of Object.keys(usage)) {
+        const value = usage[key];
+        if (typeof value === "number") {
+          this.message.usage[key] = value;
+        } else if (value != null && typeof value === "object") {
+          this.message.usage[key] = { ...this.message.usage[key], ...value };
+        }
+      }
+    }
+  }
+  setBlock(index, block) {
+    while (this.contentBlocks.length <= index) {
+      this.contentBlocks.push(null);
+    }
+    this.contentBlocks[index] = block;
+  }
+}
+function parseSSEEvents(rawText) {
+  const results = [];
+  const blocks = rawText.split(`
+
+`);
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (trimmed.length === 0)
+      continue;
+    let eventType;
+    let dataStr;
+    const lines = trimmed.split(`
+`);
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        eventType = line.slice("event:".length).trim();
+      } else if (line.startsWith("data:")) {
+        const value = line.slice("data:".length).trim();
+        dataStr = dataStr == null ? value : dataStr + `
+` + value;
+      }
+    }
+    if (dataStr === "[DONE]")
+      continue;
+    if (dataStr == null || dataStr.length === 0)
+      continue;
+    try {
+      const parsed = JSON.parse(dataStr);
+      if (parsed != null && typeof parsed === "object") {
+        const type = eventType ?? parsed.type;
+        if (typeof type === "string") {
+          results.push({ ...parsed, type });
+        }
+      }
+    } catch {}
+  }
+  return results;
+}
+
+// src/main/features/agent/interceptor/fetch-interceptor.ts
+var DEBUG_ENABLED = process.env.NV_DEBUG === "1" || (process.env.DEBUG ?? "").includes("neovate:interceptor");
+function dlog(...args) {
+  if (DEBUG_ENABLED)
+    console.error("[neovate:interceptor]", ...args);
+}
+if (globalThis.__nvInterceptorInstalled) {
+  dlog("skip: already installed");
+} else {
+  globalThis.__nvInterceptorInstalled = true;
+  setup();
+}
+function setup() {
+  const originalFetch = globalThis.fetch;
+  const sessionId = process.env.NV_SESSION_ID ?? "";
+  const customBaseURL = process.env.ANTHROPIC_BASE_URL ?? "";
+  const fd = 3;
+  let ipcAlive = true;
+  dlog("setup: sessionId=%s customBaseURL=%s", sessionId, customBaseURL || "(default)");
+  try {
+    fs.writeSync(fd, `__NV_READY
+`);
+    dlog("handshake sent");
+  } catch {
+    ipcAlive = false;
+    dlog("handshake FAILED — fd 3 not open, disabling");
+  }
+  function emitSync(data) {
+    if (!ipcAlive)
+      return;
+    try {
+      fs.writeSync(fd, `__NV_REQ:${JSON.stringify(data)}
+`);
+    } catch {
+      ipcAlive = false;
+      globalThis.fetch = originalFetch;
+    }
+  }
+  function emitAsync(data) {
+    if (!ipcAlive)
+      return;
+    try {
+      const line = `__NV_REQ:${JSON.stringify(data)}
+`;
+      fs.write(fd, line, (err) => {
+        if (err) {
+          ipcAlive = false;
+          globalThis.fetch = originalFetch;
+        }
+      });
+    } catch {
+      ipcAlive = false;
+      globalThis.fetch = originalFetch;
+    }
+  }
+  function isAnthropicURL(url) {
+    try {
+      const u = new URL(url);
+      if (u.hostname.includes("anthropic") || u.hostname.includes("claude"))
+        return true;
+      if (u.pathname.startsWith("/v1/messages"))
+        return true;
+      if (u.pathname.startsWith("/api/eval/sdk-"))
+        return true;
+      if (customBaseURL) {
+        const base = new URL(customBaseURL);
+        if (u.hostname === base.hostname && u.port === base.port)
+          return true;
+      }
+    } catch {
+      if (url.includes("anthropic") || url.includes("claude"))
+        return true;
+    }
+    return false;
+  }
+  function hasAnthropicHeaders(headers) {
+    for (const key of Object.keys(headers)) {
+      const lower = key.toLowerCase();
+      if (lower === "anthropic-version" || lower === "x-api-key")
+        return true;
+    }
+    return false;
+  }
+  function extractHeaders(init) {
+    const raw = {};
+    const h = init?.headers;
+    if (!h)
+      return raw;
+    if (h instanceof Headers) {
+      h.forEach((v, k) => {
+        raw[k] = v;
+      });
+    } else if (Array.isArray(h)) {
+      for (const [k, v] of h)
+        raw[k] = v;
+    } else {
+      Object.assign(raw, h);
+    }
+    return raw;
+  }
+  globalThis.fetch = async function patchedFetch(input, init) {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (!ipcAlive) {
+      return originalFetch.apply(this, arguments);
+    }
+    if (!isAnthropicURL(url)) {
+      if (!hasAnthropicHeaders(extractHeaders(init))) {
+        return originalFetch.apply(this, arguments);
+      }
+    }
+    const id = randomUUID();
+    const method = init?.method ?? "GET";
+    const startTime = Date.now();
+    dlog("intercept: %s %s id=%s", method, url, id);
+    const rawHeaders = extractHeaders(init);
+    const maskedHdrs = maskHeaders(rawHeaders);
+    const rawBody = typeof init?.body === "string" ? init.body : "";
+    let parsed = null;
+    try {
+      if (rawBody)
+        parsed = JSON.parse(rawBody);
+    } catch {}
+    const summaryBase = {
+      id,
+      sessionId,
+      url,
+      method,
+      model: parsed?.model,
+      isStream: parsed?.stream === true,
+      headers: maskedHdrs,
+      messageCount: Array.isArray(parsed?.messages) ? parsed.messages.length : undefined,
+      toolNames: Array.isArray(parsed?.tools) ? parsed.tools.map((t) => t.name).filter(Boolean) : undefined,
+      systemPromptLength: typeof parsed?.system === "string" ? parsed.system.length : Array.isArray(parsed?.system) ? JSON.stringify(parsed.system).length : undefined,
+      maxTokens: parsed?.max_tokens
+    };
+    dlog("start: id=%s model=%s stream=%s msgs=%s tools=%s", id, parsed?.model, parsed?.stream, summaryBase.messageCount, summaryBase.toolNames?.length);
+    emitSync({ ...summaryBase, phase: "start", timestamp: startTime });
+    let response;
+    try {
+      response = await originalFetch.apply(this, arguments);
+    } catch (err) {
+      const duration = Date.now() - startTime;
+      dlog("fetch error: id=%s duration=%dms error=%s", id, duration, err?.message);
+      emitAsync({
+        ...summaryBase,
+        phase: "end",
+        timestamp: Date.now(),
+        duration,
+        error: err?.message ?? "fetch failed",
+        detail: {
+          request: { headers: maskedHdrs, rawBody }
+        }
+      });
+      throw err;
+    }
+    const respHeaders = {};
+    response.headers.forEach((v, k) => {
+      respHeaders[k] = v;
+    });
+    dlog("response: id=%s status=%d stream=%s", id, response.status, !!(parsed?.stream && response.body));
+    if (parsed?.stream && response.body && response.ok) {
+      return handleStreamResponse(response, id, summaryBase, maskedHdrs, rawBody, respHeaders, startTime);
+    }
+    return handleNonStreamResponse(response, id, summaryBase, maskedHdrs, rawBody, respHeaders, startTime);
+  };
+  function handleStreamResponse(response, _id, summaryBase, maskedHdrs, rawBody, respHeaders, startTime) {
+    dlog("stream start: id=%s", summaryBase.id);
+    const assembler = new StreamAssembler;
+    let streamedContent = "";
+    const original = response.body;
+    const reader = original.getReader();
+    const decoder = new TextDecoder;
+    const passThrough = new ReadableStream({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            const events = parseSSEEvents(streamedContent);
+            for (const event of events) {
+              assembler.processEvent(event);
+            }
+            const assembled = assembler.finalize();
+            const duration = Date.now() - startTime;
+            const usage = assembled.usage;
+            const contentBlockTypes = Array.isArray(assembled.content) ? [...new Set(assembled.content.map((b) => b?.type).filter(Boolean))] : undefined;
+            dlog("stream end: id=%s duration=%dms events=%d blocks=%d stop=%s in=%d out=%d", summaryBase.id, duration, events.length, assembled.content?.length ?? 0, assembled.stop_reason, usage?.input_tokens ?? 0, usage?.output_tokens ?? 0);
+            emitAsync({
+              ...summaryBase,
+              phase: "end",
+              timestamp: Date.now(),
+              status: response.status,
+              duration,
+              responseHeaders: respHeaders,
+              stopReason: assembled.stop_reason,
+              usage: usage ? {
+                inputTokens: usage.input_tokens ?? 0,
+                outputTokens: usage.output_tokens ?? 0,
+                cacheReadInputTokens: usage.cache_read_input_tokens,
+                cacheCreationInputTokens: usage.cache_creation_input_tokens
+              } : undefined,
+              contentBlockTypes,
+              detail: {
+                request: { headers: maskedHdrs, rawBody },
+                response: { headers: respHeaders, body: assembled }
+              }
+            });
+            return;
+          }
+          controller.enqueue(value);
+          streamedContent += decoder.decode(value, { stream: true });
+        } catch (err) {
+          controller.error(err);
+        }
+      },
+      cancel() {
+        reader.cancel();
+      }
+    });
+    return new Response(passThrough, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers
+    });
+  }
+  async function handleNonStreamResponse(response, _id, summaryBase, maskedHdrs, rawBody, respHeaders, startTime) {
+    const cloned = response.clone();
+    let respBody;
+    try {
+      const text = await cloned.text();
+      try {
+        respBody = JSON.parse(text);
+      } catch {
+        respBody = text.slice(0, 2000);
+      }
+    } catch {
+      respBody = "[failed to read response body]";
+    }
+    const duration = Date.now() - startTime;
+    const usage = respBody && typeof respBody === "object" && "usage" in respBody ? respBody.usage : undefined;
+    dlog("non-stream end: id=%s status=%d duration=%dms", summaryBase.id, response.status, duration);
+    emitAsync({
+      ...summaryBase,
+      phase: "end",
+      timestamp: Date.now(),
+      status: response.status,
+      duration,
+      responseHeaders: respHeaders,
+      stopReason: respBody && typeof respBody === "object" && "stop_reason" in respBody ? respBody.stop_reason : undefined,
+      usage: usage ? {
+        inputTokens: usage.input_tokens ?? 0,
+        outputTokens: usage.output_tokens ?? 0,
+        cacheReadInputTokens: usage.cache_read_input_tokens,
+        cacheCreationInputTokens: usage.cache_creation_input_tokens
+      } : undefined,
+      detail: {
+        request: { headers: maskedHdrs, rawBody },
+        response: { headers: respHeaders, body: respBody }
+      }
+    });
+    return response;
+  }
+}

--- a/packages/desktop/scripts/build-interceptor.ts
+++ b/packages/desktop/scripts/build-interceptor.ts
@@ -1,0 +1,37 @@
+/**
+ * Bundle the fetch interceptor into a standalone JS file.
+ * Output: resources/fetch-interceptor.js
+ *
+ * Uses Bun's built-in bundler — no extra dependencies needed.
+ * Run: bun scripts/build-interceptor.ts
+ */
+import { mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, "..");
+
+const outdir = join(projectRoot, "resources");
+mkdirSync(outdir, { recursive: true });
+
+const result = await Bun.build({
+  entrypoints: [join(projectRoot, "src/main/features/agent/interceptor/fetch-interceptor.ts")],
+  outdir,
+  naming: "fetch-interceptor.js",
+  target: "node",
+  format: "esm",
+  minify: false,
+  sourcemap: "none",
+  external: [],
+});
+
+if (!result.success) {
+  console.error("Build failed:");
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}
+
+console.log("Built fetch-interceptor →", join(outdir, "fetch-interceptor.js"));

--- a/packages/desktop/src/main/__tests__/router.test.ts
+++ b/packages/desktop/src/main/__tests__/router.test.ts
@@ -1,6 +1,7 @@
 import { call } from "@orpc/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { RequestTracker } from "../features/agent/request-tracker";
 import { buildRouter, type AppDependencies } from "../router";
 
 const router = buildRouter(new Map());
@@ -9,6 +10,7 @@ describe("main router context wiring", () => {
   it("ping returns pong", async () => {
     const context = {
       sessionManager: {} as unknown as AppDependencies["sessionManager"],
+      requestTracker: new RequestTracker(),
       configStore: {} as unknown as AppDependencies["configStore"],
       projectStore: {} as unknown as AppDependencies["projectStore"],
       skillsService: {} as unknown as AppDependencies["skillsService"],

--- a/packages/desktop/src/main/features/agent/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/router.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { AppContext } from "../../../router";
 import type { SessionManager } from "../session-manager";
 
+import { RequestTracker } from "../request-tracker";
 import { agentRouter } from "../router";
 
 function makeContext(overrides?: Partial<AppContext>): AppContext {
@@ -14,6 +15,7 @@ function makeContext(overrides?: Partial<AppContext>): AppContext {
       closeSession: vi.fn(),
       closeAll: vi.fn(),
     } as unknown as SessionManager,
+    requestTracker: new RequestTracker(),
     configStore: {} as any,
     projectStore: {} as any,
     mainApp: { windowManager: { mainWindow: null } } as any,

--- a/packages/desktop/src/main/features/agent/__tests__/session-manager.test.ts
+++ b/packages/desktop/src/main/features/agent/__tests__/session-manager.test.ts
@@ -8,6 +8,7 @@ import type { ConfigStore } from "../../config/config-store";
 import type { ProjectStore } from "../../project/project-store";
 
 import { Pushable } from "../pushable";
+import { RequestTracker } from "../request-tracker";
 import { SessionManager, PERMISSION_TIMEOUT_MS } from "../session-manager";
 
 const makeStreamEventMsg = (event: any) => ({
@@ -70,6 +71,7 @@ describe("SessionManager", () => {
     manager = new SessionManager(
       { get: vi.fn(() => undefined) } as unknown as ConfigStore,
       {} as ProjectStore,
+      new RequestTracker(),
     );
   });
 

--- a/packages/desktop/src/main/features/agent/claude-code-utils.ts
+++ b/packages/desktop/src/main/features/agent/claude-code-utils.ts
@@ -45,6 +45,19 @@ export function resolveRtkPath(): string {
 }
 
 /**
+ * Resolve the path to the bundled fetch interceptor script.
+ *
+ * In dev mode, uses the build output in the project resources directory.
+ * In production, uses the file bundled via electron-builder extraResources.
+ */
+export function resolveInterceptorPath(): string {
+  if (is.dev) {
+    return path.join(path.dirname(path.dirname(__dirname)), "resources", "fetch-interceptor.js");
+  }
+  return path.join(process.resourcesPath, "fetch-interceptor.js");
+}
+
+/**
  * Check if a file-based RTK PreToolUse hook already exists in ~/.claude/settings.json.
  * Returns true if found, so the programmatic hook can be skipped to avoid double-rewriting.
  */

--- a/packages/desktop/src/main/features/agent/interceptor/credential-mask.ts
+++ b/packages/desktop/src/main/features/agent/interceptor/credential-mask.ts
@@ -1,0 +1,33 @@
+const SENSITIVE_HEADERS = new Set(["x-api-key", "authorization"]);
+
+/**
+ * Mask an API key or token, keeping a recognizable prefix and the last 3 chars.
+ *
+ * Examples:
+ *   "sk-ant-api03-abcdef...xyz"  → "sk-ant-****xyz"
+ *   "Bearer sk-ant-api03-abc..."  → "Bearer sk-ant-****xyz"
+ */
+export function maskCredential(value: string): string {
+  if (value.startsWith("Bearer ")) {
+    return `Bearer ${maskCredential(value.slice(7))}`;
+  }
+
+  if (value.startsWith("sk-")) {
+    const prefix = value.slice(0, 6);
+    const suffix = value.slice(-3);
+    return `${prefix}****${suffix}`;
+  }
+
+  return value;
+}
+
+/**
+ * Return a copy of the headers with sensitive values masked.
+ */
+export function maskHeaders(headers: Record<string, string>): Record<string, string> {
+  const masked: Record<string, string> = {};
+  for (const [key, val] of Object.entries(headers)) {
+    masked[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? maskCredential(val) : val;
+  }
+  return masked;
+}

--- a/packages/desktop/src/main/features/agent/interceptor/fetch-interceptor.ts
+++ b/packages/desktop/src/main/features/agent/interceptor/fetch-interceptor.ts
@@ -1,0 +1,415 @@
+/**
+ * Fetch interceptor — injected into the Claude Code CLI subprocess via
+ * `bun --preload`. Monkey-patches globalThis.fetch to capture all Anthropic
+ * API calls and emit them to the parent process over fd 3.
+ *
+ * This file is bundled with esbuild into a standalone JS file shipped
+ * alongside the app. It must have zero runtime dependencies on the
+ * Electron main process.
+ */
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+
+import { maskHeaders } from "./credential-mask";
+import { StreamAssembler, parseSSEEvents } from "./stream-assembler";
+
+// Lightweight debug logger — no dependency on the `debug` package.
+// Enable via DEBUG=neovate:interceptor* or NV_DEBUG=1 env var.
+const DEBUG_ENABLED =
+  process.env.NV_DEBUG === "1" || (process.env.DEBUG ?? "").includes("neovate:interceptor");
+function dlog(...args: unknown[]) {
+  if (DEBUG_ENABLED) console.error("[neovate:interceptor]", ...args);
+}
+
+// ── Guards ──────────────────────────────────────────────────────────
+
+if ((globalThis as any).__nvInterceptorInstalled) {
+  dlog("skip: already installed");
+} else {
+  (globalThis as any).__nvInterceptorInstalled = true;
+  setup();
+}
+
+// ── Setup ───────────────────────────────────────────────────────────
+
+function setup() {
+  const originalFetch = globalThis.fetch;
+  const sessionId = process.env.NV_SESSION_ID ?? "";
+  const customBaseURL = process.env.ANTHROPIC_BASE_URL ?? "";
+  const fd = 3;
+  let ipcAlive = true;
+
+  dlog("setup: sessionId=%s customBaseURL=%s", sessionId, customBaseURL || "(default)");
+
+  // Ready handshake — parent waits for this to confirm interceptor loaded
+  try {
+    fs.writeSync(fd, "__NV_READY\n");
+    dlog("handshake sent");
+  } catch {
+    ipcAlive = false;
+    dlog("handshake FAILED — fd 3 not open, disabling");
+  }
+
+  // ── Emitters ────────────────────────────────────────────────────
+
+  function emitSync(data: Record<string, unknown>): void {
+    if (!ipcAlive) return;
+    try {
+      fs.writeSync(fd, `__NV_REQ:${JSON.stringify(data)}\n`);
+    } catch {
+      ipcAlive = false;
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  function emitAsync(data: Record<string, unknown>): void {
+    if (!ipcAlive) return;
+    try {
+      const line = `__NV_REQ:${JSON.stringify(data)}\n`;
+      fs.write(fd, line, (err) => {
+        if (err) {
+          ipcAlive = false;
+          globalThis.fetch = originalFetch;
+        }
+      });
+    } catch {
+      ipcAlive = false;
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  // ── URL matching ────────────────────────────────────────────────
+
+  function isAnthropicURL(url: string): boolean {
+    try {
+      const u = new URL(url);
+      if (u.hostname.includes("anthropic") || u.hostname.includes("claude")) return true;
+      if (u.pathname.startsWith("/v1/messages")) return true;
+      if (u.pathname.startsWith("/api/eval/sdk-")) return true;
+      if (customBaseURL) {
+        const base = new URL(customBaseURL);
+        if (u.hostname === base.hostname && u.port === base.port) return true;
+      }
+    } catch {
+      // Fallback: string matching for relative URLs or malformed
+      if (url.includes("anthropic") || url.includes("claude")) return true;
+    }
+    return false;
+  }
+
+  // ── Header matching (case-insensitive) ─────────────────────────
+
+  function hasAnthropicHeaders(headers: Record<string, string>): boolean {
+    for (const key of Object.keys(headers)) {
+      const lower = key.toLowerCase();
+      if (lower === "anthropic-version" || lower === "x-api-key") return true;
+    }
+    return false;
+  }
+
+  // ── Header extraction ───────────────────────────────────────────
+
+  function extractHeaders(init?: RequestInit): Record<string, string> {
+    const raw: Record<string, string> = {};
+    const h = init?.headers;
+    if (!h) return raw;
+    if (h instanceof Headers) {
+      h.forEach((v, k) => {
+        raw[k] = v;
+      });
+    } else if (Array.isArray(h)) {
+      for (const [k, v] of h) raw[k] = v;
+    } else {
+      Object.assign(raw, h);
+    }
+    return raw;
+  }
+
+  // ── Fetch patch ─────────────────────────────────────────────────
+
+  globalThis.fetch = async function patchedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (!ipcAlive) {
+      return originalFetch.apply(this, arguments as any);
+    }
+
+    // Fast path: URL matches known Anthropic patterns
+    if (!isAnthropicURL(url)) {
+      // Slow path: custom provider URL — check for Anthropic-specific headers
+      if (!hasAnthropicHeaders(extractHeaders(init))) {
+        return originalFetch.apply(this, arguments as any);
+      }
+    }
+
+    const id = randomUUID();
+    const method = init?.method ?? "GET";
+    const startTime = Date.now();
+    dlog("intercept: %s %s id=%s", method, url, id);
+    const rawHeaders = extractHeaders(init);
+    const maskedHdrs = maskHeaders(rawHeaders);
+
+    // Zero-copy: grab raw body string from fetch options
+    const rawBody = typeof init?.body === "string" ? init.body : "";
+
+    // Parse once for summary extraction
+    let parsed: any = null;
+    try {
+      if (rawBody) parsed = JSON.parse(rawBody);
+    } catch {
+      // not JSON
+    }
+
+    const summaryBase = {
+      id,
+      sessionId,
+      url,
+      method,
+      model: parsed?.model,
+      isStream: parsed?.stream === true,
+      headers: maskedHdrs,
+      messageCount: Array.isArray(parsed?.messages) ? parsed.messages.length : undefined,
+      toolNames: Array.isArray(parsed?.tools)
+        ? parsed.tools.map((t: any) => t.name).filter(Boolean)
+        : undefined,
+      systemPromptLength:
+        typeof parsed?.system === "string"
+          ? parsed.system.length
+          : Array.isArray(parsed?.system)
+            ? JSON.stringify(parsed.system).length
+            : undefined,
+      maxTokens: parsed?.max_tokens,
+    };
+
+    // Emit start (summary only, sync, small)
+    dlog(
+      "start: id=%s model=%s stream=%s msgs=%s tools=%s",
+      id,
+      parsed?.model,
+      parsed?.stream,
+      summaryBase.messageCount,
+      summaryBase.toolNames?.length,
+    );
+    emitSync({ ...summaryBase, phase: "start", timestamp: startTime });
+
+    // Execute original fetch
+    let response: Response;
+    try {
+      response = await originalFetch.apply(this, arguments as any);
+    } catch (err: any) {
+      const duration = Date.now() - startTime;
+      dlog("fetch error: id=%s duration=%dms error=%s", id, duration, err?.message);
+      emitAsync({
+        ...summaryBase,
+        phase: "end",
+        timestamp: Date.now(),
+        duration,
+        error: err?.message ?? "fetch failed",
+        detail: {
+          request: { headers: maskedHdrs, rawBody },
+        },
+      });
+      throw err;
+    }
+
+    const respHeaders: Record<string, string> = {};
+    response.headers.forEach((v, k) => {
+      respHeaders[k] = v;
+    });
+
+    dlog(
+      "response: id=%s status=%d stream=%s",
+      id,
+      response.status,
+      !!(parsed?.stream && response.body),
+    );
+
+    // Stream response — only when the server actually streams (2xx).
+    // Error responses (403, 429, 500, etc.) are always plain JSON, never SSE.
+    if (parsed?.stream && response.body && response.ok) {
+      return handleStreamResponse(
+        response,
+        id,
+        summaryBase,
+        maskedHdrs,
+        rawBody,
+        respHeaders,
+        startTime,
+      );
+    }
+
+    // Non-stream response
+    return handleNonStreamResponse(
+      response,
+      id,
+      summaryBase,
+      maskedHdrs,
+      rawBody,
+      respHeaders,
+      startTime,
+    );
+  };
+
+  // ── Stream handler ──────────────────────────────────────────────
+
+  function handleStreamResponse(
+    response: Response,
+    _id: string,
+    summaryBase: Record<string, unknown>,
+    maskedHdrs: Record<string, string>,
+    rawBody: string,
+    respHeaders: Record<string, string>,
+    startTime: number,
+  ): Response {
+    dlog("stream start: id=%s", summaryBase.id);
+    const assembler = new StreamAssembler();
+    let streamedContent = "";
+
+    const original = response.body!;
+    const reader = original.getReader();
+    const decoder = new TextDecoder();
+
+    const passThrough = new ReadableStream({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+
+            // Assemble and emit
+            const events = parseSSEEvents(streamedContent);
+            for (const event of events) {
+              assembler.processEvent(event);
+            }
+            const assembled = assembler.finalize();
+            const duration = Date.now() - startTime;
+            const usage = assembled.usage;
+            const contentBlockTypes = Array.isArray(assembled.content)
+              ? [...new Set(assembled.content.map((b: any) => b?.type).filter(Boolean))]
+              : undefined;
+
+            dlog(
+              "stream end: id=%s duration=%dms events=%d blocks=%d stop=%s in=%d out=%d",
+              summaryBase.id,
+              duration,
+              events.length,
+              assembled.content?.length ?? 0,
+              assembled.stop_reason,
+              usage?.input_tokens ?? 0,
+              usage?.output_tokens ?? 0,
+            );
+
+            emitAsync({
+              ...summaryBase,
+              phase: "end",
+              timestamp: Date.now(),
+              status: response.status,
+              duration,
+              responseHeaders: respHeaders,
+              stopReason: assembled.stop_reason,
+              usage: usage
+                ? {
+                    inputTokens: usage.input_tokens ?? 0,
+                    outputTokens: usage.output_tokens ?? 0,
+                    cacheReadInputTokens: usage.cache_read_input_tokens,
+                    cacheCreationInputTokens: usage.cache_creation_input_tokens,
+                  }
+                : undefined,
+              contentBlockTypes,
+              detail: {
+                request: { headers: maskedHdrs, rawBody },
+                response: { headers: respHeaders, body: assembled },
+              },
+            });
+            return;
+          }
+
+          // Forward bytes and accumulate for assembly
+          controller.enqueue(value);
+          streamedContent += decoder.decode(value, { stream: true });
+        } catch (err) {
+          controller.error(err);
+        }
+      },
+      cancel() {
+        reader.cancel();
+      },
+    });
+
+    return new Response(passThrough, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  // ── Non-stream handler ──────────────────────────────────────────
+
+  async function handleNonStreamResponse(
+    response: Response,
+    _id: string,
+    summaryBase: Record<string, unknown>,
+    maskedHdrs: Record<string, string>,
+    rawBody: string,
+    respHeaders: Record<string, string>,
+    startTime: number,
+  ): Promise<Response> {
+    const cloned = response.clone();
+    let respBody: unknown;
+    try {
+      const text = await cloned.text();
+      try {
+        respBody = JSON.parse(text);
+      } catch {
+        respBody = text.slice(0, 2000);
+      }
+    } catch {
+      respBody = "[failed to read response body]";
+    }
+
+    const duration = Date.now() - startTime;
+    const usage =
+      respBody && typeof respBody === "object" && "usage" in respBody
+        ? (respBody as any).usage
+        : undefined;
+
+    dlog(
+      "non-stream end: id=%s status=%d duration=%dms",
+      summaryBase.id,
+      response.status,
+      duration,
+    );
+
+    emitAsync({
+      ...summaryBase,
+      phase: "end",
+      timestamp: Date.now(),
+      status: response.status,
+      duration,
+      responseHeaders: respHeaders,
+      stopReason:
+        respBody && typeof respBody === "object" && "stop_reason" in respBody
+          ? (respBody as any).stop_reason
+          : undefined,
+      usage: usage
+        ? {
+            inputTokens: usage.input_tokens ?? 0,
+            outputTokens: usage.output_tokens ?? 0,
+            cacheReadInputTokens: usage.cache_read_input_tokens,
+            cacheCreationInputTokens: usage.cache_creation_input_tokens,
+          }
+        : undefined,
+      detail: {
+        request: { headers: maskedHdrs, rawBody },
+        response: { headers: respHeaders, body: respBody },
+      },
+    });
+
+    return response;
+  }
+}

--- a/packages/desktop/src/main/features/agent/interceptor/stream-assembler.ts
+++ b/packages/desktop/src/main/features/agent/interceptor/stream-assembler.ts
@@ -1,0 +1,260 @@
+/**
+ * Per-request SSE stream assembler that reconstructs a complete Anthropic
+ * Messages API response from streaming SSE events.
+ *
+ * Each patched fetch call creates its own instance — no shared state.
+ * This is critical because the SDK can have multiple concurrent in-flight
+ * requests (main agent + sub-agents making parallel tool calls).
+ */
+
+/**
+ * Reconstructs a complete Anthropic Messages API response object from
+ * a sequence of streaming SSE events.
+ */
+export class StreamAssembler {
+  private message: Record<string, any> = {};
+  private contentBlocks: any[] = [];
+  private activeBlockIndex = -1;
+  private inputJsonBuffer = "";
+
+  /**
+   * Process a single parsed SSE event. Call in order for each event
+   * received from the stream.
+   */
+  processEvent(event: { type: string; [key: string]: any }): void {
+    switch (event.type) {
+      case "message_start":
+        this.handleMessageStart(event);
+        break;
+      case "content_block_start":
+        this.handleContentBlockStart(event);
+        break;
+      case "content_block_delta":
+        this.handleContentBlockDelta(event);
+        break;
+      case "content_block_stop":
+        this.handleContentBlockStop(event);
+        break;
+      case "message_delta":
+        this.handleMessageDelta(event);
+        break;
+      case "message_stop":
+        // No-op: the message is already fully assembled.
+        break;
+    }
+  }
+
+  /**
+   * Return the fully assembled Messages API response object.
+   * Call after the stream ends (after message_stop, or on stream close).
+   */
+  finalize(): Record<string, any> {
+    return { ...this.message, content: this.contentBlocks };
+  }
+
+  // -- Event handlers --------------------------------------------------------
+
+  private handleMessageStart(event: { type: string; [key: string]: any }): void {
+    const msg = event.message;
+    if (msg == null || typeof msg !== "object") return;
+
+    this.message = {
+      id: msg.id,
+      type: msg.type ?? "message",
+      role: msg.role ?? "assistant",
+      model: msg.model,
+      stop_reason: msg.stop_reason ?? null,
+      stop_sequence: msg.stop_sequence ?? null,
+      usage: msg.usage ? { ...msg.usage } : { input_tokens: 0, output_tokens: 0 },
+    };
+    this.contentBlocks = [];
+  }
+
+  private handleContentBlockStart(event: { type: string; [key: string]: any }): void {
+    const block = event.content_block;
+    if (block == null || typeof block !== "object") return;
+
+    const index = typeof event.index === "number" ? event.index : this.contentBlocks.length;
+
+    switch (block.type) {
+      case "text":
+        this.setBlock(index, { type: "text", text: block.text ?? "" });
+        break;
+      case "thinking":
+        this.setBlock(index, {
+          type: "thinking",
+          thinking: block.thinking ?? "",
+          signature: block.signature ?? "",
+        });
+        break;
+      case "redacted_thinking":
+        this.setBlock(index, { type: "redacted_thinking", data: block.data ?? "" });
+        break;
+      case "tool_use":
+        this.setBlock(index, {
+          type: "tool_use",
+          id: block.id ?? "",
+          name: block.name ?? "",
+          input: {},
+        });
+        this.inputJsonBuffer = "";
+        break;
+      default:
+        // Unknown block type — preserve as-is so finalize() doesn't lose data.
+        this.setBlock(index, { ...block });
+        break;
+    }
+
+    this.activeBlockIndex = index;
+  }
+
+  private handleContentBlockDelta(event: { type: string; [key: string]: any }): void {
+    const delta = event.delta;
+    if (delta == null || typeof delta !== "object") return;
+
+    const index = typeof event.index === "number" ? event.index : this.activeBlockIndex;
+    const block = this.contentBlocks[index];
+    if (block == null) return;
+
+    switch (delta.type) {
+      case "text_delta":
+        if (block.type === "text" && typeof delta.text === "string") {
+          block.text += delta.text;
+        }
+        break;
+      case "thinking_delta":
+        if (block.type === "thinking" && typeof delta.thinking === "string") {
+          block.thinking += delta.thinking;
+        }
+        break;
+      case "input_json_delta":
+        if (block.type === "tool_use" && typeof delta.partial_json === "string") {
+          this.inputJsonBuffer += delta.partial_json;
+        }
+        break;
+      case "signature_delta":
+        if (block.type === "thinking" && typeof delta.signature === "string") {
+          block.signature = delta.signature;
+        }
+        break;
+    }
+  }
+
+  private handleContentBlockStop(event: { type: string; [key: string]: any }): void {
+    const index = typeof event.index === "number" ? event.index : this.activeBlockIndex;
+    const block = this.contentBlocks[index];
+
+    if (block != null && block.type === "tool_use") {
+      // Parse the accumulated JSON input buffer.
+      if (this.inputJsonBuffer.length > 0) {
+        try {
+          block.input = JSON.parse(this.inputJsonBuffer);
+        } catch {
+          // Malformed JSON — store the raw string so the data isn't lost.
+          block.input = this.inputJsonBuffer;
+        }
+      }
+      this.inputJsonBuffer = "";
+    }
+
+    this.activeBlockIndex = -1;
+  }
+
+  private handleMessageDelta(event: { type: string; [key: string]: any }): void {
+    const delta = event.delta;
+    if (delta != null && typeof delta === "object") {
+      if (delta.stop_reason !== undefined) {
+        this.message.stop_reason = delta.stop_reason;
+      }
+      if (delta.stop_sequence !== undefined) {
+        this.message.stop_sequence = delta.stop_sequence;
+      }
+    }
+
+    // Merge usage — message_delta carries output_tokens (and sometimes more).
+    const usage = event.usage;
+    if (usage != null && typeof usage === "object") {
+      if (this.message.usage == null) {
+        this.message.usage = {};
+      }
+      for (const key of Object.keys(usage)) {
+        const value = usage[key];
+        if (typeof value === "number") {
+          this.message.usage[key] = value;
+        } else if (value != null && typeof value === "object") {
+          // Nested objects like server_tool_use — merge shallowly.
+          this.message.usage[key] = { ...this.message.usage[key], ...value };
+        }
+      }
+    }
+  }
+
+  // -- Helpers ---------------------------------------------------------------
+
+  private setBlock(index: number, block: any): void {
+    // Pad the array if needed (indices may not be contiguous, though they
+    // normally are with Anthropic's API).
+    while (this.contentBlocks.length <= index) {
+      this.contentBlocks.push(null);
+    }
+    this.contentBlocks[index] = block;
+  }
+}
+
+/**
+ * Parse raw SSE text into an array of typed event objects.
+ *
+ * SSE format:
+ *   event: <type>\n
+ *   data: <json>\n
+ *   \n
+ *
+ * Each block is separated by a blank line (`\n\n`).
+ * Returns only successfully parsed events; skips `[DONE]` sentinels
+ * and blocks with JSON parse errors.
+ */
+export function parseSSEEvents(rawText: string): Array<{ type: string; [key: string]: any }> {
+  const results: Array<{ type: string; [key: string]: any }> = [];
+  // Split on double newline — the SSE block boundary.
+  const blocks = rawText.split("\n\n");
+
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (trimmed.length === 0) continue;
+
+    let eventType: string | undefined;
+    let dataStr: string | undefined;
+
+    const lines = trimmed.split("\n");
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        eventType = line.slice("event:".length).trim();
+      } else if (line.startsWith("data:")) {
+        const value = line.slice("data:".length).trim();
+        // Accumulate data lines (SSE spec allows multiple data: lines per event).
+        dataStr = dataStr == null ? value : dataStr + "\n" + value;
+      }
+    }
+
+    // Skip [DONE] sentinel.
+    if (dataStr === "[DONE]") continue;
+
+    if (dataStr == null || dataStr.length === 0) continue;
+
+    try {
+      const parsed = JSON.parse(dataStr);
+      if (parsed != null && typeof parsed === "object") {
+        // Use the event: line as `type` if present, otherwise fall back to
+        // the `type` field in the parsed JSON (Anthropic SSE uses both).
+        const type = eventType ?? parsed.type;
+        if (typeof type === "string") {
+          results.push({ ...parsed, type });
+        }
+      }
+    } catch {
+      // Malformed JSON — skip this event silently.
+    }
+  }
+
+  return results;
+}

--- a/packages/desktop/src/main/features/agent/request-tracker.ts
+++ b/packages/desktop/src/main/features/agent/request-tracker.ts
@@ -1,0 +1,152 @@
+import { EventPublisher } from "@orpc/server";
+import debug from "debug";
+
+import type {
+  InspectorState,
+  InterceptorMessage,
+  RequestDetail,
+  RequestSummary,
+} from "../../../shared/features/agent/request-types";
+
+const log = debug("neovate:request-tracker");
+
+const MAX_ENTRIES = 500;
+const MAX_BODY_BYTES = 50 * 1024 * 1024; // 50MB
+
+type SessionData = {
+  summaries: RequestSummary[];
+  bodies: Map<string, RequestDetail>;
+  bodySizes: Map<string, number>;
+  totalBodyBytes: number;
+};
+
+export class RequestTracker {
+  private sessions = new Map<string, SessionData>();
+  private currentTurn = new Map<string, number>();
+  private inspectorState = new Map<string, InspectorState>();
+  readonly eventPublisher = new EventPublisher<Record<string, RequestSummary>>();
+
+  markInspectorEnabled(sessionId: string): void {
+    this.inspectorState.set(sessionId, "enabled");
+    log("markInspectorEnabled: sessionId=%s", sessionId);
+  }
+
+  markInspectorFailed(sessionId: string): void {
+    this.inspectorState.set(sessionId, "failed");
+    log("markInspectorFailed: sessionId=%s", sessionId);
+  }
+
+  getInspectorState(sessionId: string): InspectorState {
+    return this.inspectorState.get(sessionId) ?? "not-enabled";
+  }
+
+  onMessage(sessionId: string, msg: InterceptorMessage): void {
+    const session = this.ensureSession(sessionId);
+
+    const { detail, ...rest } = msg;
+    const summary: RequestSummary = {
+      ...rest,
+      turnIndex: this.currentTurn.get(sessionId) ?? 0,
+    };
+
+    log(
+      "onMessage: sid=%s phase=%s id=%s model=%s status=%s duration=%s",
+      sessionId,
+      msg.phase,
+      msg.id.slice(0, 8),
+      msg.model ?? "-",
+      msg.status ?? "-",
+      msg.duration != null ? `${msg.duration}ms` : "-",
+    );
+
+    session.summaries.push(summary);
+
+    if (detail) {
+      const requestDetail: RequestDetail = {
+        id: msg.id,
+        request: detail.request ?? { headers: {}, rawBody: "" },
+        response: detail.response,
+      };
+
+      const byteSize =
+        (detail.request?.rawBody?.length ?? 0) +
+        (detail.response
+          ? typeof detail.response.body === "string"
+            ? detail.response.body.length
+            : JSON.stringify(detail.response.body ?? "").length
+          : 0);
+
+      session.bodies.set(msg.id, requestDetail);
+      session.bodySizes.set(msg.id, byteSize);
+      session.totalBodyBytes += byteSize;
+    }
+
+    // Dual-cap eviction
+    let evictedCount = 0;
+    while (session.summaries.length > MAX_ENTRIES || session.totalBodyBytes > MAX_BODY_BYTES) {
+      const evicted = session.summaries.shift()!;
+      const evictedSize = session.bodySizes.get(evicted.id) ?? 0;
+      session.totalBodyBytes -= evictedSize;
+      session.bodySizes.delete(evicted.id);
+      session.bodies.delete(evicted.id);
+      evictedCount++;
+    }
+    if (evictedCount > 0) {
+      log(
+        "eviction: sid=%s evicted=%d remaining=%d bodyBytes=%d",
+        sessionId,
+        evictedCount,
+        session.summaries.length,
+        session.totalBodyBytes,
+      );
+    }
+
+    this.eventPublisher.publish(sessionId, summary);
+  }
+
+  startTurn(sessionId: string): void {
+    const next = (this.currentTurn.get(sessionId) ?? 0) + 1;
+    this.currentTurn.set(sessionId, next);
+    log("startTurn: sid=%s turn=%d", sessionId, next);
+  }
+
+  getRequests(sessionId: string): RequestSummary[] {
+    return this.sessions.get(sessionId)?.summaries ?? [];
+  }
+
+  getRequestDetail(sessionId: string, requestId: string): RequestDetail | null {
+    return this.sessions.get(sessionId)?.bodies.get(requestId) ?? null;
+  }
+
+  clearRequests(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.summaries = [];
+      session.bodies.clear();
+      session.bodySizes.clear();
+      session.totalBodyBytes = 0;
+      log("clearRequests: sessionId=%s", sessionId);
+    }
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+    this.currentTurn.delete(sessionId);
+    this.inspectorState.delete(sessionId);
+    log("clearSession: sessionId=%s", sessionId);
+  }
+
+  private ensureSession(sessionId: string): SessionData {
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = {
+        summaries: [],
+        bodies: new Map(),
+        bodySizes: new Map(),
+        totalBodyBytes: 0,
+      };
+      this.sessions.set(sessionId, session);
+    }
+    return session;
+  }
+}

--- a/packages/desktop/src/main/features/agent/router.ts
+++ b/packages/desktop/src/main/features/agent/router.ts
@@ -78,6 +78,32 @@ export const agentRouter = os.agent.router({
     }),
   }),
 
+  network: os.agent.network.router({
+    listRequests: os.agent.network.listRequests.handler(({ input, context }) => {
+      return context.requestTracker.getRequests(input.sessionId);
+    }),
+
+    getRequestDetail: os.agent.network.getRequestDetail.handler(({ input, context }) => {
+      return context.requestTracker.getRequestDetail(input.sessionId, input.requestId);
+    }),
+
+    getInspectorState: os.agent.network.getInspectorState.handler(({ input, context }) => {
+      return context.requestTracker.getInspectorState(input.sessionId);
+    }),
+
+    clearRequests: os.agent.network.clearRequests.handler(({ input, context }) => {
+      context.requestTracker.clearRequests(input.sessionId);
+    }),
+
+    subscribe: os.agent.network.subscribe.handler(async function* ({ input, context, signal }) {
+      for await (const summary of context.requestTracker.eventPublisher.subscribe(input.sessionId, {
+        signal,
+      })) {
+        yield summary;
+      }
+    }),
+  }),
+
   savePlan: os.agent.savePlan.handler(async ({ input }) => {
     const slug = input.title
       ? input.title

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -8,12 +8,13 @@ import type {
 
 import { EventPublisher } from "@orpc/server";
 import debug from "debug";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readdirSync, statSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { promisify } from "node:util";
 
 import type {
@@ -33,9 +34,11 @@ const execFileAsync = promisify(execFile);
 import type { Provider } from "../../../shared/features/provider/types";
 import type { ConfigStore } from "../config/config-store";
 import type { ProjectStore } from "../project/project-store";
+import type { RequestTracker } from "./request-tracker";
 
 import {
   resolveBunPath,
+  resolveInterceptorPath,
   resolveRtkPath,
   resolveSDKCliPath,
   detectRtkHookInSettings,
@@ -117,6 +120,7 @@ export class SessionManager {
   constructor(
     private configStore: ConfigStore,
     private projectStore: ProjectStore,
+    private requestTracker: RequestTracker,
   ) {}
 
   /** Return all in-memory (active) sessions. */
@@ -486,6 +490,12 @@ export class SessionManager {
       }
     };
 
+    // Network inspector: conditionally inject fetch interceptor via --preload
+    const networkInspector = this.configStore.get("networkInspector") === true;
+    if (networkInspector) {
+      this.requestTracker.markInspectorEnabled(sessionId);
+    }
+
     const queryOpts = this.queryOptions({
       sessionId,
       cwd,
@@ -502,6 +512,74 @@ export class SessionManager {
         ? { hooks: { PreToolUse: [{ matcher: "Bash", hooks: [rtkHook] }] } }
         : {}),
       ...(opts?.resume ? { resume: opts.resume, sessionId: undefined } : {}),
+      ...(networkInspector
+        ? {
+            spawnClaudeCodeProcess: (
+              spawnOpts: import("@anthropic-ai/claude-agent-sdk").SpawnOptions,
+            ) => {
+              const interceptorPath = resolveInterceptorPath();
+              log(
+                "spawnClaudeCodeProcess: interceptor=%s sessionId=%s",
+                interceptorPath,
+                sessionId,
+              );
+
+              const child = spawn(
+                spawnOpts.command,
+                ["--preload", interceptorPath, ...spawnOpts.args],
+                {
+                  cwd: spawnOpts.cwd,
+                  env: {
+                    ...spawnOpts.env,
+                    NV_SESSION_ID: sessionId,
+                    ...(settingsEnv?.ANTHROPIC_BASE_URL
+                      ? { ANTHROPIC_BASE_URL: settingsEnv.ANTHROPIC_BASE_URL }
+                      : {}),
+                  },
+                  signal: spawnOpts.signal,
+                  stdio: ["pipe", "pipe", "pipe", "pipe"],
+                },
+              );
+
+              // Read interceptor data from fd 3 (dedicated IPC pipe)
+              let interceptorReady = false;
+              const ipcStream = child.stdio[3];
+              if (ipcStream && "on" in ipcStream) {
+                const rl = createInterface({ input: ipcStream as NodeJS.ReadableStream });
+                rl.on("line", (line: string) => {
+                  if (line === "__NV_READY") {
+                    interceptorReady = true;
+                    log("interceptor ready: sessionId=%s", sessionId);
+                    return;
+                  }
+                  if (!line.startsWith("__NV_REQ:")) {
+                    log("interceptor fd3 unknown line: %s", line.slice(0, 100));
+                    return;
+                  }
+                  try {
+                    const msg = JSON.parse(line.slice("__NV_REQ:".length));
+                    this.requestTracker.onMessage(sessionId, msg);
+                  } catch (err) {
+                    log(
+                      "interceptor fd3 parse error: %s line=%s",
+                      err instanceof Error ? err.message : err,
+                      line.slice(0, 200),
+                    );
+                  }
+                });
+              }
+
+              setTimeout(() => {
+                if (!interceptorReady) {
+                  log("WARNING: network interceptor did not initialize — sessionId=%s", sessionId);
+                  this.requestTracker.markInspectorFailed(sessionId);
+                }
+              }, 5000);
+
+              return child;
+            },
+          }
+        : {}),
     };
 
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
@@ -580,6 +658,7 @@ export class SessionManager {
       this.eventPublisher.publish(sessionId, { kind: "request_settled", requestId });
     }
     this.sessions.delete(sessionId);
+    this.requestTracker.clearSession(sessionId);
     log("closeSession: closed sessionId=%s remainingSessions=%d", sessionId, this.sessions.size);
   }
 
@@ -721,6 +800,7 @@ export class SessionManager {
     const userMessageId = randomUUID();
     session.lastUserMessageId = userMessageId;
 
+    this.requestTracker.startTurn(sessionId);
     session.input.push({
       type: "user",
       message: { role: "user", content },

--- a/packages/desktop/src/main/features/config/config-store.ts
+++ b/packages/desktop/src/main/features/config/config-store.ts
@@ -34,6 +34,7 @@ const DEFAULT_APP_CONFIG: AppConfig = {
   permissionMode: "default",
   notificationSound: "default",
   tokenOptimization: true,
+  networkInspector: false,
 
   // Keybindings
   keybindings: {},

--- a/packages/desktop/src/main/features/storage/__tests__/router.test.ts
+++ b/packages/desktop/src/main/features/storage/__tests__/router.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { AppContext } from "../../../router";
 
 import { StorageService } from "../../../core/storage-service";
+import { RequestTracker } from "../../agent/request-tracker";
 import { storageRouter } from "../router";
 
 /**
@@ -25,6 +26,7 @@ beforeEach(() => {
   context = {
     storage,
     sessionManager: {} as any,
+    requestTracker: new RequestTracker(),
     configStore: {} as any,
     projectStore: {} as any,
     skillsService: {} as any,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import type { AppContext } from "./router";
 
 import { MainApp } from "./app";
 import { setupApplicationMenu } from "./core/menu";
+import { RequestTracker } from "./features/agent/request-tracker";
 import { SessionManager } from "./features/agent/session-manager";
 import { getShellEnvironment } from "./features/agent/shell-env";
 import { ConfigStore } from "./features/config/config-store";
@@ -51,7 +52,8 @@ process.on("unhandledRejection", (reason) => {
   projectStore.recordCrash();
   process.exit(1);
 });
-const sessionManager = new SessionManager(configStore, projectStore);
+const requestTracker = new RequestTracker();
+const sessionManager = new SessionManager(configStore, projectStore, requestTracker);
 const stateStore = new StateStore();
 const mainApp = new MainApp({
   plugins: [gitPlugin, filesPlugin, terminalPlugin, editorPlugin, reviewPlugin],
@@ -62,6 +64,7 @@ const skillsService = new SkillsService(projectStore, configStore, process.resou
 
 const appContext: AppContext = {
   sessionManager,
+  requestTracker,
   configStore,
   projectStore,
   skillsService,

--- a/packages/desktop/src/main/router.ts
+++ b/packages/desktop/src/main/router.ts
@@ -4,6 +4,7 @@ import { implement } from "@orpc/server";
 
 import type { StorageService } from "./core/storage-service";
 import type { IMainApp } from "./core/types";
+import type { RequestTracker } from "./features/agent/request-tracker";
 import type { SessionManager } from "./features/agent/session-manager";
 import type { ConfigStore } from "./features/config/config-store";
 import type { ProjectStore } from "./features/project/project-store";
@@ -24,6 +25,7 @@ import { utilsRouter } from "./features/utils/router";
 
 export type AppContext = {
   sessionManager: SessionManager;
+  requestTracker: RequestTracker;
   configStore: ConfigStore;
   projectStore: ProjectStore;
   skillsService: SkillsService;

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -20,6 +20,7 @@ import debugPlugin from "../plugins/debug";
 import editorPlugin from "../plugins/editor";
 import filesPlugin from "../plugins/files";
 import gitPlugin from "../plugins/git";
+import networkPlugin from "../plugins/network";
 import { providersPlugin } from "../plugins/providers";
 import reviewPlugin from "../plugins/review";
 import searchPlugin from "../plugins/search";
@@ -95,6 +96,7 @@ const BUILTIN_PLUGINS: RendererPlugin[] = [
   searchPlugin,
   editorPlugin,
   reviewPlugin,
+  networkPlugin,
   debugPlugin,
   providersPlugin,
   // TODO: Remove in the future

--- a/packages/desktop/src/renderer/src/features/config/store.ts
+++ b/packages/desktop/src/renderer/src/features/config/store.ts
@@ -41,6 +41,7 @@ const DEFAULT_CONFIG: AppConfig = {
   permissionMode: "default",
   notificationSound: "default",
   tokenOptimization: true,
+  networkInspector: false,
 
   // Keybindings
   keybindings: {},

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -154,6 +154,17 @@ export const ChatPanel = () => {
           />
         </SettingsRow>
 
+        {/* Network Inspector */}
+        <SettingsRow
+          title={t("settings.chat.networkInspector")}
+          description={t("settings.chat.networkInspector.description")}
+        >
+          <Switch
+            checked={config.networkInspector}
+            onCheckedChange={(v) => setConfig("networkInspector", v)}
+          />
+        </SettingsRow>
+
         {/* Send Message With */}
         <SettingsRow
           title={t("settings.chat.sendMessage")}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -63,6 +63,8 @@
   "settings.chat.notification.funk": "Funk",
   "settings.chat.tokenOptimization": "Token Optimization",
   "settings.chat.tokenOptimization.description": "Reduce token usage by filtering command output (via RTK)",
+  "settings.chat.networkInspector": "Network Inspector",
+  "settings.chat.networkInspector.description": "Show API requests in the Network panel. Takes effect on new sessions.",
   "settings.chat.sendMessage": "Send Message",
   "settings.chat.sendMessage.description": "Keyboard shortcut to send messages",
   "settings.chat.model.auto": "Default (auto)",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -63,6 +63,8 @@
   "settings.chat.notification.funk": "Funk",
   "settings.chat.tokenOptimization": "Token 优化",
   "settings.chat.tokenOptimization.description": "通过过滤命令输出减少 Token 用量（基于 RTK）",
+  "settings.chat.networkInspector": "网络检查器",
+  "settings.chat.networkInspector.description": "在网络面板中显示 API 请求。在新会话中生效。",
   "settings.chat.sendMessage": "发送消息",
   "settings.chat.sendMessage.description": "发送消息的键盘快捷键",
   "settings.chat.model.auto": "默认（自动）",

--- a/packages/desktop/src/renderer/src/plugins/network/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/network/index.tsx
@@ -1,0 +1,28 @@
+import { Activity01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { RendererPlugin } from "../../core/plugin";
+
+const NetworkIcon = ({ className }: { className?: string }) => (
+  <HugeiconsIcon icon={Activity01Icon} className={className} size={16} strokeWidth={1.5} />
+);
+
+const plugin: RendererPlugin = {
+  name: "plugin-network",
+
+  configContributions() {
+    return {
+      contentPanelViews: [
+        {
+          viewType: "network",
+          name: "Network",
+          singleton: true,
+          icon: NetworkIcon,
+          component: () => import("./network-view"),
+        },
+      ],
+    };
+  },
+};
+
+export default plugin;

--- a/packages/desktop/src/renderer/src/plugins/network/network-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/network/network-view.tsx
@@ -1,0 +1,432 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { RequestDetail } from "../../../../shared/features/agent/request-types";
+
+import { useAgentStore } from "../../features/agent/store";
+import { client } from "../../orpc";
+import { useNetworkStore } from "./store";
+
+type DetailTab = "headers" | "request" | "response";
+
+export default function NetworkView() {
+  const activeSessionId = useAgentStore((s) => s.activeSessionId);
+  const inspectorState = useNetworkStore((s) => s.inspectorState);
+  const requestOrder = useNetworkStore((s) => s.requestOrder);
+  const requests = useNetworkStore((s) => s.requests);
+  const selectedRequestId = useNetworkStore((s) => s.selectedRequestId);
+  const selectedDetail = useNetworkStore((s) => s.selectedDetail);
+  const loadSession = useNetworkStore((s) => s.loadSession);
+  const onSummary = useNetworkStore((s) => s.onSummary);
+  const selectRequest = useNetworkStore((s) => s.selectRequest);
+  const clear = useNetworkStore((s) => s.clear);
+  const reset = useNetworkStore((s) => s.reset);
+
+  const [activeTab, setActiveTab] = useState<DetailTab>("headers");
+
+  // Load session data on mount / session change
+  useEffect(() => {
+    if (!activeSessionId) {
+      reset();
+      return;
+    }
+    loadSession(activeSessionId);
+  }, [activeSessionId, loadSession, reset]);
+
+  // Subscribe to live updates
+  useEffect(() => {
+    if (!activeSessionId) return;
+
+    let cancelled = false;
+
+    async function subscribe() {
+      try {
+        const iter = await client.agent.network.subscribe({ sessionId: activeSessionId! });
+        for await (const summary of iter) {
+          if (cancelled) break;
+          onSummary(summary);
+        }
+      } catch {
+        // Stream closed or session ended — expected
+      }
+    }
+
+    subscribe();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, onSummary]);
+
+  // Fetch detail when selection changes
+  useEffect(() => {
+    if (!activeSessionId || !selectedRequestId) return;
+
+    let cancelled = false;
+
+    async function fetchDetail() {
+      try {
+        const detail = await client.agent.network.getRequestDetail({
+          sessionId: activeSessionId!,
+          requestId: selectedRequestId!,
+        });
+        if (!cancelled) {
+          useNetworkStore.setState({ selectedDetail: detail });
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    fetchDetail();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, selectedRequestId]);
+
+  const handleClear = useCallback(() => {
+    if (activeSessionId) clear(activeSessionId);
+  }, [activeSessionId, clear]);
+
+  // No session
+  if (!activeSessionId) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No active session
+      </div>
+    );
+  }
+
+  // Inspector not enabled
+  if (inspectorState === "not-enabled") {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        <p>Network inspector is not enabled for this session.</p>
+        <p className="text-xs">Enable it in chat settings to capture API requests.</p>
+      </div>
+    );
+  }
+
+  // Inspector failed
+  if (inspectorState === "failed") {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        <p>Network inspector failed to initialize.</p>
+        <p className="text-xs">Check the debug console for details.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-3">
+        <span className="text-xs font-medium text-muted-foreground">
+          {requestOrder.length} request{requestOrder.length !== 1 ? "s" : ""}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={handleClear}
+          className="rounded px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          Clear
+        </button>
+      </div>
+
+      {/* Main split */}
+      <div className="flex flex-1 min-h-0">
+        {/* Request list */}
+        <div className="w-72 shrink-0 overflow-y-auto border-r border-border">
+          {requestOrder.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+              Waiting for requests...
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {requestOrder.map((id) => {
+                const req = requests.get(id);
+                if (!req) return null;
+                const isSelected = id === selectedRequestId;
+
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => selectRequest(id)}
+                    className={`flex flex-col gap-0.5 px-3 py-2 text-left text-xs border-b border-border transition-colors ${
+                      isSelected
+                        ? "bg-[#fa216e]/10 border-l-2 border-l-[#fa216e]"
+                        : "hover:bg-muted border-l-2 border-l-transparent"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <RequestStatusBadge state={req.requestState} />
+                      <span className="font-mono font-medium truncate">{req.method}</span>
+                      {req.httpStatus != null && (
+                        <span
+                          className={`font-mono ${
+                            req.httpStatus >= 400
+                              ? "text-red-500"
+                              : "text-green-600 dark:text-green-400"
+                          }`}
+                        >
+                          {req.httpStatus}
+                        </span>
+                      )}
+                      {req.duration != null && (
+                        <span className="ml-auto text-muted-foreground">
+                          {formatDuration(req.duration)}
+                        </span>
+                      )}
+                    </div>
+                    <span className="font-mono text-muted-foreground truncate">
+                      {formatUrl(req.url)}
+                    </span>
+                    {req.model && (
+                      <span className="text-muted-foreground truncate">{req.model}</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Detail panel */}
+        <div className="flex-1 min-w-0 flex flex-col">
+          {selectedRequestId && selectedDetail ? (
+            <DetailPanel
+              detail={selectedDetail}
+              request={requests.get(selectedRequestId) ?? null}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+            />
+          ) : selectedRequestId ? (
+            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+              Loading...
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+              Select a request to view details
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Detail Panel ────────────────────────────────────────────────────
+
+type MergedRequest =
+  ReturnType<typeof useNetworkStore.getState>["requests"] extends Map<string, infer V> ? V : never;
+
+function DetailPanel({
+  detail,
+  request,
+  activeTab,
+  onTabChange,
+}: {
+  detail: RequestDetail;
+  request: MergedRequest | null;
+  activeTab: DetailTab;
+  onTabChange: (tab: DetailTab) => void;
+}) {
+  const tabs: { id: DetailTab; label: string }[] = [
+    { id: "headers", label: "Headers" },
+    { id: "request", label: "Request" },
+    { id: "response", label: "Response" },
+  ];
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Tab bar */}
+      <div className="flex h-9 shrink-0 items-center gap-0 border-b border-border px-2">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onTabChange(tab.id)}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === tab.id
+                ? "text-[#fa216e] border-b-2 border-[#fa216e]"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-3">
+        {activeTab === "headers" && <HeadersTab detail={detail} request={request} />}
+        {activeTab === "request" && <RequestTab detail={detail} />}
+        {activeTab === "response" && <ResponseTab detail={detail} />}
+      </div>
+    </div>
+  );
+}
+
+// ─── Headers Tab ─────────────────────────────────────────────────────
+
+function HeadersTab({ detail, request }: { detail: RequestDetail; request: MergedRequest | null }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Summary */}
+      {request && (
+        <div className="flex flex-col gap-1">
+          <SectionTitle>General</SectionTitle>
+          <div className="rounded border border-border">
+            <HeaderRow label="URL" value={request.url} />
+            <HeaderRow label="Method" value={request.method} />
+            {request.httpStatus != null && (
+              <HeaderRow label="Status" value={String(request.httpStatus)} />
+            )}
+            {request.model && <HeaderRow label="Model" value={request.model} />}
+            {request.duration != null && (
+              <HeaderRow label="Duration" value={formatDuration(request.duration)} />
+            )}
+            {request.stopReason && <HeaderRow label="Stop Reason" value={request.stopReason} />}
+            {request.usage && (
+              <>
+                <HeaderRow
+                  label="Input Tokens"
+                  value={request.usage.inputTokens.toLocaleString()}
+                />
+                <HeaderRow
+                  label="Output Tokens"
+                  value={request.usage.outputTokens.toLocaleString()}
+                />
+                {request.usage.cacheReadInputTokens != null && (
+                  <HeaderRow
+                    label="Cache Read"
+                    value={request.usage.cacheReadInputTokens.toLocaleString()}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Request headers */}
+      <div className="flex flex-col gap-1">
+        <SectionTitle>Request Headers</SectionTitle>
+        <div className="rounded border border-border">
+          {Object.entries(detail.request.headers).length > 0 ? (
+            Object.entries(detail.request.headers).map(([key, value]) => (
+              <HeaderRow key={key} label={key} value={value} />
+            ))
+          ) : (
+            <div className="px-3 py-2 text-xs text-muted-foreground">No headers</div>
+          )}
+        </div>
+      </div>
+
+      {/* Response headers */}
+      {detail.response && (
+        <div className="flex flex-col gap-1">
+          <SectionTitle>Response Headers</SectionTitle>
+          <div className="rounded border border-border">
+            {Object.entries(detail.response.headers).length > 0 ? (
+              Object.entries(detail.response.headers).map(([key, value]) => (
+                <HeaderRow key={key} label={key} value={value} />
+              ))
+            ) : (
+              <div className="px-3 py-2 text-xs text-muted-foreground">No headers</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Request Tab ─────────────────────────────────────────────────────
+
+function RequestTab({ detail }: { detail: RequestDetail }) {
+  const body = detail.request.rawBody;
+  const formatted = tryFormatJson(body);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SectionTitle>Request Body</SectionTitle>
+      <pre className="rounded border border-border bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-all overflow-x-auto">
+        {formatted}
+      </pre>
+    </div>
+  );
+}
+
+// ─── Response Tab ────────────────────────────────────────────────────
+
+function ResponseTab({ detail }: { detail: RequestDetail }) {
+  if (!detail.response) {
+    return (
+      <div className="flex h-32 items-center justify-center text-xs text-muted-foreground">
+        No response data available
+      </div>
+    );
+  }
+
+  const body = detail.response.body;
+  const formatted = typeof body === "string" ? tryFormatJson(body) : JSON.stringify(body, null, 2);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SectionTitle>Response Body</SectionTitle>
+      <pre className="rounded border border-border bg-muted/50 p-3 text-xs font-mono whitespace-pre-wrap break-all overflow-x-auto">
+        {formatted}
+      </pre>
+    </div>
+  );
+}
+
+// ─── Shared Components ───────────────────────────────────────────────
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-xs font-medium text-muted-foreground">{children}</h3>;
+}
+
+function HeaderRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex border-b border-border last:border-b-0 px-3 py-1.5 text-xs">
+      <span className="w-40 shrink-0 font-mono font-medium text-foreground">{label}</span>
+      <span className="font-mono text-muted-foreground break-all">{value}</span>
+    </div>
+  );
+}
+
+function RequestStatusBadge({ state }: { state: "in-flight" | "complete" | "error" }) {
+  if (state === "in-flight") {
+    return <span className="inline-block size-2 rounded-full bg-blue-500 animate-pulse" />;
+  }
+  if (state === "error") {
+    return <span className="inline-block size-2 rounded-full bg-red-500" />;
+  }
+  return <span className="inline-block size-2 rounded-full bg-green-500" />;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.pathname + u.search;
+  } catch {
+    return url;
+  }
+}
+
+function tryFormatJson(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/desktop/src/renderer/src/plugins/network/store.ts
+++ b/packages/desktop/src/renderer/src/plugins/network/store.ts
@@ -1,0 +1,222 @@
+import debug from "debug";
+import { enableMapSet } from "immer";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+
+import type {
+  InspectorState,
+  RequestDetail,
+  RequestSummary,
+} from "../../../../shared/features/agent/request-types";
+
+import { client } from "../../orpc";
+
+const log = debug("neovate:network-store");
+
+enableMapSet();
+
+type MergedRequest = {
+  id: string;
+  requestState: "in-flight" | "complete" | "error";
+  turnIndex: number;
+  timestamp: number;
+  url: string;
+  method: string;
+  model?: string;
+  isStream?: boolean;
+  headers: Record<string, string>;
+  messageCount?: number;
+  toolNames?: string[];
+  maxTokens?: number;
+  httpStatus?: number;
+  duration?: number;
+  stopReason?: string;
+  usage?: RequestSummary["usage"];
+  contentBlockTypes?: string[];
+  error?: string;
+};
+
+type NetworkState = {
+  requests: Map<string, MergedRequest>;
+  requestOrder: string[];
+  selectedRequestId: string | null;
+  selectedDetail: RequestDetail | null;
+  inspectorState: InspectorState;
+
+  onSummary: (summary: RequestSummary) => void;
+  selectRequest: (requestId: string | null) => void;
+  loadSession: (sessionId: string) => Promise<void>;
+  clear: (sessionId: string) => void;
+  reset: () => void;
+};
+
+function summaryToMerged(summary: RequestSummary, phase: "start" | "end"): MergedRequest {
+  const requestState: MergedRequest["requestState"] =
+    phase === "start" ? "in-flight" : summary.error ? "error" : "complete";
+
+  return {
+    id: summary.id,
+    requestState,
+    turnIndex: summary.turnIndex,
+    timestamp: summary.timestamp,
+    url: summary.url,
+    method: summary.method,
+    model: summary.model,
+    isStream: summary.isStream,
+    headers: summary.headers,
+    messageCount: summary.messageCount,
+    toolNames: summary.toolNames,
+    maxTokens: summary.maxTokens,
+    httpStatus: summary.status,
+    duration: summary.duration,
+    stopReason: summary.stopReason,
+    usage: summary.usage,
+    contentBlockTypes: summary.contentBlockTypes,
+    error: summary.error,
+  };
+}
+
+export const useNetworkStore = create<NetworkState>()(
+  immer((set, get) => ({
+    requests: new Map(),
+    requestOrder: [],
+    selectedRequestId: null,
+    selectedDetail: null,
+    inspectorState: "not-enabled",
+
+    onSummary: (summary) => {
+      log("onSummary: id=%s phase=%s", summary.id, summary.phase);
+      set((state) => {
+        const existing = state.requests.get(summary.id);
+
+        if (summary.phase === "start") {
+          state.requests.set(summary.id, summaryToMerged(summary, "start"));
+          if (!existing) {
+            state.requestOrder.push(summary.id);
+          }
+        } else {
+          // "end" phase
+          if (existing) {
+            // Merge response fields onto existing in-flight request
+            existing.requestState = summary.error ? "error" : "complete";
+            existing.httpStatus = summary.status;
+            existing.duration = summary.duration;
+            existing.stopReason = summary.stopReason;
+            existing.usage = summary.usage;
+            existing.contentBlockTypes = summary.contentBlockTypes;
+            existing.error = summary.error;
+          } else {
+            // No prior start — create complete entry directly
+            state.requests.set(summary.id, summaryToMerged(summary, "end"));
+            state.requestOrder.push(summary.id);
+          }
+        }
+      });
+    },
+
+    selectRequest: async (requestId) => {
+      log("selectRequest: %s", requestId);
+      set((state) => {
+        state.selectedRequestId = requestId;
+        if (!requestId) {
+          state.selectedDetail = null;
+        }
+      });
+
+      if (!requestId) return;
+
+      // Fetch detail from main process
+      // We need a sessionId — find it from the agent store or pass it through.
+      // For now, we use the same pattern as loadSession: the caller provides sessionId
+      // via the view component. We'll fetch from the component instead.
+    },
+
+    loadSession: async (sessionId) => {
+      log("loadSession: %s", sessionId);
+      try {
+        const [inspectorState, summaries] = await Promise.all([
+          client.agent.network.getInspectorState({ sessionId }),
+          client.agent.network.listRequests({ sessionId }),
+        ]);
+
+        set((state) => {
+          state.inspectorState = inspectorState;
+          state.requests = new Map();
+          state.requestOrder = [];
+          state.selectedRequestId = null;
+          state.selectedDetail = null;
+
+          // Rebuild from summaries — pair start+end by ID
+          const startMap = new Map<string, RequestSummary>();
+          for (const s of summaries) {
+            if (s.phase === "start") {
+              startMap.set(s.id, s);
+            }
+          }
+
+          const seen = new Set<string>();
+          for (const s of summaries) {
+            if (seen.has(s.id)) continue;
+            seen.add(s.id);
+
+            const start = startMap.get(s.id);
+            const end = summaries.find((r) => r.id === s.id && r.phase === "end");
+
+            if (start && end) {
+              const merged = summaryToMerged(start, "start");
+              merged.requestState = end.error ? "error" : "complete";
+              merged.httpStatus = end.status;
+              merged.duration = end.duration;
+              merged.stopReason = end.stopReason;
+              merged.usage = end.usage;
+              merged.contentBlockTypes = end.contentBlockTypes;
+              merged.error = end.error;
+              state.requests.set(s.id, merged);
+            } else if (start) {
+              state.requests.set(s.id, summaryToMerged(start, "start"));
+            } else if (end) {
+              state.requests.set(s.id, summaryToMerged(end, "end"));
+            }
+
+            state.requestOrder.push(s.id);
+          }
+        });
+
+        log(
+          "loadSession: loaded %d requests, inspector=%s",
+          get().requestOrder.length,
+          inspectorState,
+        );
+      } catch (err) {
+        log("loadSession: error %o", err);
+        set((state) => {
+          state.inspectorState = "failed";
+        });
+      }
+    },
+
+    clear: (sessionId) => {
+      log("clear: %s", sessionId);
+      client.agent.network.clearRequests({ sessionId }).catch((err: unknown) => {
+        log("clear: error %o", err);
+      });
+      set((state) => {
+        state.requests = new Map();
+        state.requestOrder = [];
+        state.selectedRequestId = null;
+        state.selectedDetail = null;
+      });
+    },
+
+    reset: () => {
+      log("reset");
+      set((state) => {
+        state.requests = new Map();
+        state.requestOrder = [];
+        state.selectedRequestId = null;
+        state.selectedDetail = null;
+        state.inspectorState = "not-enabled";
+      });
+    },
+  })),
+);

--- a/packages/desktop/src/shared/features/agent/contract.ts
+++ b/packages/desktop/src/shared/features/agent/contract.ts
@@ -10,6 +10,7 @@ import type {
   ClaudeCodeUIDispatch,
   ClaudeCodeUIDispatchResult,
 } from "../../claude-code/types";
+import type { InspectorState, RequestDetail, RequestSummary } from "./request-types";
 import type { ActiveSessionInfo, ModelScope, SessionInfo } from "./types";
 
 export const agentContract = {
@@ -65,6 +66,22 @@ export const agentContract = {
         providerId?: string;
       }>(),
     ),
+  },
+
+  network: {
+    listRequests: oc.input(z.object({ sessionId: z.string() })).output(type<RequestSummary[]>()),
+
+    getRequestDetail: oc
+      .input(z.object({ sessionId: z.string(), requestId: z.string() }))
+      .output(type<RequestDetail | null>()),
+
+    getInspectorState: oc.input(z.object({ sessionId: z.string() })).output(type<InspectorState>()),
+
+    clearRequests: oc.input(z.object({ sessionId: z.string() })).output(type<void>()),
+
+    subscribe: oc
+      .input(type<{ sessionId: string }>())
+      .output(eventIterator(type<RequestSummary>())),
   },
 
   savePlan: oc

--- a/packages/desktop/src/shared/features/agent/request-types.ts
+++ b/packages/desktop/src/shared/features/agent/request-types.ts
@@ -1,0 +1,77 @@
+export type InspectorState = "enabled" | "failed" | "not-enabled";
+
+export type RequestUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+};
+
+export type RequestSummary = {
+  id: string;
+  sessionId: string;
+  phase: "start" | "end";
+  timestamp: number;
+  turnIndex: number;
+
+  // Request info (both phases)
+  url: string;
+  method: string;
+  model?: string;
+  isStream?: boolean;
+  headers: Record<string, string>;
+
+  // Request body summary (start phase)
+  messageCount?: number;
+  toolNames?: string[];
+  systemPromptLength?: number;
+  maxTokens?: number;
+
+  // Response info (end phase only)
+  status?: number;
+  duration?: number;
+  responseHeaders?: Record<string, string>;
+  stopReason?: string;
+  usage?: RequestUsage;
+  contentBlockTypes?: string[];
+  error?: string;
+};
+
+export type RequestDetail = {
+  id: string;
+  request: {
+    headers: Record<string, string>;
+    rawBody: string;
+  };
+  response?: {
+    headers: Record<string, string>;
+    body: unknown;
+  };
+};
+
+export type InterceptorMessage = {
+  id: string;
+  phase: "start" | "end";
+  sessionId: string;
+  timestamp: number;
+  url: string;
+  method: string;
+  model?: string;
+  isStream?: boolean;
+  headers: Record<string, string>;
+  messageCount?: number;
+  toolNames?: string[];
+  systemPromptLength?: number;
+  maxTokens?: number;
+  status?: number;
+  duration?: number;
+  responseHeaders?: Record<string, string>;
+  stopReason?: string;
+  usage?: RequestUsage;
+  contentBlockTypes?: string[];
+  error?: string;
+  detail?: {
+    request?: { headers: Record<string, string>; rawBody: string };
+    response?: { headers: Record<string, string>; body: unknown };
+  };
+};

--- a/packages/desktop/src/shared/features/config/contract.ts
+++ b/packages/desktop/src/shared/features/config/contract.ts
@@ -55,6 +55,7 @@ export const configContract = {
         z.object({ key: z.literal("keybindings"), value: keybindingsValueSchema }),
         z.object({ key: z.literal("sidebarOrganize"), value: sidebarOrganizeValueSchema }),
         z.object({ key: z.literal("tokenOptimization"), value: booleanValueSchema }),
+        z.object({ key: z.literal("networkInspector"), value: booleanValueSchema }),
         z.object({ key: z.literal("sidebarSortBy"), value: sidebarSortByValueSchema }),
         z.object({
           key: z.literal("skillsRegistryUrls"),

--- a/packages/desktop/src/shared/features/config/types.ts
+++ b/packages/desktop/src/shared/features/config/types.ts
@@ -27,6 +27,7 @@ export type AppConfig = {
   permissionMode: ConfigPermissionMode;
   notificationSound: NotificationSound;
   tokenOptimization: boolean;
+  networkInspector: boolean;
 
   // Keybindings
   keybindings: Record<string, string>;


### PR DESCRIPTION

## Screenshots

<img width="3720" height="1868" alt="image" src="https://github.com/user-attachments/assets/25c03d36-1716-44f0-8fe5-a274417a0126" />


## Summary

- Add a Network Inspector panel that captures and displays every HTTP request Claude Code makes to the Anthropic API in real-time
- Fetch interceptor injected into CLI subprocess via `bun --preload` with dedicated fd 3 IPC pipe
- In-memory `RequestTracker` with dual-cap eviction (500 entries / 50MB)
- New `networkInspector` toggle in Settings > Chat (opt-in, persisted, takes effect on new sessions)
- Network plugin with flat request list, detail panel (Headers/Request/Response tabs), and 4 session states
- Header-based matching for custom provider URLs (case-insensitive `anthropic-version` / `x-api-key`)
- Zero-copy body forwarding, per-request stream assembly, credential masking, graceful pipe close handling

## Test plan

- [ ] Enable Network Inspector in Settings > Chat, start a new session, send a message — requests appear in the Network panel
- [ ] Click a completed request — Headers/Request/Response tabs show correct data
- [ ] In-flight requests show animated indicator, update in-place when complete
- [ ] Test with a custom provider — requests are captured via header matching
- [ ] Test with inspector disabled — Network panel shows "not enabled" placeholder
- [ ] Test 403/error responses — captured in non-stream handler with error body
- [ ] Switch between sessions — panel shows correct state per session
- [ ] `bun ready` passes (format, typecheck, lint, tests)