### PR TITLE
fix: hide session list empty state until sessions are loaded

### DIFF
--- a/docs/designs/session-list-empty-state-guard.md
+++ b/docs/designs/session-list-empty-state-guard.md
@@ -1,0 +1,45 @@
+# Session List: Don't Show Empty State When Not Loaded
+
+## Problem
+
+The session list shows `EmptySessionState` immediately on mount, before sessions have been fetched from the backend. The store initializes `agentSessions` as `[]`, which is indistinguishable from "fetched and got zero results".
+
+## Decision Log
+
+| #   | Question                    | Options                                                                                                           | Decision | Reasoning                                                                                                                                                                                                                        |
+| --- | --------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | How to track loaded state?  | A) `sessionsLoaded` boolean in agent store B) Local state per component C) `agentSessions: null \| SessionInfo[]` | A        | Store-level boolean is simplest; all three list components share the same data source. Null union would require changing all consumers.                                                                                          |
+| 2   | What to show before loaded? | A) Nothing B) Skeleton/spinner                                                                                    | A        | Less visual noise; the fetch is fast, so showing nothing avoids a flash of loading UI.                                                                                                                                           |
+| 3   | When to reset loaded flag?  | A) Never reset B) Reset when `setAgentSessions([])` is called from the no-project path                            | B        | When there's no project, the effect explicitly clears sessions — `setAgentSessions([])` sets `sessionsLoaded: true`, which is correct (sessions are genuinely empty). On initial mount before any effect runs, it stays `false`. |
+
+## Architecture
+
+- Added `sessionsLoaded: boolean` to `AgentState` in `store.ts`, initialized `false`.
+- `setAgentSessions` sets `sessionsLoaded: true` alongside `agentSessions`.
+- Three components gate `EmptySessionState` on `sessionsLoaded`:
+  - `SingleProjectSessionList` in `session-list.tsx`
+  - `ChronologicalList` in `chronological-list.tsx`
+  - `ProjectSessions` in `project-accordion-list.tsx`
+
+## Data Flow
+
+```
+mount -> agentSessions=[], sessionsLoaded=false -> render nothing
+  |
+  v
+effect fires -> client.agent.listSessions()
+  |
+  v
+setAgentSessions(results) -> sessionsLoaded=true
+  |
+  v
+results.length === 0 -> show EmptySessionState
+results.length > 0   -> show session list
+```
+
+## Files Modified
+
+- `packages/desktop/src/renderer/src/features/agent/store.ts`
+- `packages/desktop/src/renderer/src/features/agent/components/session-list.tsx`
+- `packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx`
+- `packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx`

--- a/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/chronological-list.tsx
@@ -19,6 +19,8 @@ export const ChronologicalList = memo(function ChronologicalList() {
   const [restoring, setRestoring] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
 
+  const sessionsLoaded = useAgentStore((s) => s.sessionsLoaded);
+
   const items = useFilteredSessions({ filter: "unpinned" });
 
   log("render: totalItems=%d", items.length);
@@ -50,7 +52,7 @@ export const ChronologicalList = memo(function ChronologicalList() {
   );
 
   if (items.length === 0) {
-    return <EmptySessionState />;
+    return sessionsLoaded ? <EmptySessionState /> : null;
   }
 
   return (

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -38,6 +38,7 @@ const DEFAULT_SESSION_LIMIT = 5;
 const ProjectSessions = memo(function ProjectSessions({ project }: { project: Project }) {
   const activeSessionId = useAgentStore((s) => s.activeSessionId);
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
+  const sessionsLoaded = useAgentStore((s) => s.sessionsLoaded);
   const loadSession = useLoadSession(project.path);
   const [restoring, setRestoring] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
@@ -71,7 +72,7 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
   ) as (sessionId: string, projectPath?: string) => Promise<void>;
 
   if (items.length === 0) {
-    return <EmptySessionState variant="compact" />;
+    return sessionsLoaded ? <EmptySessionState variant="compact" /> : null;
   }
 
   return (

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -69,6 +69,7 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
   const activeSessionId = useAgentStore((s) => s.activeSessionId);
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
   const agentSessions = useAgentStore((s) => s.agentSessions);
+  const sessionsLoaded = useAgentStore((s) => s.sessionsLoaded);
 
   const activeProject = useProjectStore((s) => s.activeProject);
   const archivedSessions = useProjectStore((s) => s.archivedSessions);
@@ -165,7 +166,9 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
     <div className="flex flex-1 flex-col gap-1">
       <NewChatButton projectPath={projectPath} />
       {pinnedItems.length === 0 && regularItems.length === 0 ? (
-        <EmptySessionState />
+        sessionsLoaded ? (
+          <EmptySessionState />
+        ) : null
       ) : (
         <ul className="flex flex-col">
           {pinnedItems.length > 0 && (

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -73,6 +73,7 @@ type AgentState = {
   sessions: Map<string, ChatSession>;
   activeSessionId: string | null;
   agentSessions: SessionInfo[];
+  sessionsLoaded: boolean;
   unseenTurnResults: Map<string, TurnResult>;
   _nextMessageId: number;
 
@@ -104,6 +105,7 @@ export const useAgentStore = create<AgentState>()(
     sessions: new Map(),
     activeSessionId: null,
     agentSessions: [],
+    sessionsLoaded: false,
     unseenTurnResults: new Map(),
     _nextMessageId: 0,
 
@@ -131,7 +133,7 @@ export const useAgentStore = create<AgentState>()(
 
     setAgentSessions: (agentSessions) => {
       storeLog("setAgentSessions: count=%d", agentSessions.length);
-      set({ agentSessions });
+      set({ agentSessions, sessionsLoaded: true });
     },
 
     createSession: (sessionId, meta) => {


### PR DESCRIPTION
## Summary

- Adds a `sessionsLoaded` boolean to the agent store to distinguish "not yet fetched" from "fetched and empty"
- Gates `EmptySessionState` on `sessionsLoaded` in all three session list components (`SingleProjectSessionList`, `ChronologicalList`, `ProjectSessions`)
- Before the fetch completes, renders nothing instead of flashing the empty state

## Test plan

- [ ] Open the app — verify the empty state does not flash before sessions load
- [ ] With no existing sessions, verify the empty state appears after loading completes
- [ ] Switch projects — verify the empty state behaves correctly per project
- [ ] Test in both single-project and multi-project modes