### PR TITLE
feat(chat): show loading state in input toolbar during session init

### DIFF
--- a/docs/designs/2026-03-18-input-toolbar-loading-state.md
+++ b/docs/designs/2026-03-18-input-toolbar-loading-state.md
@@ -1,0 +1,33 @@
+# Input Toolbar Loading State for Session Init
+
+## Background
+
+When the app starts or the user switches projects, a new Claude Code session is created via an async RPC call (`claudeCodeChatManager.createSession`). During this initialization period, `activeSessionId` is `null` — the session hasn't been registered in the store yet.
+
+## Problem
+
+The input toolbar gives no visual feedback during this async gap. The editor is editable (since `disabled` is only true when there's no project path), so the user can type a message and click send — but `handleSend` silently no-ops because `activeSessionId` is null. The model selector and permission mode selector also disappear (they return null when there's no session), leaving a bare toolbar with no explanation.
+
+## Decision Log
+
+**1. Where to compute session-initializing state?**
+
+- Options: A) Derive in AgentChat from existing state · B) Add explicit store field
+- Decision: **A) Derive** — `!!activeProjectPath && !activeSessionId` precisely captures "session is being created." No store changes needed.
+
+**2. How to pass loading to the toolbar?**
+
+- Options: A) New `loading` prop · B) Reuse `disabled`
+- Decision: **A) New `loading` prop** — Semantically different from disabled. User can type ahead while session spins up.
+
+**3. What to show when loading?**
+
+- Options: A) Spinner replacing send button · B) Pulsing text label · C) Both
+- Decision: **A) Spinner replacing send button** — Clean, minimal. Existing `Spinner` component used. Model/permission selectors already hide when no session, so toolbar naturally looks sparse during init.
+
+## Changes
+
+- `agent-chat.tsx`: Derive `sessionInitializing`, pass as `sessionInitializing` to `MessageInput`
+- `message-input.tsx`: Accept `sessionInitializing` prop, forward to `InputToolbar`
+- `input-toolbar.tsx`: Accept `sessionInitializing` prop, show `Spinner` in send button area and pulsing "Starting session..." label
+- `en-US.json` / `zh-CN.json`: Add `chat.sessionInitializing` translation key

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -178,6 +178,8 @@ export function AgentChat() {
     });
   };
 
+  const sessionInitializing = !!activeProjectPath && !activeSessionId;
+
   // State 1: No session yet (or new empty session) — show welcome panel with input
   if (!activeSession || activeSession.isNew) {
     return (
@@ -188,6 +190,7 @@ export function AgentChat() {
           onCancel={() => {}}
           streaming={false}
           disabled={!activeProjectPath}
+          sessionInitializing={sessionInitializing}
           cwd={cwd}
         />
         {cwd && (

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -33,6 +33,7 @@ import {
   MenuRadioGroup,
   MenuRadioItem,
 } from "../../../components/ui/menu";
+import { Spinner } from "../../../components/ui/spinner";
 import { client } from "../../../orpc";
 import { useConfigStore } from "../../config/store";
 import { useProviderStore } from "../../provider/store";
@@ -46,6 +47,7 @@ const log = debug("neovate:input-toolbar");
 type Props = {
   streaming: boolean;
   disabled?: boolean;
+  sessionInitializing?: boolean;
   onSend: () => void;
   onCancel: () => void;
   onAttach: () => void;
@@ -55,6 +57,7 @@ type Props = {
 export function InputToolbar({
   streaming,
   disabled,
+  sessionInitializing,
   onSend,
   onCancel,
   onAttach,
@@ -77,11 +80,17 @@ export function InputToolbar({
         className="h-7 w-7"
         title={t("chat.attachImage")}
         onClick={onAttach}
+        disabled={sessionInitializing}
       >
         <Paperclip className="h-4 w-4" />
       </Button>
       <ModelSelect activeSessionId={activeSessionId} disabled={disabled || streaming} />
       <PermissionModeSelect activeSessionId={activeSessionId} disabled={disabled || streaming} />
+      {sessionInitializing && (
+        <span className="text-xs text-muted-foreground animate-pulse">
+          {t("chat.sessionInitializing")}
+        </span>
+      )}
       <div className="flex-1" />
       {streaming ? (
         <Button
@@ -93,6 +102,10 @@ export function InputToolbar({
         >
           <Square className="h-3.5 w-3.5" />
         </Button>
+      ) : sessionInitializing ? (
+        <div className="flex h-7 w-7 items-center justify-center">
+          <Spinner className="h-4 w-4 text-muted-foreground" />
+        </div>
       ) : (
         <Button
           type="button"

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -34,6 +34,7 @@ type Props = {
   onCancel: () => void;
   streaming: boolean;
   disabled?: boolean;
+  sessionInitializing?: boolean;
   cwd: string;
   dockAttached?: boolean;
 };
@@ -45,6 +46,7 @@ export function MessageInput({
   onCancel,
   streaming,
   disabled,
+  sessionInitializing,
   cwd,
   dockAttached = false,
 }: Props) {
@@ -344,6 +346,7 @@ export function MessageInput({
           <InputToolbar
             streaming={streaming}
             disabled={disabled}
+            sessionInitializing={sessionInitializing}
             onSend={send}
             onCancel={onCancel}
             onAttach={() => fileInputRef.current?.click()}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -323,5 +323,6 @@
   "chat.setGlobalDefault": "Set as global default",
   "chat.clearSessionOverride": "Clear session override",
   "chat.providerSwitchHint": "Provider switch requires a new session",
-  "chat.messageActions": "Message actions"
+  "chat.messageActions": "Message actions",
+  "chat.sessionInitializing": "Starting session..."
 }

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -325,5 +325,6 @@
   "chat.setGlobalDefault": "设为全局默认",
   "chat.clearSessionOverride": "清除会话覆盖",
   "chat.providerSwitchHint": "切换服务商需要新建会话",
-  "chat.messageActions": "消息操作"
+  "chat.messageActions": "消息操作",
+  "chat.sessionInitializing": "正在启动会话..."
 }


### PR DESCRIPTION
## Summary

- Show a spinner in place of the send button and a pulsing "Starting session..." label in the input toolbar while a Claude Code session is being created
- Derive `sessionInitializing` from existing state (`!!activeProjectPath && !activeSessionId`) — no store changes needed
- Users can still type ahead during init; only sending is blocked until the session is ready

## Test plan

- [ ] Open the app with a project — verify spinner + "Starting session..." appears briefly in the toolbar, then resolves to normal send button + model/permission selectors
- [ ] Switch projects — verify the loading state appears again during the new session creation
- [ ] Type a message during session init — verify the editor is editable but the send button is replaced by a spinner
- [ ] Verify `bun ready` passes (format, typecheck, lint, tests)