### PR TITLE
feat(provider): show detailed error info on model check failure

### DIFF
--- a/docs/designs/2026-03-18-model-check-detailed-failure-info.md
+++ b/docs/designs/2026-03-18-model-check-detailed-failure-info.md
@@ -1,0 +1,40 @@
+# Model Check: Show Detailed Info on Failure
+
+**Date:** 2026-03-18
+**Status:** Implemented
+
+## Problem
+
+When a model check (benchmark) fails, the error details are hidden behind a tiny tooltip showing a raw `String(err)` dump. Users cannot easily see _why_ a model check failed (auth error, model not found, rate limit, network issue, etc.).
+
+## Decision Log
+
+| #   | Question                                | Options                                                                                                 | Decision | Reasoning                                                                                                                      |
+| --- | --------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Where to extract structured error info? | A) Backend: parse Anthropic SDK error B) Frontend: parse error string                                   | A        | Backend has access to the actual error object with `status`, `message` properties                                              |
+| 2   | How to display failure details?         | A) Keep tooltip-only B) Show error inline below the model row C) Expand the badge to include error text | B+C      | Show "Failed" badge inline plus the error message directly below the row — tooltip is too hidden for important diagnostic info |
+| 3   | Add new fields to contract schema?      | A) Add `errorCode` field B) Keep single `error` string, make it better formatted                        | B        | YAGNI — a well-formatted error string is sufficient                                                                            |
+| 4   | How verbose should the error be?        | A) Just HTTP status + message B) Status + error type + message                                          | B        | Developers want to know _why_ it failed (auth error, model not found, rate limit, etc.)                                        |
+
+## Design
+
+### Backend (`src/main/features/provider/router.ts`)
+
+In `runBenchmark`'s catch block, detect the error type and extract structured info:
+
+- **`Anthropic.APIError`**: Extract HTTP status, error type from JSON body (e.g. `authentication_error`), and message. Format: `401 — authentication_error — invalid x-api-key`
+- **Other `Error`**: Use `err.message`
+- **Fallback**: `String(err)`
+
+### Frontend (`providers-panel.tsx`)
+
+When a model check fails:
+
+- The "Failed" badge remains visible inline (no change)
+- The error message is rendered directly below the model row as `text-xs text-destructive` text
+- Removed the tooltip wrapper for failed state — error is now always visible
+
+## Files Changed
+
+- `packages/desktop/src/main/features/provider/router.ts` — Structured error extraction in `runBenchmark` catch block
+- `packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx` — Inline error display for failed model checks

