### PR TITLE
feat: add electron dialog API for plugin folder selection

### DIFF
--- a/packages/desktop/src/main/features/electron/router.ts
+++ b/packages/desktop/src/main/features/electron/router.ts
@@ -1,0 +1,28 @@
+import { implement } from "@orpc/server";
+import debug from "debug";
+import { BrowserWindow, dialog } from "electron";
+
+import type { AppContext } from "../../router";
+
+import { electronContract } from "../../../shared/features/electron/contract";
+
+const log = debug("neovate:electron");
+
+const os = implement({ electron: electronContract }).$context<AppContext>();
+
+export const electronRouter = os.electron.router({
+  dialog: os.electron.dialog.router({
+    showOpenDialog: os.electron.dialog.showOpenDialog.handler(async ({ input }) => {
+      log("dialog.showOpenDialog", input);
+      const win = BrowserWindow.getFocusedWindow();
+      const result = win
+        ? await dialog.showOpenDialog(win, input)
+        : await dialog.showOpenDialog(input);
+      log("dialog.showOpenDialog result", {
+        canceled: result.canceled,
+        count: result.filePaths.length,
+      });
+      return result;
+    }),
+  }),
+});

--- a/packages/desktop/src/main/router.ts
+++ b/packages/desktop/src/main/router.ts
@@ -14,6 +14,7 @@ import type { UpdaterService } from "./features/updater/service";
 import { contract } from "../shared/contract";
 import { agentRouter } from "./features/agent/router";
 import { configRouter } from "./features/config/router";
+import { electronRouter } from "./features/electron/router";
 import { projectRouter } from "./features/project/router";
 import { providerRouter } from "./features/provider/router";
 import { rulesRouter } from "./features/rules/router";
@@ -42,6 +43,7 @@ export function buildRouter(pluginRouters: Map<string, AnyRouter>) {
     ping: os.ping.handler(() => "pong" as const),
     agent: agentRouter,
     config: configRouter,
+    electron: electronRouter,
     project: projectRouter,
     provider: providerRouter,
     rules: rulesRouter,

--- a/packages/desktop/src/renderer/src/plugins/content-panel-demo/demo-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/content-panel-demo/demo-view.tsx
@@ -5,7 +5,7 @@ import type { ContentPanelStoreState } from "../../features/content-panel";
 
 import { Button } from "../../components/ui/button";
 import { ScrollArea } from "../../components/ui/scroll-area";
-import { useRendererApp } from "../../core/app";
+import { usePluginContext, useRendererApp } from "../../core/app";
 import { useContentPanelViewContext } from "../../features/content-panel";
 
 export default function DemoView() {
@@ -137,6 +137,11 @@ export default function DemoView() {
           </div>
         </Section>
 
+        {/* Electron API */}
+        <Section title="Electron API">
+          <FolderPicker />
+        </Section>
+
         {/* Local State */}
         <Section title="Local State (resets on remount)">
           <div className="flex items-center gap-2">
@@ -151,6 +156,34 @@ export default function DemoView() {
         </Section>
       </div>
     </ScrollArea>
+  );
+}
+
+function FolderPicker() {
+  const { orpcClient } = usePluginContext();
+  const client = orpcClient as any;
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const pickFolder = async () => {
+    const result = await client.electron.dialog.showOpenDialog({
+      properties: ["openDirectory"],
+    });
+    if (!result.canceled && result.filePaths.length > 0) {
+      setSelectedPath(result.filePaths[0]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={pickFolder}>
+          Pick Folder
+        </Button>
+        {selectedPath && (
+          <span className="truncate text-xs font-mono text-muted-foreground">{selectedPath}</span>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/packages/desktop/src/shared/contract.ts
+++ b/packages/desktop/src/shared/contract.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { agentContract } from "./features/agent/contract";
 import { configContract } from "./features/config/contract";
+import { electronContract } from "./features/electron/contract";
 import { projectContract } from "./features/project/contract";
 import { providerContract } from "./features/provider/contract";
 import { rulesContract } from "./features/rules/contract";
@@ -17,6 +18,7 @@ export const contract = {
   ping: oc.output(type<"pong">()),
   agent: agentContract,
   config: configContract,
+  electron: electronContract,
   project: projectContract,
   provider: providerContract,
   rules: rulesContract,

--- a/packages/desktop/src/shared/features/electron/contract.ts
+++ b/packages/desktop/src/shared/features/electron/contract.ts
@@ -1,0 +1,11 @@
+import type { OpenDialogOptions, OpenDialogReturnValue } from "electron";
+
+import { oc, type } from "@orpc/contract";
+
+const dialogContract = {
+  showOpenDialog: oc.input(type<OpenDialogOptions>()).output(type<OpenDialogReturnValue>()),
+};
+
+export const electronContract = {
+  dialog: dialogContract,
+};


### PR DESCRIPTION
Add electron dialog module exposing showOpenDialog via oRPC, allowing plugins to access system file dialogs. Integrate electron router into main contract. Add demo in content-panel-demo showing folder picker usage. Plugins can now call client.electron.dialog.showOpenDialog() to let users pick folders or files with system dialogs.