### PR TITLE
Application menu refactor with live updater state feedback

### DIFF
--- a/docs/designs/2026-03-18-application-menu-refactor.md
+++ b/docs/designs/2026-03-18-application-menu-refactor.md
@@ -1,0 +1,108 @@
+# Application Menu Refactor
+
+## Goal
+
+Refactor the application menu from a plain function (`setupApplicationMenu`) into an `ApplicationMenu` class that:
+
+1. Capitalizes the "About" label properly (`About Neovate` instead of lowercase)
+2. Adds a dynamic "Check for Updates" menu item with live state feedback
+3. Follows VS Code's pattern for menu ↔ service interaction via interface injection
+4. Handles Electron's immutable MenuItem limitation with safe menu rebuilds
+
+## Architecture
+
+### Dependency Direction
+
+```
+ApplicationMenu  →  IUpdateService (interface, in shared/)
+                         ↑
+                    UpdaterService (implements, in main/)
+```
+
+- `ApplicationMenu` depends on `IUpdateService` interface — never the concrete class
+- `UpdaterService` implements `IUpdateService` — knows nothing about the menu
+- `index.ts` (assembly layer) wires them together: `new ApplicationMenu(updaterService)`
+- Interface defined in `shared/features/updater/types.ts` alongside `UpdaterState`
+
+This matches VS Code's `Menubar` → `IUpdateService` pattern: the menu imports a lightweight interface from the update module, not the implementation.
+
+### Multi-Window Support
+
+`ApplicationMenu` holds no window reference. Per-window actions (e.g. open settings) resolve via `BrowserWindow.getFocusedWindow()` at click time. Future plugin windows work without menu changes.
+
+### Future: Data-Driven Menus
+
+Currently menu items are hardcoded in `build()`. To support plugin-contributed menu items, the evolution path is:
+
+1. Extract hardcoded template into a menu data structure
+2. `build()` renders from data instead of inline templates
+3. Expose `registerMenuItems(section, items)` for plugins
+
+The class-based design with centralized `build()` already supports this — no structural changes needed.
+
+## Interface
+
+### `IUpdateService` (`shared/features/updater/types.ts`)
+
+```ts
+export interface IUpdateService {
+  readonly state: UpdaterState;
+  onStateChange(cb: (state: UpdaterState) => void): () => void;
+  check(manual?: boolean): void;
+  install(): void;
+}
+```
+
+## Implementation
+
+### `ApplicationMenu` (`main/core/menu.ts`)
+
+Class with the following lifecycle:
+
+| Concern            | Implementation                                                                                                                                           |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Construction       | Subscribes to `IUpdateService.onStateChange`, registers `before-quit` listener, calls `build()`                                                          |
+| Rebuild scheduling | Debounced via `setTimeout(0)` + 10ms delay to avoid rebuilding while menu is open (same approach as VS Code)                                             |
+| Old menu GC        | Retains references to replaced `Menu` objects for 10s to prevent Electron GC crash ([electron#55347](https://github.com/electron/electron/issues/55347)) |
+| Disposal           | Unsubscribes from update service, removes `before-quit` listener, clears all timers                                                                      |
+
+### Update Menu Item States
+
+| `UpdaterState.status`           | Label                 | Enabled | Click Action                |
+| ------------------------------- | --------------------- | ------- | --------------------------- |
+| `idle` / `up-to-date` / `error` | Check for Updates     | yes     | `updateService.check(true)` |
+| `checking`                      | Checking for Updates… | no      | —                           |
+| `downloading`                   | Downloading Update…   | no      | —                           |
+| `ready`                         | Restart to Update     | yes     | `updateService.install()`   |
+
+### `UpdaterService` Changes (`main/features/updater/service.ts`)
+
+- `implements IUpdateService`
+- Renamed internal `state` → `_state` (private), exposed via `get state()` getter
+- Added `onStateChange(cb)`: thin wrapper over existing `publisher.subscribe("state", cb)`, returns unsubscribe function
+
+### `index.ts` Changes
+
+```ts
+// Before
+setupApplicationMenu(mainApp.windowManager.mainWindow, {
+  onCheckForUpdates: () => updaterService.check(true),
+});
+
+// After
+const menu = new ApplicationMenu(updaterService);
+
+// Cleanup
+app.on("before-quit", () => {
+  menu.dispose();
+});
+```
+
+## Files Changed
+
+| File                                   | Change                                                                                       |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `src/shared/features/updater/types.ts` | Added `IUpdateService` interface                                                             |
+| `src/main/features/updater/service.ts` | `implements IUpdateService`, added `onStateChange()`, renamed `state` → `_state` with getter |
+| `src/main/core/menu.ts`                | Replaced `setupApplicationMenu` function with `ApplicationMenu` class                        |
+| `src/main/index.ts`                    | Simplified to `new ApplicationMenu(updaterService)`, added `menu.dispose()`                  |

--- a/packages/desktop/src/main/core/menu.ts
+++ b/packages/desktop/src/main/core/menu.ts
@@ -1,91 +1,182 @@
-import { Menu, BrowserWindow, MenuItemConstructorOptions, app } from "electron";
+import { BrowserWindow, Menu, MenuItemConstructorOptions, app } from "electron";
+
+import type { IUpdateService } from "../../shared/features/updater/types";
 
 import { APP_NAME } from "../../shared/constants";
 
 const isDev = !app.isPackaged;
 
-export function setupApplicationMenu(mainWindow: BrowserWindow | null): void {
-  const isMac = process.platform === "darwin";
+export class ApplicationMenu {
+  private updateService: IUpdateService;
+  private willShutdown = false;
+  private rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  private unsubscribeUpdate: (() => void) | null = null;
 
-  const openSettings = (): void => {
-    mainWindow?.webContents.send("menu:open-settings");
+  // Keep old menus around to prevent GC crash (Electron bug)
+  // https://github.com/electron/electron/issues/55347
+  private oldMenus: Menu[] = [];
+  private gcTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private onBeforeQuit = (): void => {
+    this.willShutdown = true;
   };
 
-  const template: MenuItemConstructorOptions[] = [
-    // App menu (macOS) / File menu (Windows/Linux)
-    ...(isMac
-      ? [
-          {
-            label: APP_NAME,
-            submenu: [
-              { role: "about" as const },
-              { type: "separator" as const },
-              { label: "Settings", accelerator: "CmdOrCtrl+,", click: openSettings },
-              { type: "separator" as const },
-              { role: "hide" as const },
-              { role: "hideOthers" as const },
-              { role: "unhide" as const },
-              { type: "separator" as const },
-              { role: "quit" as const },
-            ],
-          },
-        ]
-      : [
-          {
-            label: "File",
-            submenu: [
-              { label: "Settings", accelerator: "CmdOrCtrl+,", click: openSettings },
-              { type: "separator" as const },
-              { role: "quit" as const },
-            ],
-          },
-        ]),
-    // Edit menu
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
-      ],
-    },
-    // View menu
-    {
-      label: "View",
-      submenu: [
-        ...(isDev
-          ? [
-              { role: "reload" as const },
-              { role: "forceReload" as const },
-              { type: "separator" as const },
-            ]
-          : []),
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { type: "separator" },
-        { role: "togglefullscreen" },
-        { type: "separator" },
-        { role: "toggleDevTools" },
-      ],
-    },
-    // Window menu
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "close" },
-        ...(isMac
-          ? [{ role: "zoom" as const }, { type: "separator" as const }, { role: "front" as const }]
-          : []),
-      ],
-    },
-  ];
+  constructor(updateService: IUpdateService) {
+    this.updateService = updateService;
+    this.unsubscribeUpdate = this.updateService.onStateChange(() => this.scheduleRebuild());
+    app.on("before-quit", this.onBeforeQuit);
+    this.build();
+  }
 
