### PR TITLE
fix: detach shell env child process to restore Ctrl-C in dev mode

### DIFF
--- a/docs/designs/2026-03-18-fix-ctrl-c-dev-mode.md
+++ b/docs/designs/2026-03-18-fix-ctrl-c-dev-mode.md
@@ -1,0 +1,28 @@
+# Fix: Dev mode (bun dev) cannot exit with Ctrl-C
+
+**Issue:** [#230](https://github.com/neovateai/neovate-desktop/issues/230)
+**Date:** 2026-03-18
+
+## Decision Log
+
+**1. How to prevent the child shell from interfering with Ctrl-C?**
+
+- Options: A) Remove `-i` flag · B) Add `detached: true` to spawn · C) Both
+- Decision: **B) `detached: true`** — Puts the child in its own process group so SIGINT never reaches it. Keeps `-i` for complete env resolution (`.zshrc`/`.bashrc`).
+
+**2. Should we `unref()` the child?**
+
+- Options: A) Yes · B) No
+- Decision: **A) Yes** — Electron keeps the event loop alive independently, so `unref()` won't cause premature exit but ensures the child doesn't block graceful shutdown.
+
+## Root Cause
+
+`shellEnvService.getEnv()` (called eagerly in `index.ts:32`) spawns a child shell with `-i -l -c` flags. The `-i` (interactive) flag causes the shell to set up job control in the parent's process group, interfering with terminal SIGINT delivery. When the user presses Ctrl-C, the signal doesn't reach the electron-vite dev server properly.
+
+## Fix
+
+Add `detached: true` to the `spawn()` call in `resolveShellEnv()` to put the child in its own process group, and call `child.unref()` so the child doesn't prevent process exit.
+
+**File:** `packages/desktop/src/main/core/shell-service.ts`
+
+Two-line change in the `spawn` call and after it.

--- a/packages/desktop/src/main/core/shell-service.ts
+++ b/packages/desktop/src/main/core/shell-service.ts
@@ -82,7 +82,9 @@ function resolveShellEnv(): Promise<Record<string, string>> {
     const child = spawn(systemShell, [...shellArgs, command], {
       stdio: ["ignore", "pipe", "pipe"],
       env,
+      detached: true,
     });
+    child.unref();
 
     const timeout = setTimeout(() => {
       child.kill();


### PR DESCRIPTION
## Summary

- Spawns the shell environment resolver child process with `detached: true` so it gets its own process group, preventing its `-i` (interactive) flag from interfering with SIGINT delivery
- Calls `child.unref()` so the child doesn't block graceful shutdown on Ctrl-C

**Root cause:** `ShellEnvironmentService` spawns an interactive login shell (`-i -l -c`) in the same process group as the parent. The `-i` flag sets up job control that prevents the terminal's SIGINT from reaching the electron-vite dev server.

Closes #230

## Test plan

- [ ] Run `bun dev`, then press Ctrl-C — process should exit cleanly
- [ ] Verify shell environment resolution still works (check that tools like `git`, `node` are found in sessions)