### PR TITLE
feat: add card-based visual grouping to settings panels

### DIFF
--- a/docs/designs/2026-03-19-settings-group-config.md
+++ b/docs/designs/2026-03-19-settings-group-config.md
@@ -1,0 +1,86 @@
+# Settings: Visual Group Config (Card-based Sections)
+
+**Date:** 2026-03-19
+**Status:** Draft
+
+## Problem
+
+Settings panels (General, Chat) render a flat list of `SettingsRow` items with no visual grouping. Related settings (e.g., theme + language, terminal font + size) are mixed together without clear sections, making panels harder to scan as they grow.
+
+## Solution
+
+Add a reusable `SettingsGroup` card component that wraps `SettingsRow` items into visually distinct sections. Apply it to General and Chat panels with logical groupings.
+
+## Component: `SettingsGroup`
+
+**File:** `src/renderer/src/features/settings/components/settings-group.tsx`
+
+```tsx
+interface SettingsGroupProps {
+  title: string;
+  description?: string;
+  children: ReactNode; // SettingsRow items
+}
+```
+
+**Visual:** Rounded card (`rounded-[0.625rem]` per design system) with subtle `border border-border`, internal padding, and a group title rendered as a small semibold label at the top. Groups separated by `space-y-4` gap.
+
+`SettingsRow` already has `border-b border-border last:border-b-0` which works perfectly inside a card container -- no changes needed to `SettingsRow`.
+
+## Panel Groupings
+
+### General Panel
+
+| Group          | Settings                                              |
+| -------------- | ----------------------------------------------------- |
+| **Appearance** | Language, Theme                                       |
+| **Terminal**   | Font Size, Font                                       |
+| **Advanced**   | Run on Startup, Multi-Project Support, Developer Mode |
+
+### Chat Panel
+
+| Group        | Settings                                                                                  |
+| ------------ | ----------------------------------------------------------------------------------------- |
+| **Model**    | Model selection                                                                           |
+| **Behavior** | Agent Language, Permission Mode, Token Optimization, Network Inspector, Send Message With |
+
+### Other Panels
+
+Keybindings, Skills, Providers, Rules, About are single-purpose and don't need sub-groups now. The `SettingsGroup` component is available for them when needed.
+
+## Changes
+
+### 1. `src/renderer/src/features/settings/components/settings-group.tsx` (new)
+
+New `SettingsGroup` card component:
+
+- Rounded card with border
+- Title as small semibold text at top
+- Optional description below title
+- Children rendered inside the card
+
+### 2. `src/renderer/src/features/settings/components/panels/general-panel.tsx`
+
+- Replace `<div className="space-y-0">` with `<div className="space-y-4">`
+- Wrap rows in 3 `SettingsGroup` cards: Appearance, Terminal, Advanced
+
+### 3. `src/renderer/src/features/settings/components/panels/chat-panel.tsx`
+
+- Replace `<div className="space-y-0">` with `<div className="space-y-4">`
+- Wrap rows in 2 `SettingsGroup` cards: Model, Behavior
+
+### 4. i18n translation files
+
+Add group title keys:
+
+- `settings.general.group.appearance`
+- `settings.general.group.terminal`
+- `settings.general.group.advanced`
+- `settings.chat.group.model`
+- `settings.chat.group.behavior`
+
+## Not Changed
+
+- `SettingsRow` -- existing border styling works inside cards as-is
+- `AppConfig` / config store -- no backend changes, purely UI
+- Other panels -- available for future use but not modified now

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/chat-panel.tsx
@@ -35,6 +35,7 @@ import { useAgentStore } from "../../../agent/store";
 import { useConfigStore } from "../../../config/store";
 import { useProjectStore } from "../../../project/store";
 import { useProviderStore } from "../../../provider/store";
+import { SettingsGroup } from "../settings-group";
 import { SettingsRow } from "../settings-row";
 
 // Translation key mappings