--- a/packages/desktop/src/main/features/provider/router.ts
+++ b/packages/desktop/src/main/features/provider/router.ts
@@ -91,6 +91,23 @@ async function runBenchmark(
     };
   } catch (err) {
     log("benchmark failed: provider=%s model=%s error=%s", provider.id, modelId, err);
+
+    let error: string;
+    if (err instanceof Anthropic.APIError) {
+      const parts = [`${err.status}`];
+      // Extract error type from the JSON body if available
+      const body = err.error as Record<string, unknown> | undefined;
+      const inner = body?.error as Record<string, unknown> | undefined;
+      if (inner?.type) parts.push(String(inner.type));
+      if (inner?.message) parts.push(String(inner.message));
+      else if (err.message) parts.push(err.message);
+      error = parts.join(" — ");
+    } else if (err instanceof Error) {
+      error = err.message;
+    } else {
+      error = String(err);
+    }
+
     return {
       ttftMs: 0,
       tpot: 0,
@@ -98,7 +115,7 @@ async function runBenchmark(
       totalTimeMs: 0,
       tokensGenerated: 0,
       success: false,
-      error: String(err),
+      error,
     };
   } finally {
     clearTimeout(timeout);

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -682,50 +682,51 @@ export const ProvidersPanel = () => {
                 const benchKey = `${form.baseURL}:${key}`;
                 const result = benchmarkResults[benchKey];
                 const isRunning = benchmarkingModels[benchKey] ?? false;
+                const failed = result && !isRunning && !result.success;
 
                 return (
-                  <div key={key} className="flex items-center gap-2 text-sm">
-                    <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{key}</code>
-                    {entry.displayName && (
-                      <span className="text-muted-foreground">{entry.displayName}</span>
-                    )}
-                    <div className="ml-auto flex items-center gap-1.5">
-                      {isRunning && <Spinner className="h-3 w-3" />}
-                      {result && !isRunning && result.success && (
-                        <Tooltip>
-                          <TooltipTrigger className="cursor-default">
-                            <BenchmarkMetrics
-                              ttftMs={result.ttftMs}
-                              tpot={result.tpot}
-                              tps={result.tps}
-                            />
-                          </TooltipTrigger>
-                          <TooltipPopup>
-                            <BenchmarkTooltipContent result={result} />
-                          </TooltipPopup>
-                        </Tooltip>
+                  <div key={key}>
+                    <div className="flex items-center gap-2 text-sm">
+                      <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{key}</code>
+                      {entry.displayName && (
+                        <span className="text-muted-foreground">{entry.displayName}</span>
                       )}
-                      {result && !isRunning && !result.success && (
-                        <Tooltip>
-                          <TooltipTrigger className="cursor-default">
-                            <Badge variant="error" size="sm">
-                              <AlertCircle className="h-3 w-3" />
-                              {t("settings.providers.benchmark.failed")}
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipPopup>
-                            <BenchmarkTooltipContent result={result} />
-                          </TooltipPopup>
-                        </Tooltip>
-                      )}
-                      <button
-                        className="text-muted-foreground hover:text-destructive"
-                        onClick={() => removeModel(key)}
-                        aria-label={t("settings.providers.removeModel", { model: key })}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
+                      <div className="ml-auto flex items-center gap-1.5">
+                        {isRunning && <Spinner className="h-3 w-3" />}
+                        {result && !isRunning && result.success && (
+                          <Tooltip>
+                            <TooltipTrigger className="cursor-default">
+                              <BenchmarkMetrics
+                                ttftMs={result.ttftMs}
+                                tpot={result.tpot}
+                                tps={result.tps}
+                              />
+                            </TooltipTrigger>
+                            <TooltipPopup>
+                              <BenchmarkTooltipContent result={result} />
+                            </TooltipPopup>
+                          </Tooltip>
+                        )}
+                        {failed && (
+                          <Badge variant="error" size="sm">
+                            <AlertCircle className="h-3 w-3" />
+                            {t("settings.providers.benchmark.failed")}
+                          </Badge>
+                        )}
+                        <button
+                          className="text-muted-foreground hover:text-destructive"
+                          onClick={() => removeModel(key)}
+                          aria-label={t("settings.providers.removeModel", { model: key })}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </div>
                     </div>
+                    {failed && result.error && (
+                      <p className="text-xs text-destructive mt-0.5 ml-1 break-all">
+                        {result.error}
+                      </p>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary

- **Backend**: Parse `Anthropic.APIError` into structured format (`401 — authentication_error — invalid x-api-key`) instead of dumping raw `String(err)`. Also handles generic `Error` and fallback cases cleanly.
- **Frontend**: Display failure error message inline below the model row instead of hiding it behind a tooltip. The "Failed" badge remains visible, with the full error text shown directly underneath.
- Includes design doc at `docs/designs/2026-03-18-model-check-detailed-failure-info.md`

## Test plan

- [ ] Configure a provider with an invalid API key, run model check — verify error shows `401 — authentication_error — ...` inline
- [ ] Configure a provider with a non-existent model ID, run model check — verify `404` or `not_found_error` details appear
- [ ] Configure a provider with valid credentials, run model check — verify success metrics still display correctly in badges/tooltip
- [ ] Verify `bun ready` passes (typecheck + lint + format + tests)