### PR TITLE
Adjust desktop titlebar UI alignment

### DIFF
--- a/packages/desktop/src/renderer/src/components/app-layout/app-layout.tsx
+++ b/packages/desktop/src/renderer/src/components/app-layout/app-layout.tsx
@@ -69,7 +69,7 @@ export function AppLayoutRoot({ children }: { children: ReactNode }) {
       className="relative grid h-screen w-screen overflow-hidden pb-2 bg-background"
       style={APP_LAYOUT_GRID}
     >
-      <div className="[-webkit-app-region:drag] absolute inset-x-0 top-0 h-10" />
+      <div className="[-webkit-app-region:drag] absolute inset-x-0 top-0 h-11" />
       {children}
     </div>
   );
@@ -81,7 +81,7 @@ export function AppLayoutTitleBar({ children }: { children: ReactNode }) {
   return (
     <motion.div
       data-slot="titlebar"
-      className="[-webkit-app-region:drag] flex h-11 select-none items-center"
+      className="flex h-11 select-none items-center justify-between gap-2"
       style={{ gridArea: APP_LAYOUT_GRID_AREA.titleBar }}
       animate={{ marginLeft: collapsed ? APP_LAYOUT_COLLAPSED_TITLEBAR_LEFT_MARGIN : 0 }}
       transition={{ type: "spring" as const, stiffness: 360, damping: 34 }}
@@ -129,7 +129,7 @@ export function AppLayoutTrafficLights() {
     <div
       data-slot="traffic-lights"
       className="[-webkit-app-region:no-drag] pointer-events-auto fixed z-[100] flex items-center gap-1"
-      style={{ top: 9, left: 82 }}
+      style={{ top: 9.5, left: 90 }}
     >
       <Button
         variant="ghost"
@@ -230,61 +230,55 @@ export function AppLayoutSecondaryTitleBar() {
   const lazyComponents = useLazyComponents(items);
 
   return (
-    <div
-      data-slot="secondary-titlebar"
-      className="[-webkit-app-region:drag] flex flex-1 items-center"
-    >
-      <div className="flex-1" />
-      <div className="[-webkit-app-region:no-drag] flex shrink-0 items-center gap-1 pr-1.5">
-        {activeProject && <OpenAppButton cwd={activeProject.path} />}
-        <TooltipProvider delay={0}>
-          {items.map((item) => {
-            const Component = lazyComponents.get(item.id)!;
-            return (
-              <Suspense key={item.id}>
-                {item.tooltip ? (
-                  <TooltipTrigger
-                    handle={secondaryTitlebarTooltipHandle}
-                    payload={resolveLocalizedString(item.tooltip, locale)}
-                    render={<span className="inline-flex" />}
-                  >
-                    <Component />
-                  </TooltipTrigger>
-                ) : (
+    <div data-slot="secondary-titlebar" className="flex shrink-0 items-center gap-1 pr-1.5">
+      {activeProject && <OpenAppButton cwd={activeProject.path} />}
+      <TooltipProvider delay={0}>
+        {items.map((item) => {
+          const Component = lazyComponents.get(item.id)!;
+          return (
+            <Suspense key={item.id}>
+              {item.tooltip ? (
+                <TooltipTrigger
+                  handle={secondaryTitlebarTooltipHandle}
+                  payload={resolveLocalizedString(item.tooltip, locale)}
+                  render={<span className="inline-flex" />}
+                >
                   <Component />
-                )}
-              </Suspense>
-            );
-          })}
-          <Tooltip handle={secondaryTitlebarTooltipHandle}>
-            {({ payload }) => <TooltipPopup side="bottom">{payload}</TooltipPopup>}
-          </Tooltip>
-        </TooltipProvider>
-        <Separator orientation="vertical" className="mx-2 my-1 w-[2px] rounded-xl" />
-        <ContentPanelToggle />
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => togglePanel("secondarySidebar")}
-          title={secondaryCollapsed ? t("sidebar.showSidebar") : t("sidebar.hideSidebar")}
-          className={cn("hover:bg-accent", !secondaryCollapsed && "bg-accent")}
-        >
-          <HugeiconsIcon
-            icon={secondaryCollapsed ? PanelRightIcon : ViewSidebarRightIcon}
-            size={16}
-            strokeWidth={1.8}
-          />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="size-7"
-          title={t("sidebar.settings")}
-          onClick={() => setShowSettings(true)}
-        >
-          <HugeiconsIcon icon={Settings03Icon} size={16} strokeWidth={1.8} />
-        </Button>
-      </div>
+                </TooltipTrigger>
+              ) : (
+                <Component />
+              )}
+            </Suspense>
+          );
+        })}
+        <Tooltip handle={secondaryTitlebarTooltipHandle}>
+          {({ payload }) => <TooltipPopup side="bottom">{payload}</TooltipPopup>}
+        </Tooltip>
+      </TooltipProvider>
+      <Separator orientation="vertical" className="mx-2 my-1 w-[2px] rounded-xl" />
+      <ContentPanelToggle />
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => togglePanel("secondarySidebar")}
+        title={secondaryCollapsed ? t("sidebar.showSidebar") : t("sidebar.hideSidebar")}
+        className={cn("hover:bg-accent", !secondaryCollapsed && "bg-accent")}
+      >
+        <HugeiconsIcon
+          icon={secondaryCollapsed ? PanelRightIcon : ViewSidebarRightIcon}
+          size={16}
+          strokeWidth={1.8}
+        />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="size-7"
+        title={t("sidebar.settings")}
+        onClick={() => setShowSettings(true)}
+      >
+        <HugeiconsIcon icon={Settings03Icon} size={16} strokeWidth={1.8} />
+      </Button>
     </div>
   );
 }

--- a/packages/desktop/src/renderer/src/dev/playground.tsx
+++ b/packages/desktop/src/renderer/src/dev/playground.tsx
@@ -21,9 +21,7 @@ export default function Playground() {
     <div className="flex h-screen flex-col">
       {/* Draggable title bar */}
       <div className="[-webkit-app-region:drag] relative flex h-11 shrink-0 select-none items-center justify-center border-b">
-        <span className="[-webkit-app-region:no-drag] text-xs font-medium text-muted-foreground">
-          Playground
-        </span>
+        <span className="text-xs font-medium text-muted-foreground">Playground</span>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## Summary
- align the custom traffic-lights control with the native macOS window controls
- keep the desktop titlebar on an h-11 layout with the updated titlebar content alignment
- clean up the playground titlebar drag region to match the current titlebar behavior

## Test Plan
- bun run --filter=neovate-desktop test:run
- bun run --filter=neovate-desktop build