@@ -89,99 +90,99 @@ export const ChatPanel = () => {
         {t("settings.chat")}
       </h1>
 
-      <div className="space-y-0">
+      <div className="space-y-4">
         {/* Model */}
-        <SettingsRow
-          title={t("settings.chat.model")}
-          description={t("settings.chat.model.description")}
-        >
-          <GlobalModelSelect />
-        </SettingsRow>
-
-        {/* Agent Language */}
-        <SettingsRow
-          title={t("settings.chat.agentLanguage")}
-          description={t("settings.chat.agentLanguage.description")}
-        >
-          <Select
-            value={config.agentLanguage}
-            onValueChange={(val) => setConfig("agentLanguage", val as AgentLanguage)}
+        <SettingsGroup title={t("settings.chat.group.model")}>
+          <SettingsRow
+            title={t("settings.chat.model")}
+            description={t("settings.chat.model.description")}
           >
-            <SelectTrigger size="sm" className="min-w-36">
-              <SelectValue placeholder={t("settings.chat.selectPlaceholder")}>
-                {t(agentLanguageKeys[config.agentLanguage])}
-              </SelectValue>
-            </SelectTrigger>
-            <SelectPopup>
-              <SelectItem value="English">{t("settings.chat.agentLanguage.english")}</SelectItem>
-              <SelectItem value="Chinese">{t("settings.chat.agentLanguage.chinese")}</SelectItem>
-            </SelectPopup>
-          </Select>
-        </SettingsRow>
+            <GlobalModelSelect />
+          </SettingsRow>
+        </SettingsGroup>
 
-        {/* Permission Mode */}
-        <SettingsRow
-          title={t("settings.chat.permissionMode")}
-          description={t("settings.chat.permissionMode.description")}
-        >
-          <Select
-            value={config.permissionMode}
-            onValueChange={(val) => setConfig("permissionMode", val as ConfigPermissionMode)}
+        {/* Behavior */}
+        <SettingsGroup title={t("settings.chat.group.behavior")}>
+          <SettingsRow
+            title={t("settings.chat.agentLanguage")}
+            description={t("settings.chat.agentLanguage.description")}
           >
-            <SelectTrigger size="sm" className="min-w-36">
-              <SelectValue>{t(permissionModeKeys[config.permissionMode])}</SelectValue>
-            </SelectTrigger>
-            <SelectPopup>
-              <SelectItem value="default">{t("settings.chat.permissionMode.default")}</SelectItem>
-              <SelectItem value="acceptEdits">
-                {t("settings.chat.permissionMode.acceptEdits")}
-              </SelectItem>
-              <SelectItem value="bypassPermissions">
-                {t("settings.chat.permissionMode.bypassPermissions")}
-              </SelectItem>
-            </SelectPopup>
-          </Select>
-        </SettingsRow>
+            <Select
+              value={config.agentLanguage}
+              onValueChange={(val) => setConfig("agentLanguage", val as AgentLanguage)}
+            >
+              <SelectTrigger size="sm" className="min-w-36">
+                <SelectValue placeholder={t("settings.chat.selectPlaceholder")}>
+                  {t(agentLanguageKeys[config.agentLanguage])}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup>
+                <SelectItem value="English">{t("settings.chat.agentLanguage.english")}</SelectItem>
+                <SelectItem value="Chinese">{t("settings.chat.agentLanguage.chinese")}</SelectItem>
+              </SelectPopup>
+            </Select>
+          </SettingsRow>
 
-        {/* Token Optimization */}
-        <SettingsRow
-          title={t("settings.chat.tokenOptimization")}
-          description={t("settings.chat.tokenOptimization.description")}
-        >
-          <Switch
-            checked={config.tokenOptimization}
-            onCheckedChange={(v) => setConfig("tokenOptimization", v)}
-          />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.chat.permissionMode")}
+            description={t("settings.chat.permissionMode.description")}
+          >
+            <Select
+              value={config.permissionMode}
+              onValueChange={(val) => setConfig("permissionMode", val as ConfigPermissionMode)}
+            >
+              <SelectTrigger size="sm" className="min-w-36">
+                <SelectValue>{t(permissionModeKeys[config.permissionMode])}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup>
+                <SelectItem value="default">{t("settings.chat.permissionMode.default")}</SelectItem>
+                <SelectItem value="acceptEdits">
+                  {t("settings.chat.permissionMode.acceptEdits")}
+                </SelectItem>
+                <SelectItem value="bypassPermissions">
+                  {t("settings.chat.permissionMode.bypassPermissions")}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          </SettingsRow>
 
-        {/* Network Inspector */}
-        <SettingsRow
-          title={t("settings.chat.networkInspector")}
-          description={t("settings.chat.networkInspector.description")}
-        >
-          <Switch
-            checked={config.networkInspector}
-            onCheckedChange={(v) => setConfig("networkInspector", v)}
-          />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.chat.tokenOptimization")}
+            description={t("settings.chat.tokenOptimization.description")}
+          >
+            <Switch
+              checked={config.tokenOptimization}
+              onCheckedChange={(v) => setConfig("tokenOptimization", v)}
+            />
+          </SettingsRow>
 
-        {/* Send Message With */}
-        <SettingsRow
-          title={t("settings.chat.sendMessage")}
-          description={t("settings.chat.sendMessage.description")}
-        >
-          <ToggleOptions
-            value={config.sendMessageWith}
-            onChange={(val) => setConfig("sendMessageWith", val as SendMessageWith)}
-            options={[
-              { value: "enter", label: "Enter" },
-              {
-                value: "cmdEnter",
-                label: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘+Enter" : "Ctrl+Enter",
-              },
-            ]}
-          />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.chat.networkInspector")}
+            description={t("settings.chat.networkInspector.description")}
+          >
+            <Switch
+              checked={config.networkInspector}
+              onCheckedChange={(v) => setConfig("networkInspector", v)}
+            />
+          </SettingsRow>
+
+          <SettingsRow
+            title={t("settings.chat.sendMessage")}
+            description={t("settings.chat.sendMessage.description")}
+          >
+            <ToggleOptions
+              value={config.sendMessageWith}
+              onChange={(val) => setConfig("sendMessageWith", val as SendMessageWith)}
+              options={[
+                { value: "enter", label: "Enter" },
+                {
+                  value: "cmdEnter",
+                  label: /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘+Enter" : "Ctrl+Enter",
+                },
+              ]}
+            />
+          </SettingsRow>
+        </SettingsGroup>
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/general-panel.tsx
@@ -13,6 +13,7 @@ import { useRendererApp } from "../../../../core";
 import { localeOptions, type Locales } from "../../../../core/i18n";
 import { client } from "../../../../orpc";
 import { useConfigStore } from "../../../config/store";
+import { SettingsGroup } from "../settings-group";
 import { SettingsRow } from "../settings-row";
 
 const log = createDebug("neovate:settings");
@@ -97,83 +98,88 @@ export const GeneralPanel = () => {
         {t("settings.general")}
       </h1>
 
-      <div className="space-y-0">
-        {/* Language */}
-        <SettingsRow
-          title={t("settings.general.language")}
-          description={t("settings.general.language.description")}
-        >
-          <ToggleOptions value={locale} onChange={handleLocaleChange} options={localeOptions} />
-        </SettingsRow>
+      <div className="space-y-4">
+        {/* Appearance */}
+        <SettingsGroup title={t("settings.general.group.appearance")}>
+          <SettingsRow
+            title={t("settings.general.language")}
+            description={t("settings.general.language.description")}
+          >
+            <ToggleOptions value={locale} onChange={handleLocaleChange} options={localeOptions} />
+          </SettingsRow>
 
-        {/* Theme */}
-        <SettingsRow title={t("settings.theme")} description={t("settings.theme.description")}>
-          <ToggleOptions
-            value={theme}
-            onChange={handleThemeChange}
-            options={[
-              { value: "light", label: t("settings.theme.light") },
-              { value: "dark", label: t("settings.theme.dark") },
-              { value: "system", label: t("settings.theme.system") },
-            ]}
-          />
-        </SettingsRow>
+          <SettingsRow title={t("settings.theme")} description={t("settings.theme.description")}>
+            <ToggleOptions
+              value={theme}
+              onChange={handleThemeChange}
+              options={[
+                { value: "light", label: t("settings.theme.light") },
+                { value: "dark", label: t("settings.theme.dark") },
+                { value: "system", label: t("settings.theme.system") },
+              ]}
+            />
+          </SettingsRow>
+        </SettingsGroup>
 
-        {/* Run on Startup */}
-        <SettingsRow
-          title={t("settings.general.runOnStartup")}
-          description={t("settings.general.runOnStartup.description")}
-        >
-          <Switch checked={runOnStartup} onCheckedChange={handleRunOnStartupChange} />
-        </SettingsRow>
+        {/* Terminal */}
+        <SettingsGroup title={t("settings.general.group.terminal")}>
+          <SettingsRow
+            title={t("settings.general.terminalFontSize")}
+            description={t("settings.general.terminalFontSize.description")}
+          >
+            <Input
+              type="number"
+              min={8}
+              max={32}
+              value={terminalFontSize}
+              onChange={(e) => setConfig("terminalFontSize", Number(e.target.value))}
+              className="w-24"
+            />
+          </SettingsRow>
 
-        {/* Multi-Project Support */}
-        <SettingsRow
-          title={t("settings.general.multiProjectSupport")}
-          description={t("settings.general.multiProjectSupport.description")}
-        >
-          <Switch
-            checked={multiProjectSupport}
-            onCheckedChange={(v) => setConfig("multiProjectSupport", v)}
-          />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.general.terminalFont")}
+            description={t("settings.general.terminalFont.description")}
+          >
+            <Input
+              type="text"
+              value={localTerminalFont}
+              onChange={(e) => setLocalTerminalFont(e.target.value)}
+              placeholder={t("settings.general.terminalFont.default")}
+              className="w-40"
+            />
+          </SettingsRow>
+        </SettingsGroup>
 
-        {/* Terminal Font Size */}
-        <SettingsRow
-          title={t("settings.general.terminalFontSize")}
-          description={t("settings.general.terminalFontSize.description")}
-        >
-          <Input
-            type="number"
-            min={8}
-            max={32}
-            value={terminalFontSize}
-            onChange={(e) => setConfig("terminalFontSize", Number(e.target.value))}
-            className="w-24"
-          />
-        </SettingsRow>
+        {/* Advanced */}
+        <SettingsGroup title={t("settings.general.group.advanced")}>
+          <SettingsRow
+            title={t("settings.general.runOnStartup")}
+            description={t("settings.general.runOnStartup.description")}
+          >
+            <Switch checked={runOnStartup} onCheckedChange={handleRunOnStartupChange} />
+          </SettingsRow>
 
-        {/* Terminal Font */}
-        <SettingsRow
-          title={t("settings.general.terminalFont")}
-          description={t("settings.general.terminalFont.description")}
-        >
-          <Input
-            type="text"
-            value={localTerminalFont}
-            onChange={(e) => setLocalTerminalFont(e.target.value)}
-            placeholder={t("settings.general.terminalFont.default")}
-            className="w-40"
-          />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.general.multiProjectSupport")}
+            description={t("settings.general.multiProjectSupport.description")}
+          >
+            <Switch
+              checked={multiProjectSupport}
+              onCheckedChange={(v) => setConfig("multiProjectSupport", v)}
+            />
+          </SettingsRow>
 
-        {/* Developer Mode */}
-        <SettingsRow
-          title={t("settings.general.developerMode")}
-          description={t("settings.general.developerMode.description")}
-        >
-          <Switch checked={developerMode} onCheckedChange={(v) => setConfig("developerMode", v)} />
-        </SettingsRow>
+          <SettingsRow
+            title={t("settings.general.developerMode")}
+            description={t("settings.general.developerMode.description")}
+          >
+            <Switch
+              checked={developerMode}
+              onCheckedChange={(v) => setConfig("developerMode", v)}
+            />
+          </SettingsRow>
+        </SettingsGroup>
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/src/features/settings/components/settings-group.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/settings-group.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { cn } from "../../../lib/utils";
+
+interface SettingsGroupProps {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingsGroup({ title, description, children, className }: SettingsGroupProps) {
+  return (
+    <div className={cn("rounded-[0.625rem] border border-border", className)}>
+      <div className="px-4 pt-3 pb-1">
+        <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          {title}
+        </div>
+        {description && <div className="text-xs text-muted-foreground mt-0.5">{description}</div>}
+      </div>
+      <div className="px-4">{children}</div>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -36,6 +36,9 @@
   "settings.general.terminalFont.default": "Default",
   "settings.general.developerMode": "Developer Mode",
   "settings.general.developerMode.description": "Show debug info in chat input and other places",
+  "settings.general.group.appearance": "Appearance",
+  "settings.general.group.terminal": "Terminal",
+  "settings.general.group.advanced": "Advanced",
 
   "settings.chat": "Chat",
   "settings.chat.model": "Model",
@@ -67,6 +70,8 @@
   "settings.chat.networkInspector.description": "Show API requests in the Network panel. Takes effect on new sessions.",
   "settings.chat.sendMessage": "Send Message",
   "settings.chat.sendMessage.description": "Keyboard shortcut to send messages",
+  "settings.chat.group.model": "Model",
+  "settings.chat.group.behavior": "Behavior",
   "settings.chat.model.auto": "Default (auto)",
   "settings.chat.model.sdkDefault": "SDK Default",
   "settings.chat.selectPlaceholder": "Select...",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -36,6 +36,9 @@
   "settings.general.terminalFont.default": "默认",
   "settings.general.developerMode": "开发者模式",
   "settings.general.developerMode.description": "在聊天输入等位置显示调试信息",
+  "settings.general.group.appearance": "外观",
+  "settings.general.group.terminal": "终端",
+  "settings.general.group.advanced": "高级",
 
   "settings.chat": "聊天",
   "settings.chat.model": "模型",
@@ -67,6 +70,8 @@
   "settings.chat.networkInspector.description": "在网络面板中显示 API 请求。在新会话中生效。",
   "settings.chat.sendMessage": "发送消息",
   "settings.chat.sendMessage.description": "发送消息的键盘快捷键",
+  "settings.chat.group.model": "模型",
+  "settings.chat.group.behavior": "行为",
   "settings.chat.model.auto": "默认（自动）",
   "settings.chat.model.sdkDefault": "SDK 默认",
   "settings.chat.selectPlaceholder": "请选择...",


### PR DESCRIPTION
## Summary

- Add reusable `SettingsGroup` card component (`rounded-[0.625rem]` border, uppercase title, optional description)
- General panel: 3 groups — Appearance (Language, Theme), Terminal (Font Size, Font), Advanced (Run on Startup, Multi-Project, Developer Mode)
- Chat panel: 2 groups — Model (Model selection), Behavior (Agent Language, Permission Mode, Token Optimization, Network Inspector, Send Message With)
- i18n keys added for both en-US and zh-CN

## Test plan

- [ ] Open Settings > General — verify 3 card groups render correctly
- [ ] Open Settings > Chat — verify 2 card groups render correctly
- [ ] Switch locale to zh-CN — verify group titles display in Chinese
- [ ] Verify all settings within groups still function (toggles, selects, inputs)