### PR TITLE
fix(content-panel): expand panel and render tab full-bleed on activation

### DIFF
--- a/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/__tests__/content-panel.test.ts
@@ -148,6 +148,15 @@ describe("activateView", () => {
 
     expect(panel.store.getState().getProjectState(PROJECT).activeTabId).toBe(id1);
   });
+
+  it("expands contentPanel when activating a view", () => {
+    const id1 = panel.openView("terminal");
+    vi.mocked(options.layout.expandPart).mockClear();
+
+    panel.activateView(id1);
+
+    expect(options.layout.expandPart).toHaveBeenCalledWith("contentPanel");
+  });
 });
 
 describe("getViewState / updateViewState", () => {

--- a/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/content-panel.tsx
@@ -156,7 +156,7 @@ export function ContentPanelRenderer() {
   const { tabs, activeTabId } = projectState;
 
   return (
-    <div className="flex h-full flex-col px-1.5">
+    <div className="flex h-full flex-col">
       <TabBar
         tabs={tabs}
         activeTabId={activeTabId}

--- a/packages/desktop/src/renderer/src/features/content-panel/components/tab-bar.tsx
+++ b/packages/desktop/src/renderer/src/features/content-panel/components/tab-bar.tsx
@@ -14,7 +14,7 @@ export function TabBar({
   registeredViewTypes: Set<string>;
 }) {
   return (
-    <div className="flex items-center border-b border-border h-10">
+    <div className="flex items-center border-b border-border h-10 px-1.5">
       <ScrollArea
         scrollFade
         className="min-w-0 flex-1 [&_[data-slot=scroll-area-scrollbar]]:hidden [&_[data-slot=scroll-area-viewport]]:!flex [&_[data-slot=scroll-area-viewport]]:items-center"

--- a/packages/desktop/src/renderer/src/features/content-panel/content-panel.ts
+++ b/packages/desktop/src/renderer/src/features/content-panel/content-panel.ts
@@ -123,6 +123,7 @@ export class ContentPanel {
 
   activateView(viewId: string): void {
     log("activate view", { viewId });
+    void this.options.layout.expandPart(COLLAPSIBLE_WORKBENCH_PART.contentPanel);
     this.store.getState().setActiveTab(this.projectPath, viewId);
   }
 


### PR DESCRIPTION
## Summary

- `activateView` now calls `layout.expandPart(contentPanel)` so the content panel becomes visible when a tab is activated (matching `openView` behavior)
- Moved `px-1.5` padding from the outer `ContentPanelRenderer` container to the `TabBar` only, giving tab views full edge-to-edge rendering space
- Added test verifying `activateView` expands the content panel

## Test plan

- [ ] Open a content panel tab (terminal, browser), verify it fills the full panel width without side padding
- [ ] Collapse the content panel, then programmatically activate a tab — verify the panel expands
- [ ] Switch between tabs — verify each tab renders at full size
- [ ] `bun ready` passes (format + typecheck + lint + tests)