### PR TITLE
fix: improve skill detection, toggle, and YAML parsing

### DIFF
--- a/docs/designs/2026-03-19-skill-detection-fix.md
+++ b/docs/designs/2026-03-19-skill-detection-fix.md
@@ -1,0 +1,179 @@
+# Fix: 3-Tier Skill Detection for Git/npm Sources
+
+**Date:** 2026-03-19
+**Status:** Approved
+
+## Problem
+
+`scanSkillDirs()` in `skill-utils.ts` only checks top-level subdirectories for `<dir>/SKILL.md`. It misses two common repo layouts:
+
+1. **Root-level** `SKILL.md` (single-skill repos like `github.com/user/my-skill`)
+2. **`skills/` subdirectory** pattern `skills/<name>/SKILL.md` (organized multi-skill repos)
+
+Additionally, both `GitInstaller` and `NpmInstaller` have `installFromPreview()` / `install()` methods that assume skill directories are always at `tmpDir/<name>`, which breaks for root and nested patterns.
+
+### Reference Implementation
+
+Takumi's `SkillManager.scanForSkills()` (`src/skill.ts:514-549`) uses a 3-tier strategy:
+
+1. Root `SKILL.md` -> return immediately (single-skill repo)
+2. `skills/<name>/SKILL.md` -> return all matches
+3. `<name>/SKILL.md` at top level -> fallback
+
+Neovate only implements tier 3.
+
+## Changes
+
+### 1. `src/main/features/skills/skill-utils.ts` — 3-tier scan + shared install helpers
+
+**3-tier `scanSkillDirs()`:**
+
+Rewrite the no-`singleName` path to match takumi's scan order:
+
+```
+Tier 1: baseDir/SKILL.md
+  -> [{ name: <from frontmatter or dirname>, description, skillPath: "." }]
+
+Tier 2: baseDir/skills/<name>/SKILL.md
+  -> [{ name, description, skillPath: "skills/<name>" }, ...]
+
+Tier 3: baseDir/<name>/SKILL.md  (existing behavior)
+  -> [{ name, description, skillPath: "<name>" }, ...]
+```
+
+`skillPath` becomes the **relative path from baseDir to the skill directory**, not just the directory name. This is the key change — it encodes where the skill lives so the installer can find it.
+
+**Tier priority:** Each tier returns early. If a root `SKILL.md` exists (tier 1), the entire source is treated as a single skill — subdirectories with their own `SKILL.md` are ignored. This matches takumi's behavior and prevents ambiguity: a repo is either one skill (root) or a collection of skills (tier 2/3), never both.
+
+Extract the existing subdirectory scanning into a helper `scanSubdirectories(dir, prefix)` to reuse between tier 2 and tier 3.
+
+For tier 1 (root-level), extract the skill name from frontmatter's `name` field if present, otherwise fall back to `path.basename(baseDir)`.
+
+**Shared install path helpers** (used by both GitInstaller and NpmInstaller):
+
+```ts
+/** Resolve the absolute source path for a skill within a base directory. */
+export function resolveSkillSource(baseDir: string, skillPath: string): string {
+  return skillPath === "." ? baseDir : path.join(baseDir, skillPath);
+}
+
+/** Derive the destination folder name for installing a skill. */
+export function deriveInstallName(skillPath: string, sourceRef: string): string {
+  return skillPath === "." ? extractFolderName(sourceRef) : path.basename(skillPath);
+}
+
+/** Extract a folder name from a source URL (ported from takumi, extended for npm). */
+export function extractFolderName(sourceRef: string): string {
+  // Git sources:
+  //   "https://github.com/user/my-skills" -> "my-skills"
+  //   "https://github.com/user/repo/tree/main/skills/foo" -> "foo"
+  //   "user/repo" -> "repo"
+  //   "git:user/repo" -> "repo"
+  //   "gitlab:user/repo" -> "repo"
+  // npm sources:
+  //   "npm:@scope/package" -> "package"
+  //   "npm:some-skill" -> "some-skill"
+  //   "npm:@scope/package@1.2.3" -> "package"
+  //   "@scope/package" -> "package"
+}
+```
+
+This keeps installers thin and avoids duplicating path resolution logic.
+
+### 2. `src/main/features/skills/installers/types.ts` — Update interface
+
+Rename `skillNames` to `skillPaths` and change return type from `void` to `string[]` (installed directory names relative to `targetDir`). This lets the service write install metadata without replicating path derivation logic:
+
+```ts
+installFromPreview(previewId: string, skillPaths: string[], targetDir: string): Promise<string[]>;
+```
+
+### 3. `src/main/features/skills/installers/git.ts` — Fix install paths
+
+**Store sourceRef with preview:**
+
+Change `previewDirs` from `Map<string, string>` to `Map<string, { tmpDir: string; sourceRef: string }>` so we can derive folder names for root-level skill installs.
+
+**Update `installFromPreview()`** using the shared helpers:
+
+```ts
+const installed: string[] = [];
+for (const sp of skillPaths) {
+  const destName = deriveInstallName(sp, preview.sourceRef);
+  const src = resolveSkillSource(tmpDir, sp);
+  const dest = path.join(targetDir, destName);
+  await cp(src, dest, { recursive: true, filter: (s) => path.basename(s) !== ".git" });
+  installed.push(destName);
+}
+return installed;
+```
+
+The `.git` filter is git-only — npm pack doesn't produce `.git` directories.
+
+**Update `install()`** for the recommended-skill flow:
+
+Handle `skillName === "."` by using `deriveInstallName(skillName, sourceRef)` for the destination folder name instead of raw `skillName`. Without this, `path.join(targetDir, ".")` resolves to `targetDir` itself — silently writing into the parent directory.
+
+### 4. `src/main/features/skills/installers/npm.ts` — Same install path fixes
+
+NpmInstaller calls `scanSkillDirs(extractedDir)` — so the 3-tier scan fix applies automatically.
+
+But `installFromPreview()` and `install()` have the same broken path assumption as GitInstaller:
+
+```js
+const src = path.join(extractedDir, name); // assumes <dir>/<name>
+```
+
+Apply the same fix using the shared `resolveSkillSource()` / `deriveInstallName()` helpers.
+
+Store `sourceRef` alongside `tmpDir` in `previewDirs` map (same pattern as GitInstaller).
+
+No `.git` filter needed — npm pack doesn't produce `.git` directories.
+
+### 5. `src/renderer/src/features/settings/components/panels/skill-add-modal.tsx` — Use `skillPath` for selection
+
+Currently `selected` is a `Set<string>` of skill names, and `selectedSkills` sends names to the backend.
+
+Change to use `skill.skillPath`:
+
+- `selected: new Set(result.skills.map((s) => s.skillPath))`
+- `toggleSkill` toggles by `skillPath`
+- `selectedSkills: Array.from(selected)` now sends `skillPath` values
+- Continue displaying `skill.name` in the UI (no visual change)
+
+No contract change needed — `selectedSkills: z.array(z.string())` stays the same, just carries `skillPath` values instead of names.
+
+### 6. `src/main/features/skills/skills-service.ts` — Write install metadata for preview installs
+
+Currently `installFromPreview()` doesn't call `writeInstallMeta()` (only `install()` does). This means preview-installed skills lack `.neovate-install.json`, causing:
+
+- No version tracking
+- No `installedFrom` field
+- Update checks skip them
+
+Fix: store a `Map<previewId, sourceRef>` in the service from the `preview()` call. In `installFromPreview()`, use the `string[]` returned by the installer (installed directory names) to write metadata without replicating path logic:
+
+```ts
+const sourceRef = this.previewSources.get(previewId);
+const installedNames = await installer.installFromPreview(previewId, selectedSkills, targetDir);
+for (const name of installedNames) {
+  await this.writeInstallMeta(path.join(targetDir, name), sourceRef);
+}
+```
+
+## Files Changed
+
+| File                                              | Change                                                                                                                                 |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/main/features/skills/skill-utils.ts`         | 3-tier `scanSkillDirs()`, `scanSubdirectories()` helper, shared `resolveSkillSource()` / `deriveInstallName()` / `extractFolderName()` |
+| `src/main/features/skills/installers/types.ts`    | Rename `skillNames` -> `skillPaths`, return `string[]` from `installFromPreview`                                                       |
+| `src/main/features/skills/installers/git.ts`      | Store sourceRef, use shared helpers, `.git` filter for root copies                                                                     |
+| `src/main/features/skills/installers/npm.ts`      | Store sourceRef, use shared helpers (no `.git` filter)                                                                                 |
+| `src/main/features/skills/installers/prebuilt.ts` | Rename parameter to match interface (no logic change)                                                                                  |
+| `src/renderer/src/.../skill-add-modal.tsx`        | Use `skillPath` for selection identity                                                                                                 |
+| `src/main/features/skills/skills-service.ts`      | Store preview sourceRef, write install meta for preview installs                                                                       |
+
+## Not Changed
+
+- **`src/shared/features/skills/types.ts`** — `PreviewSkill.skillPath` already exists, just used differently
+- **`src/shared/features/skills/contract.ts`** — `selectedSkills: z.array(z.string())` unchanged

--- a/packages/desktop/src/main/features/skills/installers/git.ts
+++ b/packages/desktop/src/main/features/skills/installers/git.ts
@@ -10,13 +10,13 @@ import type { PreviewSkill } from "../../../../shared/features/skills/types";
 import type { SkillInstaller } from "./types";
 
 import { shellEnvService } from "../../../core/shell-service";
-import { scanSkillDirs } from "../skill-utils";
+import { deriveInstallName, resolveSkillSource, scanSkillDirs } from "../skill-utils";
 
 const execFileAsync = promisify(execFile);
 const log = debug("neovate:skills:git");
 
 export class GitInstaller implements SkillInstaller {
-  private previewDirs = new Map<string, string>();
+  private previewDirs = new Map<string, { tmpDir: string; sourceRef: string }>();
 
   detect(sourceRef: string): boolean {
     if (sourceRef.startsWith("prebuilt:") || sourceRef.startsWith("npm:")) return false;
@@ -39,7 +39,7 @@ export class GitInstaller implements SkillInstaller {
       env,
     });
 
-    this.previewDirs.set(previewId, tmpDir);
+    this.previewDirs.set(previewId, { tmpDir, sourceRef });
     const skills = await scanSkillDirs(tmpDir);
     return { previewId, skills };
   }
@@ -48,17 +48,19 @@ export class GitInstaller implements SkillInstaller {
     log("install", { sourceRef, skillName, targetDir });
     const env = await shellEnvService.getEnv();
     const url = this.normalizeUrl(sourceRef);
-    const previewId = randomUUID();
-    const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${previewId}`);
+    const tmpId = randomUUID();
+    const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${tmpId}`);
 
     try {
       await execFileAsync("git", ["clone", "--depth", "1", url, tmpDir], {
         timeout: 60_000,
         env,
       });
-      const src = path.join(tmpDir, skillName);
-      const dest = path.join(targetDir, skillName);
-      await cp(src, dest, { recursive: true });
+      const src = resolveSkillSource(tmpDir, skillName);
+      const destName = deriveInstallName(skillName, sourceRef);
+      const dest = path.join(targetDir, destName);
+      const filter = (s: string) => path.basename(s) !== ".git";
+      await cp(src, dest, { recursive: true, filter });
     } finally {
       await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -66,26 +68,31 @@ export class GitInstaller implements SkillInstaller {
 
   async installFromPreview(
     previewId: string,
-    skillNames: string[],
+    skillPaths: string[],
     targetDir: string,
-  ): Promise<void> {
-    log("installFromPreview", { previewId, skillNames });
-    const tmpDir = this.previewDirs.get(previewId);
-    if (!tmpDir) throw new Error("Preview not found or expired");
+  ): Promise<string[]> {
+    log("installFromPreview", { previewId, skillPaths });
+    const preview = this.previewDirs.get(previewId);
+    if (!preview) throw new Error("Preview not found or expired");
 
-    for (const name of skillNames) {
-      const src = path.join(tmpDir, name);
-      const dest = path.join(targetDir, name);
-      await cp(src, dest, { recursive: true });
+    const installed: string[] = [];
+    const filter = (s: string) => path.basename(s) !== ".git";
+    for (const sp of skillPaths) {
+      const destName = deriveInstallName(sp, preview.sourceRef);
+      const src = resolveSkillSource(preview.tmpDir, sp);
+      const dest = path.join(targetDir, destName);
+      await cp(src, dest, { recursive: true, filter });
+      installed.push(destName);
     }
 
     await this.cleanup(previewId);
+    return installed;
   }
 
   async cleanup(previewId: string): Promise<void> {
-    const tmpDir = this.previewDirs.get(previewId);
-    if (tmpDir) {
-      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    const preview = this.previewDirs.get(previewId);
+    if (preview) {
+      await rm(preview.tmpDir, { recursive: true, force: true }).catch(() => {});
       this.previewDirs.delete(previewId);
     }
   }
@@ -108,8 +115,8 @@ export class GitInstaller implements SkillInstaller {
 
   /** Clean up any stale preview directories */
   cleanupStale(): void {
-    for (const [id, dir] of this.previewDirs) {
-      rm(dir, { recursive: true, force: true })
+    for (const [id, { tmpDir }] of this.previewDirs) {
+      rm(tmpDir, { recursive: true, force: true })
         .then(() => this.previewDirs.delete(id))
         .catch(() => {});
     }

--- a/packages/desktop/src/main/features/skills/installers/npm.ts
+++ b/packages/desktop/src/main/features/skills/installers/npm.ts
@@ -10,13 +10,13 @@ import type { PreviewSkill } from "../../../../shared/features/skills/types";
 import type { SkillInstaller } from "./types";
 
 import { shellEnvService } from "../../../core/shell-service";
-import { scanSkillDirs } from "../skill-utils";
+import { deriveInstallName, resolveSkillSource, scanSkillDirs } from "../skill-utils";
 
 const execFileAsync = promisify(execFile);
 const log = debug("neovate:skills:npm");
 
 export class NpmInstaller implements SkillInstaller {
-  private previewDirs = new Map<string, string>();
+  private previewDirs = new Map<string, { tmpDir: string; sourceRef: string }>();
 
   detect(sourceRef: string): boolean {
     if (sourceRef.startsWith("npm:")) return true;
@@ -33,7 +33,7 @@ export class NpmInstaller implements SkillInstaller {
 
     await this.fetchAndExtract(pkg, tmpDir, registry);
 
-    this.previewDirs.set(previewId, tmpDir);
+    this.previewDirs.set(previewId, { tmpDir, sourceRef });
     // npm pack extracts to a "package" subdirectory
     const extractedDir = path.join(tmpDir, "package");
     const skills = await scanSkillDirs(extractedDir);
@@ -43,15 +43,16 @@ export class NpmInstaller implements SkillInstaller {
   async install(sourceRef: string, skillName: string, targetDir: string): Promise<void> {
     const { pkg, registry } = this.parseSourceRef(sourceRef);
     log("install", { pkg, skillName, targetDir, registry: registry ?? "default" });
-    const previewId = randomUUID();
-    const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${previewId}`);
+    const tmpId = randomUUID();
+    const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${tmpId}`);
     await mkdir(tmpDir, { recursive: true });
 
     try {
       await this.fetchAndExtract(pkg, tmpDir, registry);
       const extractedDir = path.join(tmpDir, "package");
-      const src = path.join(extractedDir, skillName);
-      const dest = path.join(targetDir, skillName);
+      const src = resolveSkillSource(extractedDir, skillName);
+      const destName = deriveInstallName(skillName, sourceRef);
+      const dest = path.join(targetDir, destName);
       await cp(src, dest, { recursive: true });
     } finally {
       await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
@@ -60,27 +61,31 @@ export class NpmInstaller implements SkillInstaller {
 
   async installFromPreview(
     previewId: string,
-    skillNames: string[],
+    skillPaths: string[],
     targetDir: string,
-  ): Promise<void> {
-    log("installFromPreview", { previewId, skillNames });
-    const tmpDir = this.previewDirs.get(previewId);
-    if (!tmpDir) throw new Error("Preview not found or expired");
+  ): Promise<string[]> {
+    log("installFromPreview", { previewId, skillPaths });
+    const preview = this.previewDirs.get(previewId);
+    if (!preview) throw new Error("Preview not found or expired");
 
-    const extractedDir = path.join(tmpDir, "package");
-    for (const name of skillNames) {
-      const src = path.join(extractedDir, name);
-      const dest = path.join(targetDir, name);
+    const extractedDir = path.join(preview.tmpDir, "package");
+    const installed: string[] = [];
+    for (const sp of skillPaths) {
+      const destName = deriveInstallName(sp, preview.sourceRef);
+      const src = resolveSkillSource(extractedDir, sp);
+      const dest = path.join(targetDir, destName);
       await cp(src, dest, { recursive: true });
+      installed.push(destName);
     }
 
     await this.cleanup(previewId);
+    return installed;
   }
 
   async cleanup(previewId: string): Promise<void> {
-    const tmpDir = this.previewDirs.get(previewId);
-    if (tmpDir) {
-      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    const preview = this.previewDirs.get(previewId);
+    if (preview) {
+      await rm(preview.tmpDir, { recursive: true, force: true }).catch(() => {});
       this.previewDirs.delete(previewId);
     }
   }

--- a/packages/desktop/src/main/features/skills/installers/prebuilt.ts
+++ b/packages/desktop/src/main/features/skills/installers/prebuilt.ts
@@ -40,15 +40,18 @@ export class PrebuiltInstaller implements SkillInstaller {
 
   async installFromPreview(
     _previewId: string,
-    skillNames: string[],
+    skillPaths: string[],
     targetDir: string,
-  ): Promise<void> {
-    log("installFromPreview", { skillNames });
-    for (const name of skillNames) {
+  ): Promise<string[]> {
+    log("installFromPreview", { skillPaths });
+    const installed: string[] = [];
+    for (const name of skillPaths) {
       const src = path.join(this.resourcesDir, name);
       const dest = path.join(targetDir, name);
       await cp(src, dest, { recursive: true });
+      installed.push(name);
     }
+    return installed;
   }
 
   async cleanup(_previewId: string): Promise<void> {

--- a/packages/desktop/src/main/features/skills/installers/types.ts
+++ b/packages/desktop/src/main/features/skills/installers/types.ts
@@ -4,7 +4,8 @@ export interface SkillInstaller {
   detect(sourceRef: string): boolean;
   scan(sourceRef: string): Promise<{ previewId: string; skills: PreviewSkill[] }>;
   install(sourceRef: string, skillName: string, targetDir: string): Promise<void>;
-  installFromPreview(previewId: string, skillNames: string[], targetDir: string): Promise<void>;
+  /** Install skills from a preview. Returns installed directory names (relative to targetDir). */
+  installFromPreview(previewId: string, skillPaths: string[], targetDir: string): Promise<string[]>;
   cleanup(previewId: string): Promise<void>;
   getLatestVersion?(sourceRef: string): Promise<string | undefined>;
 }

--- a/packages/desktop/src/main/features/skills/skill-utils.ts
+++ b/packages/desktop/src/main/features/skills/skill-utils.ts
@@ -38,14 +38,41 @@ export function parseFrontmatter(content: string): {
   const body = content.slice(match[0].length);
   const fm: Record<string, unknown> = {};
 
-  for (const line of yamlStr.split("\n")) {
-    const kv = line.match(/^(\S[\w-]*)\s*:\s*(.*)$/);
+  const lines = yamlStr.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const kv = lines[i]!.match(/^(\S[\w-]*)\s*:\s*(.*)$/);
     if (!kv) continue;
     const [, key, rawValue] = kv;
     if (!key) continue;
     const value = rawValue?.trim() ?? "";
 
-    if (value === "true") fm[key] = true;
+    // YAML block scalar: | (literal) or > (folded)
+    if (/^[|>][+-]?$/.test(value)) {
+      const isFolded = value.startsWith(">");
+      const blockLines: string[] = [];
+      while (i + 1 < lines.length && /^[ \t]/.test(lines[i + 1]!)) {
+        i++;
+        blockLines.push(lines[i]!.replace(/^[ \t]{2}/, ""));
+      }
+      if (isFolded) {
+        // Folded: join non-empty lines with space, preserve empty lines as newlines
+        const paragraphs = blockLines.join("\n").split(/\n{2,}/);
+        fm[key] = paragraphs
+          .map((p) => p.replace(/\n/g, " ").trim())
+          .join("\n\n")
+          .trim();
+      } else {
+        fm[key] = blockLines.join("\n").trim();
+      }
+    } else if (value === "" && i + 1 < lines.length && /^[ \t]+- /.test(lines[i + 1]!)) {
+      // YAML block sequence: indented "- item" lines
+      const items: string[] = [];
+      while (i + 1 < lines.length && /^[ \t]+- /.test(lines[i + 1]!)) {
+        i++;
+        items.push(lines[i]!.replace(/^[ \t]+- /, "").trim());
+      }
+      fm[key] = items;
+    } else if (value === "true") fm[key] = true;
     else if (value === "false") fm[key] = false;
     else if (/^\[.*\]$/.test(value)) {
       // Simple array: [Read, Grep, Glob]
@@ -87,12 +114,16 @@ export function parseFrontmatter(content: string): {
 }
 
 /**
- * Scan a directory for skill subdirectories containing SKILL.md or SKILL.md.disabled.
- * Returns PreviewSkill[] for use in previews.
+ * Scan a directory for skills using a 3-tier strategy:
+ *   Tier 1: Root-level SKILL.md (single-skill source)
+ *   Tier 2: skills/<name>/SKILL.md (organized multi-skill source)
+ *   Tier 3: <name>/SKILL.md at top level (flat multi-skill source)
+ *
+ * Each tier returns early — a root SKILL.md means the entire source is one skill,
+ * even if subdirectories also contain SKILL.md files.
  */
 export async function scanSkillDirs(baseDir: string, singleName?: string): Promise<PreviewSkill[]> {
   log("scanSkillDirs", { baseDir, singleName });
-  const skills: PreviewSkill[] = [];
 
   // If singleName provided, check that specific directory
   if (singleName) {
@@ -100,22 +131,51 @@ export async function scanSkillDirs(baseDir: string, singleName?: string): Promi
     try {
       const content = await readFile(skillFile, "utf-8");
       const { description } = parseFrontmatter(content);
-      skills.push({ name: singleName, description, skillPath: singleName });
+      return [{ name: singleName, description, skillPath: singleName }];
     } catch {
-      // Not a valid skill directory
+      return [];
     }
-    return skills;
   }
+
+  // Tier 1: Root-level SKILL.md
+  const rootContent = await readFile(path.join(baseDir, SKILL_FILE), "utf-8").catch(() => null);
+  if (rootContent) {
+    const { frontmatter, description } = parseFrontmatter(rootContent);
+    const name =
+      typeof (frontmatter as Record<string, unknown>).name === "string"
+        ? ((frontmatter as Record<string, unknown>).name as string)
+        : path.basename(baseDir);
+    return [{ name, description, skillPath: "." }];
+  }
+
+  // Tier 2: skills/ subdirectory
+  try {
+    const skillsSubdir = path.join(baseDir, "skills");
+    const s = await stat(skillsSubdir);
+    if (s.isDirectory()) {
+      const skills = await scanSubdirectories(skillsSubdir, "skills");
+      if (skills.length > 0) return skills;
+    }
+  } catch {
+    // No skills/ subdirectory
+  }
+
+  // Tier 3: Top-level subdirectories (existing behavior)
+  return scanSubdirectories(baseDir, "");
+}
+
+async function scanSubdirectories(dir: string, prefix: string): Promise<PreviewSkill[]> {
+  const skills: PreviewSkill[] = [];
 
   let entries: string[];
   try {
-    entries = await readdir(baseDir);
+    entries = await readdir(dir);
   } catch {
     return skills;
   }
 
   for (const entry of entries) {
-    const entryPath = path.join(baseDir, entry);
+    const entryPath = path.join(dir, entry);
     try {
       const s = await stat(entryPath);
       if (!s.isDirectory()) continue;
@@ -125,13 +185,69 @@ export async function scanSkillDirs(baseDir: string, singleName?: string): Promi
       if (!content) continue;
 
       const { description } = parseFrontmatter(content);
-      skills.push({ name: entry, description, skillPath: entry });
+      const skillPath = prefix ? `${prefix}/${entry}` : entry;
+      skills.push({ name: entry, description, skillPath });
     } catch {
       continue;
     }
   }
 
   return skills;
+}
+
+/** Resolve the absolute source path for a skill within a base directory. */
+export function resolveSkillSource(baseDir: string, skillPath: string): string {
+  return skillPath === "." ? baseDir : path.join(baseDir, skillPath);
+}
+
+/** Derive the destination folder name for installing a skill. */
+export function deriveInstallName(skillPath: string, sourceRef: string): string {
+  return skillPath === "." ? extractFolderName(sourceRef) : path.basename(skillPath);
+}
+
+/** Extract a folder name from a source URL. */
+export function extractFolderName(sourceRef: string): string {
+  let normalized = sourceRef;
+
+  // Handle npm sources: npm:@scope/package@1.2.3 -> package
+  if (normalized.startsWith("npm:") || normalized.startsWith("@")) {
+    normalized = normalized.replace(/^npm:/, "");
+    // Strip version suffix: @scope/package@1.2.3 -> @scope/package
+    normalized = normalized.replace(/@[\d.]+(-[\w.]+)?$/, "");
+    // Strip registry query: @scope/package?registry=... -> @scope/package
+    const qIdx = normalized.indexOf("?");
+    if (qIdx !== -1) normalized = normalized.slice(0, qIdx);
+    const lastSegment = normalized.split("/").filter(Boolean).pop();
+    return lastSegment || "skill";
+  }
+
+  // Handle git sources
+  normalized = normalized
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/^https?:\/\/gitlab\.com\//, "")
+    .replace(/^https?:\/\/bitbucket\.org\//, "")
+    .replace(/^git:/, "")
+    .replace(/^github:/, "")
+    .replace(/^gitlab:/, "")
+    .replace(/^bitbucket:/, "");
+
+  // Handle GitHub tree URLs: user/repo/tree/branch/subpath -> subpath
+  const treeMatchWithPath = normalized.match(/^[^/]+\/[^/]+\/tree\/[^/]+\/(.+)$/);
+  if (treeMatchWithPath) {
+    normalized = treeMatchWithPath[1]!;
+  } else {
+    const treeMatchBranchOnly = normalized.match(/^([^/]+)\/([^/]+)\/tree\/[^/]+$/);
+    if (treeMatchBranchOnly) {
+      normalized = treeMatchBranchOnly[2]!;
+    }
+  }
+
+  // Strip branch ref: user/repo#branch -> user/repo
+  normalized = normalized.replace(/#.*$/, "");
+  // Strip .git suffix
+  normalized = normalized.replace(/\.git$/, "");
+  const lastSegment = normalized.split("/").filter(Boolean).pop();
+  return lastSegment || "skill";
 }
 
 /**

--- a/packages/desktop/src/main/features/skills/skills-service.ts
+++ b/packages/desktop/src/main/features/skills/skills-service.ts
@@ -44,6 +44,7 @@ export class SkillsService {
     data: Omit<RecommendedSkill, "installed">[];
     fetchedAt: number;
   } | null = null;
+  private previewSources = new Map<string, string>();
 
   constructor(projectStore: ProjectStore, configStore: ConfigStore, resourcesDir: string) {
     this.projectStore = projectStore;
@@ -115,7 +116,9 @@ export class SkillsService {
     log("preview", { source });
     const installer = this.findInstaller(source);
     if (!installer) throw new Error(`No installer found for source: ${source}`);
-    return installer.scan(source);
+    const result = await installer.scan(source);
+    this.previewSources.set(result.previewId, source);
+    return result;
   }
 
   async install(
@@ -145,14 +148,27 @@ export class SkillsService {
     const targetDir = this.resolveSkillsDir(scope, projectPath);
     await mkdir(targetDir, { recursive: true });
 
+    const sourceRef = this.previewSources.get(previewId);
+
     for (const installer of this.installers) {
       try {
-        await installer.installFromPreview(previewId, selectedSkills, targetDir);
+        const installedNames = await installer.installFromPreview(
+          previewId,
+          selectedSkills,
+          targetDir,
+        );
+        if (sourceRef) {
+          for (const name of installedNames) {
+            await this.writeInstallMeta(path.join(targetDir, name), sourceRef);
+          }
+        }
+        this.previewSources.delete(previewId);
         return;
       } catch {
         continue;
       }
     }
+    this.previewSources.delete(previewId);
     throw new Error("Preview not found or expired");
   }
 
@@ -165,13 +181,27 @@ export class SkillsService {
   async enable(name: string, scope: "global" | "project", projectPath?: string): Promise<void> {
     log("enable", { name, scope, projectPath });
     const skillDir = this.resolveSkillDir(name, scope, projectPath);
-    await rename(path.join(skillDir, "SKILL.md.disabled"), path.join(skillDir, "SKILL.md"));
+    const enabledPath = path.join(skillDir, "SKILL.md");
+    const disabledPath = path.join(skillDir, "SKILL.md.disabled");
+    try {
+      await readFile(enabledPath, "utf-8");
+      return; // Already enabled
+    } catch {
+      await rename(disabledPath, enabledPath);
+    }
   }
 
   async disable(name: string, scope: "global" | "project", projectPath?: string): Promise<void> {
     log("disable", { name, scope, projectPath });
     const skillDir = this.resolveSkillDir(name, scope, projectPath);
-    await rename(path.join(skillDir, "SKILL.md"), path.join(skillDir, "SKILL.md.disabled"));
+    const enabledPath = path.join(skillDir, "SKILL.md");
+    const disabledPath = path.join(skillDir, "SKILL.md.disabled");
+    try {
+      await readFile(disabledPath, "utf-8");
+      return; // Already disabled
+    } catch {
+      await rename(enabledPath, disabledPath);
+    }
   }
 
   async exists(name: string, scope: "global" | "project", projectPath?: string): Promise<boolean> {
@@ -193,6 +223,7 @@ export class SkillsService {
     for (const installer of this.installers) {
       await installer.cleanup(previewId);
     }
+    this.previewSources.delete(previewId);
   }
 
   async checkUpdates(

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/skill-add-modal.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/skill-add-modal.tsx
@@ -72,7 +72,7 @@ export const SkillAddModal = ({ projects, onClose, onRefresh }: SkillAddModalPro
         previewId: result.previewId,
         source,
         skills: result.skills,
-        selected: new Set(result.skills.map((s) => s.name)),
+        selected: new Set(result.skills.map((s) => s.skillPath)),
       });
     } catch (e: any) {
       setPhase({ step: "input", error: e.message || t("settings.skills.fetchFailed") });
@@ -88,11 +88,11 @@ export const SkillAddModal = ({ projects, onClose, onRefresh }: SkillAddModalPro
     onClose();
   };
 
-  const toggleSkill = (name: string) => {
+  const toggleSkill = (skillPath: string) => {
     if (phase.step !== "select") return;
     const next = new Set(phase.selected);
-    if (next.has(name)) next.delete(name);
-    else next.add(name);
+    if (next.has(skillPath)) next.delete(skillPath);
+    else next.add(skillPath);
     setPhase({ ...phase, selected: next });
   };
 
@@ -183,7 +183,7 @@ export const SkillAddModal = ({ projects, onClose, onRefresh }: SkillAddModalPro
               </div>
               <div className="space-y-1">
                 {phase.skills.map((skill) => {
-                  const isSelected = phase.selected.has(skill.name);
+                  const isSelected = phase.selected.has(skill.skillPath);
                   return (
                     <label
                       key={skill.skillPath}
@@ -194,7 +194,7 @@ export const SkillAddModal = ({ projects, onClose, onRefresh }: SkillAddModalPro
                     >
                       <Checkbox
                         checked={isSelected}
-                        onCheckedChange={() => toggleSkill(skill.name)}
+                        onCheckedChange={() => toggleSkill(skill.skillPath)}
                       />
                       <div className="min-w-0">
                         <span className="text-sm font-medium text-foreground">{skill.name}</span>

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/skill-detail-modal.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/skill-detail-modal.tsx
@@ -65,6 +65,7 @@ export const SkillDetailModal = ({
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [toggling, setToggling] = useState(false);
   const [installScope, setInstallScope] = useState<string>("global");
 
   // Fetch SKILL.md content for installed skills
@@ -79,7 +80,8 @@ export const SkillDetailModal = ({
   }, [skill]);
 
   const handleToggle = async () => {
-    if (!skill) return;
+    if (!skill || toggling) return;
+    setToggling(true);
     try {
       if (skill.enabled) {
         await client.skills.disable({
@@ -95,9 +97,10 @@ export const SkillDetailModal = ({
         });
       }
       await onRefresh();
-      onClose();
     } catch {
       // Silently fail
+    } finally {
+      setToggling(false);
     }
   };
 
@@ -175,7 +178,7 @@ export const SkillDetailModal = ({
                   ? t("settings.skills.detail.enabled")
                   : t("settings.skills.detail.disabled")}
               </span>
-              <Switch checked={skill.enabled} onCheckedChange={handleToggle} />
+              <Switch checked={skill.enabled} disabled={toggling} onCheckedChange={handleToggle} />
             </div>
           )}
           {isInstalled && (

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/skills-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/skills-panel.tsx
@@ -130,8 +130,11 @@ export const SkillsPanel = () => {
     });
   }, [recommended, searchQuery]);
 
-  const handleToggleEnabled = async (skill: SkillMeta, e: React.MouseEvent) => {
-    e.stopPropagation();
+  const [togglingSkill, setTogglingSkill] = useState<string | null>(null);
+  const handleToggleEnabled = async (skill: SkillMeta) => {
+    const key = `${skill.scope}-${skill.projectPath ?? ""}-${skill.name}`;
+    if (togglingSkill) return;
+    setTogglingSkill(key);
     log("toggle skill: name=%s enabled=%s", skill.name, !skill.enabled);
     try {
       if (skill.enabled) {
@@ -150,6 +153,8 @@ export const SkillsPanel = () => {
       await fetchData();
     } catch {
       // Silently fail — user can retry
+    } finally {
+      setTogglingSkill(null);
     }
   };
 
@@ -308,8 +313,12 @@ export const SkillsPanel = () => {
                     </p>
                   )}
                 </div>
-                <div onClick={(e) => handleToggleEnabled(skill, e)}>
-                  <Switch checked={skill.enabled} />
+                <div onClick={(e) => e.stopPropagation()}>
+                  <Switch
+                    checked={skill.enabled}
+                    disabled={togglingSkill !== null}
+                    onCheckedChange={() => handleToggleEnabled(skill)}
+                  />
                 </div>
               </div>
             ))}
@@ -391,7 +400,14 @@ export const SkillsPanel = () => {
       {/* Detail Modal */}
       {selectedSkill && (
         <SkillDetailModal
-          skill={selectedSkill}
+          skill={
+            installed.find(
+              (s) =>
+                s.name === selectedSkill.name &&
+                s.scope === selectedSkill.scope &&
+                s.projectPath === selectedSkill.projectPath,
+            ) ?? selectedSkill
+          }
           update={getUpdate(selectedSkill)}
           onClose={() => setSelectedSkill(null)}
           onRefresh={fetchData}


### PR DESCRIPTION
## Summary

- **3-tier skill scan**: Port takumi's detection strategy — root `SKILL.md`, `skills/` subdir, then top-level subdirs. Fixes single-skill repos and organized multi-skill repos returning "no skills found."
- **YAML frontmatter parser**: Support block scalars (`|`, `>`) and block sequences (indented `- item`). Fixes descriptions showing as `"|"` for multiline values.
- **Toggle race condition**: Switch double-fired due to base-ui label/button interaction. Moved to `onCheckedChange`, added guard ref, made backend `enable`/`disable` idempotent.
- **Toggle loading state**: Switch shows disabled + opacity during async toggle operation.
- **Detail modal**: Toggle no longer closes the modal; Switch reflects fresh state after refresh.
- **Install metadata**: Preview-based installs now write `.neovate-install.json` for version tracking.
- **Install path helpers**: Shared `resolveSkillSource`, `deriveInstallName`, `extractFolderName` used by both git and npm installers. Handles root-level skills, `skills/` nested skills, and npm sources.

## Test plan

- [ ] Add skill from single-skill repo (e.g. `sorrycc/newsnow`) — should detect root `SKILL.md`
- [ ] Add skill from multi-skill repo with `skills/` subdir — should detect all skills
- [ ] Add skill from flat multi-skill repo — should detect all skills (existing behavior)
- [ ] Verify description displays correctly for skills with `description: |` multiline YAML
- [ ] Toggle enable/disable on skills panel — switch should show disabled state during operation
- [ ] Toggle in detail modal — modal stays open, switch reflects new state
- [ ] Verify `.neovate-install.json` is created after preview-based install