-  const menu = Menu.buildFromTemplate(template);
-  Menu.setApplicationMenu(menu);
+  dispose(): void {
+    this.unsubscribeUpdate?.();
+    this.unsubscribeUpdate = null;
+    app.off("before-quit", this.onBeforeQuit);
+    if (this.rebuildTimer) {
+      clearTimeout(this.rebuildTimer);
+      this.rebuildTimer = null;
+    }
+    if (this.gcTimer) {
+      clearTimeout(this.gcTimer);
+      this.gcTimer = null;
+    }
+    this.oldMenus = [];
+  }
+
+  private scheduleRebuild(): void {
+    if (this.rebuildTimer) return;
+    this.rebuildTimer = setTimeout(() => {
+      this.rebuildTimer = null;
+      if (!this.willShutdown) {
+        // Delay slightly to avoid rebuilding while menu is open
+        setTimeout(() => {
+          if (!this.willShutdown) this.build();
+        }, 10);
+      }
+    }, 0);
+  }
+
+  private build(): void {
+    const oldMenu = Menu.getApplicationMenu();
+    if (oldMenu) {
+      this.oldMenus.push(oldMenu);
+      this.scheduleGC();
+    }
+
+    const isMac = process.platform === "darwin";
+
+    const openSettings = (): void => {
+      BrowserWindow.getFocusedWindow()?.webContents.send("menu:open-settings");
+    };
+
+    const template: MenuItemConstructorOptions[] = [
+      ...(isMac
+        ? [
+            {
+              label: APP_NAME,
+              submenu: [
+                { label: `About ${APP_NAME}`, click: () => app.showAboutPanel() },
+                ...this.getUpdateMenuItems(),
+                { type: "separator" as const },
+                { label: "Settings", accelerator: "CmdOrCtrl+,", click: openSettings },
+                { type: "separator" as const },
+                { role: "hide" as const },
+                { role: "hideOthers" as const },
+                { role: "unhide" as const },
+                { type: "separator" as const },
+                { role: "quit" as const },
+              ],
+            },
+          ]
+        : [
+            {
+              label: "File",
+              submenu: [
+                { label: "Settings", accelerator: "CmdOrCtrl+,", click: openSettings },
+                { type: "separator" as const },
+                { role: "quit" as const },
+              ],
+            },
+          ]),
+      {
+        label: "Edit",
+        submenu: [
+          { role: "undo" },
+          { role: "redo" },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          { role: "selectAll" },
+        ],
+      },
+      {
+        label: "View",
+        submenu: [
+          ...(isDev
+            ? [
+                { role: "reload" as const },
+                { role: "forceReload" as const },
+                { type: "separator" as const },
+              ]
+            : []),
+          { role: "resetZoom" },
+          { role: "zoomIn" },
+          { role: "zoomOut" },
+          { type: "separator" },
+          { role: "togglefullscreen" },
+          { type: "separator" },
+          { role: "toggleDevTools" },
+        ],
+      },
+      {
+        label: "Window",
+        submenu: [
+          { role: "minimize" },
+          { role: "close" },
+          ...(isMac
+            ? [
+                { role: "zoom" as const },
+                { type: "separator" as const },
+                { role: "front" as const },
+              ]
+            : []),
+        ],
+      },
+    ];
+
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+  }
+
+  private getUpdateMenuItems(): MenuItemConstructorOptions[] {
+    const state = this.updateService.state;
+
+    switch (state.status) {
+      case "idle":
+      case "up-to-date":
+      case "error":
+        return [{ label: "Check for Updates", click: () => this.updateService.check(true) }];
+
+      case "checking":
+        return [{ label: "Checking for Updates\u2026", enabled: false }];
+
+      case "downloading":
+        return [{ label: "Downloading Update\u2026", enabled: false }];
+
+      case "ready":
+        return [{ label: "Restart to Update", click: () => this.updateService.install() }];
+
+      default:
+        return [];
+    }
+  }
+
+  private scheduleGC(): void {
+    if (this.gcTimer) return;
+    this.gcTimer = setTimeout(() => {
+      this.oldMenus = [];
+      this.gcTimer = null;
+    }, 10_000);
+  }
 }

