### PR TITLE
fix: add timeout to session init to prevent hanging

### DIFF
--- a/docs/designs/2026-03-20-session-init-timeout.md
+++ b/docs/designs/2026-03-20-session-init-timeout.md
@@ -1,0 +1,152 @@
+# Session Init Timeout & Error Recovery
+
+## Problem
+
+Sessions get stuck showing "Starting session..." (正在启动会话...) forever when `initializationResult()` hangs or the network interceptor subprocess fails to start.
+
+**Root cause:** `session-manager.ts:593` calls `q.initializationResult()` with no timeout. If it hangs, the oRPC response never returns to the renderer, `activeSessionId` stays `null`, and the UI condition `!!activeProjectPath && !activeSessionId` remains `true` indefinitely.
+
+**Secondary cause:** When `networkInspector` is enabled, `spawnClaudeCodeProcess` spawns a subprocess that often fails immediately ("Query closed before response received") with a 5s interceptor timeout — but this failure doesn't propagate back to reject the init promise.
+
+## Approach
+
+Timeout + error state in store. On failure, show inline error with retry button in the input toolbar. When `networkInspector` is enabled, hint the user to disable it.
+
+## Changes
+
+### 1. Main Process — Timeout on `initializationResult()`
+
+**File:** `src/main/features/agent/session-manager.ts` (line 593)
+
+Wrap `q.initializationResult()` in `Promise.race` with 10s timeout. On failure (timeout or rejection), clean up the orphaned session entry and clear the dangling timer:
+
+```ts
+const INIT_TIMEOUT_MS = 10_000;
+
+let timer: ReturnType<typeof setTimeout>;
+const timeoutPromise = new Promise<never>((_, reject) => {
+  timer = setTimeout(() => reject(new Error("Session initialization timed out")), INIT_TIMEOUT_MS);
+});
+
+try {
+  const initResult = await Promise.race([q.initializationResult(), timeoutPromise]);
+  clearTimeout(timer!);
+  return initResult;
+} catch (err) {
+  clearTimeout(timer!);
+  await this.closeSession(sessionId); // clean up orphaned session + SDK query
+  throw err;
+}
+```
+
+The existing `router.ts:38-43` try-catch converts errors to `ORPCError("BAD_GATEWAY")` — no router changes needed.
+
+### 1b. Same timeout for `loadSession`
+
+**File:** `src/main/features/agent/session-manager.ts` (line 334)
+
+`loadSession()` also calls `this.initSession()` with no timeout — same hang risk when resuming a session. Extract the timeout + cleanup logic into a shared helper (or just apply the same `Promise.race` pattern) so both `createSession` and `loadSession` are protected.
+
+### 2. Renderer Store — Add `sessionInitError`
+
+**File:** `src/renderer/src/features/agent/store.ts`
+
+Add to `AgentState`:
+
+```ts
+sessionInitError: string | null;
+setSessionInitError: (error: string | null) => void;
+```
+
+Initial value: `null`. This is separate from per-session state because the error occurs before a session exists in the store. Whether `networkInspector` is enabled is read directly from `useConfigStore` in the UI component — no duplication needed.
+
+### 3. Renderer — Error Handling
+
+**File:** `src/renderer/src/features/agent/hooks/use-new-session.ts`
+
+In `createNewSession()`:
+
+- On catch: call `setSessionInitError(error.message)`
+- On success (before `registerSessionInStore`): call `setSessionInitError(null)` to clear any previous error
+
+`preWarmSession()` also calls `createSession` with no error handling. Add a `.catch()` that logs the failure. No UI error needed (it's a background optimization), but ensure a failed pre-warm doesn't leave a stale entry that `findPreWarmedSession()` would try to reuse.
+
+**File:** `src/renderer/src/features/agent/components/agent-chat.tsx`
+
+In the `auto-create` effect (line 153):
+
+- The existing `.catch()` currently just logs — also call `setSessionInitError(error.message)`
+- Guard the catch against project switches: only set the error if `initializedPathRef.current` still matches `activeProjectPath`, otherwise the error belongs to a stale project:
+
+```ts
+.catch((error) => {
+  if (initializedPathRef.current === activeProjectPath) {
+    setSessionInitError(error instanceof Error ? error.message : String(error));
+  }
+});
+```
+
+Add a `retry` callback that directly calls `createNewSession()` (do NOT rely on resetting the ref to re-trigger the effect — React effects don't re-run on ref changes):
+
+```ts
+const handleRetry = useCallback(() => {
+  if (!activeProjectPath) return;
+  setSessionInitError(null); // optimistic: show spinner immediately
+  createNewSession(activeProjectPath).catch((error) => {
+    setSessionInitError(error instanceof Error ? error.message : String(error));
+  });
+}, [activeProjectPath, createNewSession, setSessionInitError]);
+```
+
+Pass `sessionInitError` and `onRetry` down to `MessageInput` -> `InputToolbar`.
+
+### 4. UI — InputToolbar Error + Retry
+
+**File:** `src/renderer/src/features/agent/components/input-toolbar.tsx`
+
+Add props: `sessionInitError?: string | null`, `onRetry?: () => void`.
+
+Replace the current `sessionInitializing` block (lines 89-93 + 105-108):
+
+- **`sessionInitializing && !sessionInitError`**: current behavior (pulsing "Starting session..." + spinner)
+- **`sessionInitError`**: error text + retry button. If `useConfigStore((s) => s.networkInspector)` is `true`, append hint to disable Network Inspector in Settings. Retry button replaces the spinner position (right side). Error text replaces the "Starting session..." position (left side).
+
+### 5. i18n Keys
+
+**File:** `src/renderer/src/locales/en-US.json`
+
+```json
+"chat.sessionInitFailed": "Session failed to start",
+"chat.sessionInitRetry": "Retry",
+"chat.sessionInitNetworkHint": "Try disabling Network Inspector in Settings and retry"
+```
+
+**File:** `src/renderer/src/locales/zh-CN.json`
+
+```json
+"chat.sessionInitFailed": "会话启动失败",
+"chat.sessionInitRetry": "重试",
+"chat.sessionInitNetworkHint": "尝试在设置中关闭网络检查器后重试"
+```
+
+## Known Gaps (out of scope)
+
+The following callers also use `createSession` and could hang, but are lower priority since they're user-initiated actions with existing error handling or fallbacks:
+
+- `handleProviderSwitch` in `input-toolbar.tsx` — switches provider on an empty session
+- `handleContextClear` in `chat-manager.ts` — creates a new session after context clear (already has try-catch with fallback)
+- `invalidateNewSessions` in `chat-manager.ts` — recreates sessions after config change
+
+These can be addressed as follow-ups if the timeout fix surfaces errors in those paths.
+
+## Files Modified
+
+| File                                                           | Change                                            |
+| -------------------------------------------------------------- | ------------------------------------------------- |
+| `src/main/features/agent/session-manager.ts`                   | 10s timeout on `initializationResult()`           |
+| `src/renderer/src/features/agent/store.ts`                     | Add `sessionInitError` + setter                   |
+| `src/renderer/src/features/agent/hooks/use-new-session.ts`     | Set error on catch, clear on success              |
+| `src/renderer/src/features/agent/components/agent-chat.tsx`    | Wire error/retry to effect + pass to InputToolbar |
+| `src/renderer/src/features/agent/components/input-toolbar.tsx` | Render error + retry + networkInspector hint      |
+| `src/renderer/src/locales/en-US.json`                          | Add 3 i18n keys                                   |
+| `src/renderer/src/locales/zh-CN.json`                          | Add 3 i18n keys                                   |

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -82,6 +82,9 @@ function listSessionFiles(filter?: string): string[] {
 /** Auto-cancel permission requests after 5 minutes of no UI response. */
 export const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000;
 
+/** Timeout for SDK initializationResult() to prevent hanging sessions. */
+const INIT_TIMEOUT_MS = 10_000;
+
 const ENV_BLOCKLIST = new Set([
   "ELECTRON_RUN_AS_NODE",
   "NODE_OPTIONS",
@@ -288,7 +291,7 @@ export class SessionManager {
       provider?.id ?? "(none)",
     );
 
-    const initResult = await this.initSession(sessionId, cwd, {
+    const initResult = await this.initSessionWithTimeout(sessionId, cwd, {
       model: modelSetting?.model,
       provider,
     });
@@ -331,7 +334,7 @@ export class SessionManager {
       ? readProviderModelSetting(sessionId, cwd, provider, this.configStore, this.projectStore)
       : readModelSetting(sessionId, cwd);
 
-    const capabilities = await this.initSession(sessionId, cwd, {
+    const capabilities = await this.initSessionWithTimeout(sessionId, cwd, {
       model: modelSetting?.model,
       resume: sessionId,
       provider,
@@ -591,6 +594,31 @@ export class SessionManager {
       pendingRequests,
     });
     return q.initializationResult();
+  }
+
+  /** Wrap initSession with a timeout to prevent hanging sessions. */
+  private async initSessionWithTimeout(
+    sessionId: string,
+    cwd: string,
+    opts?: { model?: string; resume?: string; provider?: Provider },
+  ): Promise<Awaited<ReturnType<Query["initializationResult"]>>> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error("Session initialization timed out")),
+        INIT_TIMEOUT_MS,
+      );
+    });
+
+    try {
+      const result = await Promise.race([this.initSession(sessionId, cwd, opts), timeoutPromise]);
+      clearTimeout(timer!);
+      return result;
+    } catch (err) {
+      clearTimeout(timer!);
+      await this.closeSession(sessionId);
+      throw err;
+    }
   }
 
   async listSessions(cwd?: string): Promise<SessionInfo[]> {

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -97,6 +97,8 @@ export function AgentChat() {
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
   const setAgentSessions = useAgentStore((s) => s.setAgentSessions);
   const sessions = useAgentStore((s) => s.sessions);
+  const sessionInitError = useAgentStore((s) => s.sessionInitError);
+  const setSessionInitError = useAgentStore((s) => s.setSessionInitError);
 
   const { createNewSession } = useNewSession();
 
@@ -159,8 +161,11 @@ export function AgentChat() {
           "effect[auto-create]: FAILED error=%s",
           error instanceof Error ? error.message : String(error),
         );
+        if (initializedPathRef.current === activeProjectPath) {
+          setSessionInitError(error instanceof Error ? error.message : String(error));
+        }
       });
-  }, [activeProjectPath, createNewSession]);
+  }, [activeProjectPath, createNewSession, setSessionInitError]);
 
   const handleSend = (message: string, attachments?: ImageAttachment[]) => {
     chatLog(
@@ -181,6 +186,14 @@ export function AgentChat() {
 
   const sessionInitializing = !!activeProjectPath && !activeSessionId;
 
+  const handleRetry = useCallback(() => {
+    if (!activeProjectPath) return;
+    setSessionInitError(null);
+    createNewSession(activeProjectPath).catch((error) => {
+      setSessionInitError(error instanceof Error ? error.message : String(error));
+    });
+  }, [activeProjectPath, createNewSession, setSessionInitError]);
+
   // State 1: No session yet (or new empty session) — show welcome panel with input
   if (!activeSession || activeSession.isNew) {
     return (
@@ -192,6 +205,8 @@ export function AgentChat() {
           streaming={false}
           disabled={!activeProjectPath}
           sessionInitializing={sessionInitializing}
+          sessionInitError={sessionInitError}
+          onRetry={handleRetry}
           cwd={cwd}
         />
         {cwd && (

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -6,6 +6,7 @@ import {
   FolderOpen,
   Globe,
   Paperclip,
+  RotateCw,
   SendHorizonal,
   Settings,
   Shield,
@@ -48,6 +49,8 @@ type Props = {
   streaming: boolean;
   disabled?: boolean;
   sessionInitializing?: boolean;
+  sessionInitError?: string | null;
+  onRetry?: () => void;
   onSend: () => void;
   onCancel: () => void;
   onAttach: () => void;
@@ -58,12 +61,15 @@ export function InputToolbar({
   streaming,
   disabled,
   sessionInitializing,
+  sessionInitError,
+  onRetry,
   onSend,
   onCancel,
   onAttach,
   activeSessionId,
 }: Props) {
   const sendMessageWith = useConfigStore((s) => s.sendMessageWith);
+  const networkInspector = useConfigStore((s) => s.networkInspector);
 
   const { t } = useTranslation();
 
@@ -86,11 +92,18 @@ export function InputToolbar({
       </Button>
       <ModelSelect activeSessionId={activeSessionId} disabled={disabled || streaming} />
       <PermissionModeSelect activeSessionId={activeSessionId} disabled={disabled || streaming} />
-      {sessionInitializing && (
+      {sessionInitError ? (
+        <span className="text-xs text-destructive">
+          {t("chat.sessionInitFailed")}
+          {networkInspector && (
+            <span className="text-muted-foreground ml-1">— {t("chat.sessionInitNetworkHint")}</span>
+          )}
+        </span>
+      ) : sessionInitializing ? (
         <span className="text-xs text-muted-foreground animate-pulse">
           {t("chat.sessionInitializing")}
         </span>
-      )}
+      ) : null}
       <div className="flex-1" />
       {streaming ? (
         <Button
@@ -101,6 +114,17 @@ export function InputToolbar({
           onClick={onCancel}
         >
           <Square className="h-3.5 w-3.5" />
+        </Button>
+      ) : sessionInitError ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onRetry}
+          title={t("chat.sessionInitRetry")}
+        >
+          <RotateCw className="h-4 w-4 text-muted-foreground" />
         </Button>
       ) : sessionInitializing ? (
         <div className="flex h-7 w-7 items-center justify-center">

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -35,6 +35,8 @@ type Props = {
   streaming: boolean;
   disabled?: boolean;
   sessionInitializing?: boolean;
+  sessionInitError?: string | null;
+  onRetry?: () => void;
   cwd: string;
   dockAttached?: boolean;
 };
@@ -47,6 +49,8 @@ export function MessageInput({
   streaming,
   disabled,
   sessionInitializing,
+  sessionInitError,
+  onRetry,
   cwd,
   dockAttached = false,
 }: Props) {
@@ -347,6 +351,8 @@ export function MessageInput({
             streaming={streaming}
             disabled={disabled}
             sessionInitializing={sessionInitializing}
+            sessionInitError={sessionInitError}
+            onRetry={onRetry}
             onSend={send}
             onCancel={onCancel}
             onAttach={() => fileInputRef.current?.click()}

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-new-session.ts
@@ -10,6 +10,7 @@ const newSessionLog = debug("neovate:agent-new-session");
 
 export function useNewSession() {
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
+  const setSessionInitError = useAgentStore((s) => s.setSessionInitError);
 
   const createNewSession = useCallback(
     async (cwd: string) => {
@@ -28,6 +29,8 @@ export function useNewSession() {
       const { sessionId, commands, models, currentModel, modelScope, providerId } =
         await claudeCodeChatManager.createSession(cwd);
       newSessionLog("createNewSession: created %s currentModel=%s", sessionId, currentModel);
+
+      setSessionInitError(null);
 
       // Guard: if user navigated to another session during the async gap, don't steal focus
       const currentActiveId = useAgentStore.getState().activeSessionId;
@@ -49,7 +52,7 @@ export function useNewSession() {
 
       return sessionId;
     },
-    [setActiveSession],
+    [setActiveSession, setSessionInitError],
   );
 
   /** Pre-warm a new empty session in the background (no activation). */
@@ -64,16 +67,23 @@ export function useNewSession() {
     }
 
     newSessionLog("preWarmSession: creating background session cwd=%s", cwd);
-    const { sessionId, commands, models, currentModel, modelScope, providerId } =
-      await claudeCodeChatManager.createSession(cwd);
-    newSessionLog("preWarmSession: created %s currentModel=%s", sessionId, currentModel);
+    try {
+      const { sessionId, commands, models, currentModel, modelScope, providerId } =
+        await claudeCodeChatManager.createSession(cwd);
+      newSessionLog("preWarmSession: created %s currentModel=%s", sessionId, currentModel);
 
-    registerSessionInStore(
-      sessionId,
-      projectPath,
-      { commands, models, currentModel, modelScope, providerId },
-      false,
-    );
+      registerSessionInStore(
+        sessionId,
+        projectPath,
+        { commands, models, currentModel, modelScope, providerId },
+        false,
+      );
+    } catch (error) {
+      newSessionLog(
+        "preWarmSession: FAILED error=%s",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }, []);
 
   return { createNewSession, preWarmSession };

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -98,6 +98,8 @@ type AgentState = {
   setProviderId: (sessionId: string, providerId: string | undefined) => void;
   setPermissionMode: (sessionId: string, mode: PermissionMode) => void;
   renameSession: (sessionId: string, title: string) => Promise<void>;
+  sessionInitError: string | null;
+  setSessionInitError: (error: string | null) => void;
 };
 
 export const useAgentStore = create<AgentState>()(
@@ -107,6 +109,7 @@ export const useAgentStore = create<AgentState>()(
     agentSessions: [],
     sessionsLoaded: false,
     unseenTurnResults: new Map(),
+    sessionInitError: null,
     _nextMessageId: 0,
 
     setActiveSession: (sessionId) => {
@@ -269,6 +272,10 @@ export const useAgentStore = create<AgentState>()(
         const session = state.sessions.get(sessionId);
         if (session) session.permissionMode = mode;
       });
+    },
+
+    setSessionInitError: (error) => {
+      set({ sessionInitError: error });
     },
 
     renameSession: async (sessionId, title) => {

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -337,5 +337,8 @@
   "chat.clearSessionOverride": "Clear session override",
   "chat.providerSwitchHint": "Provider switch requires a new session",
   "chat.messageActions": "Message actions",
-  "chat.sessionInitializing": "Starting session..."
+  "chat.sessionInitializing": "Starting session...",
+  "chat.sessionInitFailed": "Session failed to start",
+  "chat.sessionInitRetry": "Retry",
+  "chat.sessionInitNetworkHint": "Try disabling Network Inspector in Settings and retry"
 }

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -339,5 +339,8 @@
   "chat.clearSessionOverride": "清除会话覆盖",
   "chat.providerSwitchHint": "切换服务商需要新建会话",
   "chat.messageActions": "消息操作",
-  "chat.sessionInitializing": "正在启动会话..."
+  "chat.sessionInitializing": "正在启动会话...",
+  "chat.sessionInitFailed": "会话启动失败",
+  "chat.sessionInitRetry": "重试",
+  "chat.sessionInitNetworkHint": "尝试在设置中关闭网络检查器后重试"
 }


### PR DESCRIPTION
## Summary

- Add 10s timeout on `initializationResult()` in `session-manager.ts` for both `createSession` and `loadSession` paths, with orphaned session cleanup on timeout/error
- Add `sessionInitError` state to the agent store so the renderer can display errors
- Show inline error message + retry button in `InputToolbar` when session init fails
- When `networkInspector` config is enabled and init fails, hint the user to disable it and retry
- Add error handling to `preWarmSession` to prevent silent failures
- Guard error state against project switches to avoid showing stale errors from wrong project

## Test plan

- [ ] Verify normal session creation still works (no regressions)
- [ ] Enable `networkInspector` in settings, verify that if init fails, error + network hint is shown in toolbar
- [ ] Click retry button, verify it clears error and re-attempts session creation
- [ ] Switch projects during a slow init, verify no stale error appears for new project
- [ ] Resume a session (`loadSession` path) — verify timeout also applies
- [ ] Verify i18n keys render correctly in both English and Chinese