### PR TITLE
feat: save and restore scroll position per session

### DIFF
--- a/docs/designs/2026-03-19-session-scroll-position.md
+++ b/docs/designs/2026-03-19-session-scroll-position.md
@@ -1,0 +1,55 @@
+# Save Scroll Position Per Session
+
+## Problem
+
+When switching between sessions, the scroll position resets to the bottom. Users lose their reading context in previous conversations.
+
+## Requirements
+
+- Restore exact scroll position when switching back to a session
+- In-memory only (no disk persistence, lost on app quit)
+- No change to existing behavior for new sessions (still scroll to bottom)
+
+## Design
+
+### Storage
+
+Module-level `Map<string, number>` in `agent-chat.tsx` — maps `sessionId` to `scrollTop`. This is transient UI state that doesn't need Zustand or persistence.
+
+### Save
+
+Two mechanisms:
+
+1. **Debounced on scroll** (~200ms) — continuously update the map as the user scrolls. Cheap writes to a module-level map.
+   - When `isAtBottom === false`: save `scrollTop` to map.
+   - When `isAtBottom === true`: **delete** the map entry — prevents restoring a stale "scrolled up" position after the user scrolled back to bottom.
+2. **On unmount** — save as cleanup effect fallback (same `isAtBottom` guard: save or delete).
+
+Access the scroll container through `StickToBottomContext.scrollRef` (already available via `conversationContextRef`).
+
+### Restore
+
+When `AgentChatSession` mounts:
+
+1. Check if the map has a saved position for this `sessionId`
+2. If **yes**: pass `initial={false}` to `Conversation` to suppress the auto-scroll-to-bottom, then set `scrollElement.scrollTop` in a `useLayoutEffect` (runs after DOM mutation but before browser paint — avoids a visual flash of the wrong scroll position)
+3. If **no** (new/first visit): keep current behavior (`initial="smooth"`, scrolls to bottom)
+
+### Invalidation
+
+- **Session deleted**: remove map entry.
+- **New messages on non-active session**: clear saved position so it scrolls to bottom when switched to. Subscribe to message count changes for non-active sessions in the store.
+
+## Files Changed
+
+| File                                                        | Change                                                                          |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `src/renderer/src/features/agent/components/agent-chat.tsx` | Module-level map, save on unmount, restore on mount, conditional `initial` prop |
+
+~20 lines of new code. No new files, no new dependencies.
+
+## Edge Cases
+
+- **Session with no messages**: `isNew` sessions show `WelcomePanel`, not `AgentChatSession`, so scroll position is irrelevant
+- **New messages arrive while away**: Saved position cleared, scrolls to bottom to show new content
+- **App restart**: Positions lost (by design), sessions load and scroll to bottom as they do today

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -6,6 +6,7 @@ import { agentContract } from "../../../../shared/features/agent/contract";
 import { client } from "../../orpc";
 import { ClaudeCodeChat } from "./chat";
 import { ClaudeCodeChatTransport } from "./chat-transport";
+import { scrollPositions } from "./scroll-positions";
 import { registerSessionInStore } from "./session-utils";
 import { useAgentStore } from "./store";
 
@@ -33,7 +34,11 @@ export class ClaudeCodeChatManager {
       }
 
       const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
