### PR TITLE
fix: load get-port via dynamic import

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       outDir: "dist/main",
       // TODO: fix this
       externalizeDeps: {
-        exclude: ["acpx", "electron-store", "get-port"],
+        exclude: ["acpx", "electron-store"],
       },
     },
   },

--- a/packages/desktop/src/main/plugins/editor/utils/index.ts
+++ b/packages/desktop/src/main/plugins/editor/utils/index.ts
@@ -1,5 +1,4 @@
 import debug from "debug";
-import getPort from "get-port";
 
 import { ExtensionBridgeServer } from "./bridge";
 
@@ -77,6 +76,7 @@ export class CodeServerManager {
     // 2. Override settings for minimal UI
     await overrideCodeServerSettings();
     // 3. Find available ports for code-server and extension bridge
+    const { default: getPort } = await import("get-port");
     const [port, bridgePort] = await Promise.all([getPort(), getPort()]);
     log("allocated ports: code-server=%d bridge=%d", port, bridgePort);
     try {


### PR DESCRIPTION
## Summary
- load `get-port` via dynamic import from main-process code
- remove `get-port` from `externalizeDeps.exclude` so it stays external
- keep `get-port` as a runtime dependency instead of bundling it into main

## Verification
- confirmed editor startup reaches allocated port logging and code-server ready locally
- `bun run typecheck` is currently blocked by an unrelated existing error in `src/renderer/src/features/updater/updater-toast.tsx`