### PR TITLE
perf: deduplicate loadSessionPreferences and add startup profiling

### DIFF
--- a/docs/designs/2026-03-18-startup-performance.md
+++ b/docs/designs/2026-03-18-startup-performance.md
@@ -1,0 +1,56 @@
+# Startup Performance Optimization
+
+## Problem
+
+App startup has excessive re-renders in the sidebar session list during initialization.
+
+## Bottlenecks Identified
+
+1. **Shell env resolution (~300-1200ms)** — Spawns interactive login shell every launch. Varies by system load.
+2. **loadSessionPreferences re-render storm** — Called 6x (per-project) but loads identical global data; `_projectPath` param unused. Causes 42 IPC calls and 88 `pinned-session-list` renders.
+3. **listSessions N+1 stats (~500-670ms)** — 821 `statSync()` calls for birthtimes after SDK already scanned dirs.
+4. **Code-server hardcoded delay (1000ms)** — `await delay(1000)` FIXME in `starter.ts:33`.
+5. **Terminal double-spawn (~130ms waste)** — React StrictMode (dev only).
+
+## Decision Log
+
+**1. Shell env resolution**
+
+- Options: A) Cache env to disk B) Use non-interactive shell C) Accept the cost
+- Decision: **C) Accept** — Attempted disk cache (Fix 1). A/B testing showed shell-env resolution time varies widely (272ms-1228ms) depending on system load, not fixable by caching. The cache added complexity without consistent benefit. Reverted.
+
+**2. loadSessionPreferences re-render storm**
+
+- Options: A) Call once instead of per-project B) Add a batch endpoint C) Debounce store updates
+- Decision: **A) Call once** — The function already ignores `_projectPath` and loads global data. Remove the loop, call once. Zero new endpoints, maximum impact.
+
+**3. listSessions N+1 stats**
+
+- Options: A) Cache birthtimes to disk B) Skip birthtimes, use SDK's lastModified C) Use async stat
+- Decision: **C was attempted, reverted** — Birthtime disk cache + async stat added overhead (JSON parse of 827 entries, `Promise.allSettled` machinery) that made warm-start performance _worse_ (673ms vs 499ms). The sync `statSync` loop is already fast enough on macOS. Reverted.
+
+**4. Code-server 1s delay**
+
+- Decision: **Leave as-is** — Not on critical path (background). FIXME comment indicates known issue.
+
+**5. Terminal double-spawn**
+
+- Decision: **Accept** — Dev-only (React StrictMode). Component already handles cleanup correctly.
+
+## Fix Implemented
+
+### Deduplicate loadSessionPreferences
+
+`loadSessionPreferences(_projectPath)` ignored its parameter — it calls 3 global endpoints (`getArchivedSessions`, `getPinnedSessions`, `getClosedAccordions`). The `MultiProjectSessionList` effect looped through all 6 projects calling it N times. Fixed: call once, removed unused param.
+
+- Files: `src/renderer/src/features/agent/components/session-list.tsx`, `src/renderer/src/features/project/store.ts`
+
+## Measured Results (A/B test, same machine, same session data)
+
+| Metric                              | Before | After | Change |
+| ----------------------------------- | ------ | ----- | ------ |
+| `loadSessionPreferences` calls      | 42     | 12    | -71%   |
+| `session preferences loaded` events | 36     | 6     | -83%   |
+| `pinned-session-list` renders       | 88     | 28    | -68%   |
+
+End-to-end startup time was similar (~2.5s) because `listSessions` dominates, but the renderer does significantly less wasted work during initialization.

--- a/packages/desktop/src/main/app.ts
+++ b/packages/desktop/src/main/app.ts
@@ -1,6 +1,7 @@
 import type { AnyRouter } from "@orpc/server";
 
 import { os } from "@orpc/server";
+import debug from "debug";
 
 import type { MainPlugin } from "./core/plugin/types";
 import type { IBrowserWindowManager, IMainApp } from "./core/types";
@@ -11,6 +12,8 @@ import { PluginManager } from "./core/plugin/plugin-manager";
 import { shellEnvService } from "./core/shell-service";
 import { StorageService } from "./core/storage-service";
 import { buildRouter } from "./router";