--- a/packages/desktop/src/main/features/updater/router.ts
+++ b/packages/desktop/src/main/features/updater/router.ts
@@ -35,7 +35,7 @@ export const updaterRouter = os.updater.router({
   }),
 
   subscribe: os.updater.subscribe.handler(async function* ({ signal, context }) {
-    yield context.updaterService.getState();
+    yield context.updaterService.state;
     for await (const s of context.updaterService.publisher.subscribe("state", { signal })) {
       yield s;
     }

--- a/packages/desktop/src/main/features/updater/service.ts
+++ b/packages/desktop/src/main/features/updater/service.ts
@@ -4,7 +4,7 @@ import { EventPublisher } from "@orpc/server";
 import debug from "debug";
 import { autoUpdater } from "electron-updater";
 
-import type { UpdaterState } from "../../../shared/features/updater/types";
+import type { IUpdateService, UpdaterState } from "../../../shared/features/updater/types";
 
 const log = debug("neovate:updater");
 
@@ -17,8 +17,8 @@ export interface UpdaterOptions {
 const CHECK_INTERVAL_MS = 60 * 60 * 1000;
 const CHECK_TIMEOUT_MS = 30_000;
 
-export class UpdaterService {
-  private state: UpdaterState = { status: "idle" };
+export class UpdaterService implements IUpdateService {
+  private _state: UpdaterState = { status: "idle" };
   readonly publisher = new EventPublisher<{ state: UpdaterState }>();
   private checkInterval: ReturnType<typeof setInterval> | null = null;
   private checkTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -32,12 +32,16 @@ export class UpdaterService {
     percent: number;
   } | null = null;
 
-  getState(): UpdaterState {
-    return this.state;
+  get state(): UpdaterState {
+    return this._state;
+  }
+
+  onStateChange(cb: (state: UpdaterState) => void): () => void {
+    return this.publisher.subscribe("state", cb);
   }
 
   private setState(newState: UpdaterState) {
-    this.state = newState;
+    this._state = newState;
     this.publisher.publish("state", newState);
   }
 
@@ -100,8 +104,8 @@ export class UpdaterService {
   }
 
   install() {
-    log("install requested", { status: this.state.status });
-    if (this.state.status !== "ready") {
+    log("install requested", { status: this._state.status });
+    if (this._state.status !== "ready") {
       return;
     }
     autoUpdater.quitAndInstall();
@@ -129,7 +133,7 @@ export class UpdaterService {
       log("update not available", { surfaceUI: this.surfaceUI });
       this.clearCheckTimeout();
       this.isChecking = false;
-      if (this.surfaceUI || this.state.status === "error") {
+      if (this.surfaceUI || this._state.status === "error") {
         this.setState({ status: "up-to-date" });
       }
     });
@@ -139,7 +143,7 @@ export class UpdaterService {
       this.clearCheckTimeout();
       this.isChecking = false;
       this.pendingUpdate = { version: info.version, status: "downloading", percent: 0 };
-      if (this.surfaceUI || this.state.status === "error") {
+      if (this.surfaceUI || this._state.status === "error") {
         this.setState({ status: "downloading", version: info.version, percent: 0 });
       }
       autoUpdater.downloadUpdate().catch(() => {});

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,7 +7,7 @@ import { app, ipcMain } from "electron";
 import type { AppContext } from "./router";
 
 import { MainApp } from "./app";
-import { setupApplicationMenu } from "./core/menu";
+import { ApplicationMenu } from "./core/menu";
 import { RequestTracker } from "./features/agent/request-tracker";
 import { SessionManager } from "./features/agent/session-manager";
 import { getShellEnvironment } from "./features/agent/shell-env";
@@ -77,6 +77,8 @@ const appContext: AppContext = {
 // Reset crash counter after 30s of stable uptime
 setTimeout(() => projectStore.clearCrashCounter(), 30_000);
 
+let menu: ApplicationMenu | null = null;
+
 app.whenReady().then(async () => {
   electronApp.setAppUserModelId("com.neovateai.desktop");
 
@@ -84,7 +86,7 @@ app.whenReady().then(async () => {
   void updaterService.init();
 
   // Setup application menu (for menu items, shortcuts handled in renderer)
-  setupApplicationMenu(mainApp.windowManager.mainWindow);
+  menu = new ApplicationMenu(updaterService);
 
   // Transport — Electron MessagePort. Swap for WS/HTTP in other environments.
   const handler = new RPCHandler(mainApp.router);
@@ -110,6 +112,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  menu?.dispose();
   updaterService.dispose();
   void sessionManager.closeAll();
   void mainApp.stop();

--- a/packages/desktop/src/shared/features/updater/types.ts
+++ b/packages/desktop/src/shared/features/updater/types.ts
@@ -6,3 +6,10 @@ export type UpdaterState =
   | { status: "downloading"; version: string; percent: number }
   | { status: "ready"; version: string }
   | { status: "error"; message: string };
+
+export interface IUpdateService {
+  readonly state: UpdaterState;
+  onStateChange(cb: (state: UpdaterState) => void): () => void;
+  check(manual?: boolean): void;
+  install(): void;
+}


### PR DESCRIPTION
## Summary
- Refactored menu from imperative function to stateful class managing lifecycle and state subscriptions
- Added dynamic "Check for Updates" menu item with proper state feedback during checking/downloading
- Introduced IUpdateService interface for clean dependency injection between menu and updater
- Fixed "About" menu label capitalization to "About Neovate"
- Follows VS Code's architectural pattern for UI ↔ service integration

## Design
Menu depends on IUpdateService interface (not concrete class), enabling future support for plugins and data-driven menus without structural changes. All subscriptions properly cleaned up on disposal.