-      if (activeSessionId !== id) markTurnCompleted(id, result);
+      if (activeSessionId !== id) {
+        markTurnCompleted(id, result);
+        log("onTurnComplete: clearing scroll position for non-active session=%s", id.slice(0, 8));
+        scrollPositions.delete(id);
+      }
     },
     onTurnStart: (id: string) => {
       useAgentStore.getState().clearTurnResult(id);
@@ -76,6 +81,8 @@ export class ClaudeCodeChatManager {
   }
 
   async removeSession(sessionId: string): Promise<void> {
+    log("removeSession: clearing scroll position for session=%s", sessionId.slice(0, 8));
+    scrollPositions.delete(sessionId);
     const chat = this.chats.get(sessionId);
     if (!chat) return;
 

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -34,6 +34,7 @@ import { cn } from "../../../lib/utils";
 import { claudeCodeChatManager } from "../chat-manager";
 import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
 import { useNewSession } from "../hooks/use-new-session";
+import { useScrollPosition } from "../hooks/use-scroll-position";
 import { BranchSwitcher } from "./branch-switcher";
 import { MessageInput } from "./message-input";
 import { MessageParts } from "./message-parts";
@@ -229,6 +230,8 @@ function AgentChatSession({
   // Ref to access scroll context for smooth scrolling on new message
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
 
+  const { initialScrollBehavior } = useScrollPosition(sessionId, conversationContextRef);
+
   const handleSend = (text: string, attachments?: ImageAttachment[]) => {
     chatLog(
       "handleSend: sessionId=%s msgLen=%d attachments=%d",
@@ -253,7 +256,7 @@ function AgentChatSession({
 
   return (
     <div className="flex h-full flex-col">
-      <Conversation contextRef={conversationContextRef}>
+      <Conversation contextRef={conversationContextRef} initial={initialScrollBehavior}>
         <ConversationContent>
           {messages.map((message) => (
             <MessageParts

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-scroll-position.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-scroll-position.ts
@@ -1,0 +1,113 @@
+import type { RefObject } from "react";
+import type { StickToBottomContext } from "use-stick-to-bottom";
+
+import debug from "debug";
+import { useEffect, useLayoutEffect } from "react";
+
+import { scrollPositions } from "../scroll-positions";
+
+const log = debug("neovate:agent-scroll");
+
+type ScrollBehavior = "smooth" | false;
+
+/**
+ * Saves and restores scroll position per session.
+ * Returns the `initial` prop to pass to `<Conversation>`.
+ */
+export function useScrollPosition(
+  sessionId: string,
+  contextRef: RefObject<StickToBottomContext | null>,
+): { initialScrollBehavior: ScrollBehavior } {
+  const savedScrollTop = scrollPositions.get(sessionId);
+  const hasSavedPosition = savedScrollTop != null;
+
+  log(
+    "render: sid=%s savedScrollTop=%s hasSaved=%s",
+    sessionId.slice(0, 8),
+    savedScrollTop ?? "none",
+    hasSavedPosition,
+  );
+
+  // Restore scroll position before paint
+  useLayoutEffect(() => {
+    if (savedScrollTop == null) {
+      log("restore: sid=%s skipped (no saved position)", sessionId.slice(0, 8));
+      return;
+    }
+
+    const el = contextRef.current?.scrollRef.current;
+    if (!el) {
+      log(
+        "restore: sid=%s FAILED (scrollRef unavailable, contextRef=%s)",
+        sessionId.slice(0, 8),
+        contextRef.current ? "set" : "null",
+      );
+      return;
+    }
+
+    el.scrollTop = savedScrollTop;
+    log(
+      "restore: sid=%s scrollTop=%d (actual=%d, scrollHeight=%d, clientHeight=%d)",
+      sessionId.slice(0, 8),
+      savedScrollTop,
+      el.scrollTop,
+      el.scrollHeight,
+      el.clientHeight,
+    );
+  }, []); // only on mount
+
+  // Save scroll position on scroll (debounced) and on unmount
+  useEffect(() => {
+    const el = contextRef.current?.scrollRef.current;
+    if (!el) {
+      log("save-effect: sid=%s skipped (scrollRef unavailable)", sessionId.slice(0, 8));
+      return;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let userHasScrolled = false;
+    const handleScroll = () => {
+      userHasScrolled = true;
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 1;
+        if (atBottom) {
+          scrollPositions.delete(sessionId);
+        } else {
+          scrollPositions.set(sessionId, el.scrollTop);
+        }
+        log(
+          "scroll: sid=%s atBottom=%s scrollTop=%d",
+          sessionId.slice(0, 8),
+          atBottom,
+          el.scrollTop,
+        );
+      }, 200);
+    };
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      clearTimeout(timeoutId);
+      el.removeEventListener("scroll", handleScroll);
+      // Skip save if element is detached or no user scroll occurred (Strict Mode)
+      if (el.scrollHeight === 0 || !userHasScrolled) {
+        log(
+          "unmount: sid=%s skipped (detached=%s userScrolled=%s)",
+          sessionId.slice(0, 8),
+          el.scrollHeight === 0,
+          userHasScrolled,
+        );
+        return;
+      }
+      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 1;
+      if (atBottom) {
+        scrollPositions.delete(sessionId);
+      } else {
+        scrollPositions.set(sessionId, el.scrollTop);
+      }
+      log("unmount: sid=%s saved=%s scrollTop=%d", sessionId.slice(0, 8), !atBottom, el.scrollTop);
+    };
+  }, [sessionId]);
+
+  return { initialScrollBehavior: hasSavedPosition ? false : "smooth" };
+}

--- a/packages/desktop/src/renderer/src/features/agent/scroll-positions.ts
+++ b/packages/desktop/src/renderer/src/features/agent/scroll-positions.ts
@@ -1,0 +1,3 @@
+// Module-level map: sessionId -> scrollTop
+// In-memory only, lost on app quit
+export const scrollPositions = new Map<string, number>();


### PR DESCRIPTION
## Summary

- Preserve scroll position when switching between chat sessions
- Uses a module-level `Map<sessionId, scrollTop>` (in-memory only, lost on app quit)
- New `useScrollPosition` hook handles save/restore with debug logging (`neovate:agent-scroll`)
- Debounced save on scroll events (~200ms), with guards against:
  - DOM-detached elements (cleanup after React unmount)
  - React Strict Mode poisoning (`userHasScrolled` flag)
- Clears saved position when a non-active session receives new messages (turn complete)
- Passes `initial={false}` to `StickToBottom` when restoring, `"smooth"` otherwise

## Test plan

- [ ] Open a session with many messages, scroll to the middle, switch to another session, switch back — should restore exact scroll position
- [ ] Open a session, stay at bottom, switch away and back — should remain at bottom (no saved position)
- [ ] Open a session, scroll up, scroll back to bottom, switch away and back — should be at bottom (position cleared when at bottom)
- [ ] Verify new sessions with no history scroll to bottom normally
- [ ] Enable `DEBUG=neovate:agent-scroll` and verify restore/save/unmount logs are correct