### PR TITLE
fix: move pinned session list below new chat button

### DIFF
--- a/docs/designs/2026-03-18-pinned-sessions-under-new-chat.md
+++ b/docs/designs/2026-03-18-pinned-sessions-under-new-chat.md
@@ -1,0 +1,16 @@
+# Pinned Sessions Under New Chat
+
+## Decision Log
+
+| #   | Question                | Options                                              | Decision | Reasoning                                                                                                    |
+| --- | ----------------------- | ---------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| 1   | Which mode is affected? | A) Multi-project only B) Single-project only C) Both | A        | Single-project already renders pinned below NewChatButton. Multi-project renders PinnedSessionList above it. |
+| 2   | How to fix the order?   | A) Swap JSX B) CSS order                             | A        | Simple JSX reorder is sufficient.                                                                            |
+
+## Change
+
+In `session-list.tsx` → `MultiProjectSessionList`, swap `<PinnedSessionList />` and `<NewChatButton>` so pinned sessions render below the New Chat button, matching single-project mode behavior.
+
+## Files
+
+- `packages/desktop/src/renderer/src/features/agent/components/session-list.tsx`

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -51,10 +51,10 @@ function MultiProjectSessionList() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <PinnedSessionList />
       <div className="px-2">
         <NewChatButton projectPath={activeProject?.path} />
       </div>
+      <PinnedSessionList />
       <SidebarTitleBar />
       {sidebarOrganize === "chronological" ? <ChronologicalList /> : <ProjectAccordionList />}
     </div>


### PR DESCRIPTION
## Summary

- Swaps the render order in `MultiProjectSessionList` so the pinned session list appears **below** the "New Chat" button, matching single-project mode behavior
- Previously, pinned sessions rendered above "New Chat" in multi-project mode, which was inconsistent

## Test plan

- [ ] Open the app in multi-project mode with pinned sessions
- [ ] Verify "New Chat" button appears at the top, followed by pinned sessions below it
- [ ] Verify single-project mode is unchanged (pinned sessions already below "New Chat")
- [ ] Verify unpinned session list still appears below pinned sessions