### PR TITLE
feat(window): persist maximized/fullscreen state and validate bounds

### DIFF
--- a/docs/designs/2026-03-18-window-state-persistence.md
+++ b/docs/designs/2026-03-18-window-state-persistence.md
@@ -1,0 +1,42 @@
+# Window State Persistence
+
+## Decision Log
+
+**1. What needs to change?**
+
+- Options: A) Everything from scratch · B) Only fill gaps in existing persistence · C) Move layout to electron-store too
+- Decision: **B) Only fill gaps** — Window bounds (x/y/width/height) are already persisted in `window-state.json`. Layout panels (width/collapsed/activeView) are already persisted via localStorage. The only gaps are: maximized/fullscreen state, and off-screen bounds validation.
+
+**2. Where to persist maximized/fullscreen state?**
+
+- Options: A) Alongside bounds in `window-state.json` · B) In `config.json` · C) In `state.json`
+- Decision: **A) `window-state.json`** — It already stores window bounds, window display state belongs here.
+
+**3. Should layout panels move from localStorage to electron-store?**
+
+- Options: A) Move to electron-store via IPC · B) Keep in localStorage
+- Decision: **B) Keep in localStorage** — Already working with validation (`mergePersisted`), more performant (no IPC per resize), localStorage reliable in Electron.
+
+**4. Off-screen validation strategy?**
+
+- Options: A) Check if saved position intersects any display · B) Center on primary display · C) No validation
+- Decision: **A) Intersect check** — Use Electron screen API to verify window would be partially visible. If not, drop position and let Electron center it.
+
+**5. When to save window state?**
+
+- Options: A) On close only · B) On resize/move events · C) Periodically
+- Decision: **A) On close only** — Current behavior, simple and sufficient.
+
+## Changes
+
+### `src/main/core/browser-window-manager.ts`
+
+- Extend `WindowStore` to include `isMaximized` and `isFullScreen`
+- On close: save `isMaximized()`, `isFullScreen()`, and `getNormalBounds()`
+- On create: validate saved bounds are on visible display, restore maximized/fullscreen after show
+- Add `#isVisibleOnAnyDisplay(bounds)` helper
+
+### No other files change
+
+- Layout panel persistence via localStorage already works (Zustand persist + `mergePersisted` validation)
+- No IPC contract changes needed

--- a/packages/desktop/src/main/core/browser-window-manager.ts
+++ b/packages/desktop/src/main/core/browser-window-manager.ts
@@ -10,7 +10,11 @@ import icon from "../../../resources/icon.png?asset";
 import { APP_DATA_DIR } from "./app-paths";
 import log from "./logger";
 
-type WindowStore = { bounds: Electron.Rectangle };
+type WindowStore = {
+  bounds: Electron.Rectangle;
+  isMaximized: boolean;
+  isFullScreen: boolean;
+};
 
 function stripColors(msg: string): string {
   return msg
@@ -35,7 +39,10 @@ export class BrowserWindowManager implements IBrowserWindowManager {
 
   createMainWindow(): BrowserWindow {
     const saved = this.#store.get("bounds");
-    const bounds = saved ?? { width: 1200, height: 800 };
+    const bounds =
+      saved && this.#isVisibleOnAnyDisplay(saved) ? saved : { width: 1200, height: 800 };
+    const wasMaximized = this.#store.get("isMaximized") ?? false;
+    const wasFullScreen = this.#store.get("isFullScreen") ?? false;
 
     const win = new BrowserWindow({
       ...bounds,
@@ -53,7 +60,14 @@ export class BrowserWindowManager implements IBrowserWindowManager {
       },
     });
 
-    win.on("ready-to-show", () => win.show());
+    win.on("ready-to-show", () => {
+      if (wasFullScreen) {
+        win.setFullScreen(true);
+      } else if (wasMaximized) {
+        win.maximize();
+      }
+      win.show();
+    });
 
     win.webContents.setWindowOpenHandler((details) => {
       shell.openExternal(details.url);
@@ -62,8 +76,27 @@ export class BrowserWindowManager implements IBrowserWindowManager {
 
     this.#fixDevToolsFonts(win);
 
-    win.on("close", () => {
+    let saveTimer: ReturnType<typeof setTimeout> | null = null;
+    const saveState = () => {
       this.#store.set("bounds", win.getNormalBounds());
+      this.#store.set("isMaximized", win.isMaximized());
+      this.#store.set("isFullScreen", win.isFullScreen());
+    };
+    const debouncedSave = () => {
+      if (saveTimer) clearTimeout(saveTimer);
+      saveTimer = setTimeout(saveState, 500);
+    };
+
+    win.on("resize", debouncedSave);
+    win.on("move", debouncedSave);
+    win.on("maximize", debouncedSave);
+    win.on("unmaximize", debouncedSave);
+    win.on("enter-full-screen", debouncedSave);
+    win.on("leave-full-screen", debouncedSave);
+
+    win.on("close", () => {
+      if (saveTimer) clearTimeout(saveTimer);
+      saveState();
     });
 
     win.on("closed", () => {
@@ -154,6 +187,18 @@ export class BrowserWindowManager implements IBrowserWindowManager {
     if (currentWidth < capped) {
       mainWindow.setSize(capped, currentHeight);
     }
+  }
+
+  /** Check that saved bounds overlap at least partially with a connected display. */
+  #isVisibleOnAnyDisplay(bounds: Electron.Rectangle): boolean {
+    const displays = screen.getAllDisplays();
+    const minOverlap = 100; // px — enough to grab the titlebar
+    return displays.some((display) => {
+      const { x, y, width, height } = display.workArea;
+      const overlapX = Math.min(bounds.x + bounds.width, x + width) - Math.max(bounds.x, x);
+      const overlapY = Math.min(bounds.y + bounds.height, y + height) - Math.max(bounds.y, y);
+      return overlapX >= minOverlap && overlapY >= 40;
+    });
   }
 
   #fixDevToolsFonts(win: BrowserWindow): void {


### PR DESCRIPTION
## Summary

- Save `isMaximized` and `isFullScreen` alongside window bounds in `window-state.json`
- Restore maximized/fullscreen state when the app relaunches
- Validate saved bounds overlap a connected display before restoring (prevents off-screen windows after monitor disconnect)
- Debounce window state saves on resize/move/maximize/fullscreen events (500ms), flush immediately on close

## Test plan

- [ ] Resize and move window, quit, relaunch — window restores at saved position/size
- [ ] Maximize window, quit, relaunch — window opens maximized
- [ ] Enter fullscreen, quit, relaunch — window opens in fullscreen
- [ ] Save window on external monitor, disconnect monitor, relaunch — window appears centered on remaining display with default size
- [ ] Force-kill the app mid-resize — window state still recovers (debounced save)