+
+const log = debug("neovate:startup");
 
 export interface MainAppOptions {
   plugins?: MainPlugin[];
@@ -39,11 +42,17 @@ export class MainApp implements IMainApp {
   }
 
   async start(): Promise<void> {
+    const t0 = performance.now();
+    const el = () => `${Math.round(performance.now() - t0)}ms`;
     const ctx = { app: this, orpcServer: os, shell: shellEnvService };
     await this.pluginManager.configContributions(ctx);
+    log("main configContributions done %s", el());
     await this.pluginManager.activate(ctx);
+    log("main activate done %s", el());
     this.#router = buildRouter(this.pluginManager.contributions.routers);
+    log("main router built %s", el());
     this.windowManager.createMainWindow();
+    log("main window created %s", el());
   }
 
   async stop(): Promise<void> {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -23,6 +23,10 @@ import reviewPlugin from "./plugins/review";
 import terminalPlugin from "./plugins/terminal";
 
 const log = debug("neovate:orpc");
+const startupLog = debug("neovate:startup");
+const t0 = performance.now();
+const elapsed = () => `${Math.round(performance.now() - t0)}ms`;
+startupLog("main process module loaded %s", elapsed());
 
 if (is.dev && process.env.ELECTRON_CDP_PORT) {
   app.commandLine.appendSwitch("remote-debugging-port", process.env.ELECTRON_CDP_PORT);
@@ -79,10 +83,13 @@ setTimeout(() => projectStore.clearCrashCounter(), 30_000);
 
 let menu: ApplicationMenu | null = null;
 
+startupLog("app.whenReady waiting %s", elapsed());
 app.whenReady().then(async () => {
+  startupLog("app.whenReady fired %s", elapsed());
   electronApp.setAppUserModelId("com.neovateai.desktop");
 
   await mainApp.start();
+  startupLog("mainApp.start done %s", elapsed());
   void updaterService.init();
 
   // Setup application menu (for menu items, shortcuts handled in renderer)

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -1,3 +1,4 @@
+import debug from "debug";
 import { ThemeProvider, useTheme } from "next-themes";
 import { StrictMode, Suspense, createContext, useContext, useEffect, useRef, lazy } from "react";
 import ReactDOM from "react-dom/client";
@@ -5,6 +6,8 @@ import ReactDOM from "react-dom/client";
 import type { ProjectTabState } from "../features/content-panel";
 import type { RendererPlugin, PluginContext } from "./plugin";
 import type { IRendererApp, IWorkbench } from "./types";
+
+const startupLog = debug("neovate:startup");
 
 import { setPanelWidth, shrinkPanelsToFit } from "../components/app-layout/layout-coordinator";
 import { layoutStore } from "../components/app-layout/store";
@@ -204,27 +207,37 @@ export class RendererApp implements IRendererApp {
   }
 
   async start(): Promise<void> {
+    const t0 = performance.now();
+    const el = () => `${Math.round(performance.now() - t0)}ms`;
     const ctx: PluginContext = { app: this, orpcClient: client };
 
     // Infrastructure — all windows
     await useConfigStore.getState().load();
+    startupLog("renderer config loaded %s", el());
     await this.i18nManager.init({ store: useConfigStore as any });
     const i18nConfigs = await this.pluginManager.configI18n();
     this.i18nManager.setupLazyNamespaces(i18nConfigs);
+    startupLog("renderer i18n done %s", el());
     await this.project.refresh();
+    startupLog("renderer project.refresh done %s", el());
 
     // Collect window contributions — all windows (needed for lookup)
     await this.pluginManager.configWindowContributions();
+    startupLog("renderer windowContributions done %s", el());
 
     if (this.#windowType === "main") {
       // Main window — full plugin UI
       await this.pluginManager.configContributions();
+      startupLog("renderer pluginContributions done %s", el());
       this.initWorkbench();
       await this.workbench.contentPanel.hydrate();
+      startupLog("renderer contentPanel hydrated %s", el());
     }
 
     await this.pluginManager.activate(ctx);
+    startupLog("renderer plugins activated %s", el());
     this.render(ctx);
+    startupLog("renderer React.render called %s", el());
   }
 
   async stop(): Promise<void> {

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -43,10 +43,8 @@ function MultiProjectSessionList() {
   log("multi-project: organize=%s projects=%d", sidebarOrganize, projects.length);
 
   useEffect(() => {
-    log("multi-project: loading session preferences for %d projects", projects.length);
-    for (const project of projects) {
-      loadSessionPreferences(project.path);
-    }
+    log("multi-project: loading session preferences");
+    loadSessionPreferences();
   }, [projects, loadSessionPreferences]);
 
   return (
@@ -83,7 +81,7 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
 
   useEffect(() => {
     if (projectPath) {
-      loadSessionPreferences(projectPath);
+      loadSessionPreferences();
     }
   }, [projectPath, loadSessionPreferences]);
 

--- a/packages/desktop/src/renderer/src/features/project/store.ts
+++ b/packages/desktop/src/renderer/src/features/project/store.ts
@@ -29,7 +29,7 @@ type ProjectState = {
   togglePinSession: (projectPath: string, sessionId: string) => void;
   setClosedProjectAccordions: (ids: string[]) => void;
   reorderProjects: (projectIds: string[]) => void;
-  loadSessionPreferences: (projectPath: string) => Promise<void>;
+  loadSessionPreferences: () => Promise<void>;
 };
 
 export const useProjectStore = create<ProjectState>()(
@@ -123,7 +123,7 @@ export const useProjectStore = create<ProjectState>()(
       set({ projects: reordered });
       client.project.reorderProjects({ projectIds }).catch(() => {});
     },
-    loadSessionPreferences: async (_projectPath) => {
+    loadSessionPreferences: async () => {
       log("loading session preferences");
       const [archived, pinned, closedAccordions] = await Promise.all([
         client.project.getArchivedSessions(),


### PR DESCRIPTION
## Summary

- **Deduplicate `loadSessionPreferences`** — The function ignores its `_projectPath` param (loads global data via 3 IPC calls). In multi-project mode, the effect looped through all 6 projects calling it N times. Now called once per effect trigger. Removed the unused parameter.
- **Add `neovate:startup` profiling logs** — Timing logs in main process (`index.ts`, `app.ts`) and renderer (`RendererApp.start()`) covering every phase from module load to React.render. Use `DEBUG=neovate:startup`.
- **Design doc** — `docs/designs/2026-03-18-startup-performance.md` with full profiling analysis, decision log, and A/B test results.

### Measured results (A/B test, same machine, same data)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `loadSessionPreferences` calls | 42 | 12 | -71% |
| `session preferences loaded` events | 36 | 6 | -83% |
| `pinned-session-list` renders | 88 | 28 | -68% |

Closes #233

## Test plan

- [ ] Launch app in multi-project mode — sidebar should load without visible lag
- [ ] Launch app in single-project mode — no regression
- [ ] Verify `DEBUG=neovate:startup` shows per-phase timing in both main and renderer logs
- [ ] Verify session preferences (pinned/archived) still work correctly after startup