### PR TITLE
feat: incremental show-more for per-project session list

### DIFF
--- a/docs/designs/2026-03-20-incremental-show-more.md
+++ b/docs/designs/2026-03-20-incremental-show-more.md
@@ -1,0 +1,72 @@
+# Incremental "Show More" in Per-Project Session List
+
+## Problem
+
+In multi-project mode, the per-project accordion expands sessions with a binary toggle: show first 5 or show all. For projects with many sessions, "show all" dumps too many items at once.
+
+## Scope
+
+Only `ProjectSessions` in `project-accordion-list.tsx`. `ChronologicalList` keeps its existing behavior.
+
+## Design
+
+### State change
+
+```diff
+- const [expanded, setExpanded] = useState(false);
++ const [visibleCount, setVisibleCount] = useState(DEFAULT_SESSION_LIMIT);
+```
+
+### Derived values
+
+```ts
+const visibleItems = items.slice(0, visibleCount);
+const remainingCount = items.length - visibleCount;
+```
+
+### Button logic (single button, swaps label)
+
+| Condition                                                                      | Label                                                                             | Action                                            |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `remainingCount > 0`                                                           | `Show ${Math.min(DEFAULT_SESSION_LIMIT, remainingCount)} more of ${items.length}` | `setVisibleCount(c => c + DEFAULT_SESSION_LIMIT)` |
+| `visibleCount > DEFAULT_SESSION_LIMIT && items.length > DEFAULT_SESSION_LIMIT` | `Show less`                                                                       | `setVisibleCount(DEFAULT_SESSION_LIMIT)`          |
+| `items.length <= DEFAULT_SESSION_LIMIT`                                        | (no button)                                                                       | -                                                 |
+
+### Animation
+
+Use `motion` (project standard) to animate newly revealed items. Wrap each session item in `motion.li` with a fade-in/slide-down via `AnimatePresence`:
+
+```tsx
+import { AnimatePresence, motion } from "motion/react";
+
+<AnimatePresence initial={false}>
+  {visibleItems.map((item) => {
+    const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+    return (
+      <motion.li
+        key={id}
+        initial={{ opacity: 0, height: 0 }}
+        animate={{ opacity: 1, height: "auto" }}
+        exit={{ opacity: 0, height: 0, transition: { duration: 0 } }}
+        transition={{ duration: 0.15 }}
+      >
+        <UnifiedSessionItem ... />
+      </motion.li>
+    );
+  })}
+</AnimatePresence>
+```
+
+### UX decisions
+
+- "Show less" always resets to the initial 5 (not decremental).
+- Only one button shown at a time; it swaps between "Show N more of X" and "Show less".
+- `DEFAULT_SESSION_LIMIT` stays at 5.
+- Total count shown in "Show more" label to give users context on list depth.
+- "Show less" condition guards against stale state: `visibleCount > DEFAULT_SESSION_LIMIT && items.length > DEFAULT_SESSION_LIMIT`. Prevents showing "Show less" when sessions are deleted below the default limit.
+- Newly revealed items animate in with fade + height transition (motion library).
+- Collapse (exit) is instant (`duration: 0`) to avoid sluggish feel when many items disappear at once.
+
+### Files changed
+
+- `packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx` (ProjectSessions component only)

--- a/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/project-accordion-list.tsx
@@ -15,6 +15,7 @@ import { FolderIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import debug from "debug";
 import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { memo, useCallback, useMemo, useState } from "react";
 
 import type { Project } from "../../../../../shared/features/project/types";
@@ -41,12 +42,12 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
   const sessionsLoaded = useAgentStore((s) => s.sessionsLoaded);
   const loadSession = useLoadSession(project.path);
   const [restoring, setRestoring] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(DEFAULT_SESSION_LIMIT);
 
   const items = useFilteredSessions({ projectPath: project.path, filter: "unpinned" });
 
-  const visibleItems = expanded ? items : items.slice(0, DEFAULT_SESSION_LIMIT);
-  const hiddenCount = items.length - DEFAULT_SESSION_LIMIT;
+  const visibleItems = items.slice(0, visibleCount);
+  const remainingCount = items.length - visibleCount;
 
   const switchToProjectByPath = useProjectStore((s) => s.switchToProjectByPath);
 
@@ -77,28 +78,44 @@ const ProjectSessions = memo(function ProjectSessions({ project }: { project: Pr
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {visibleItems.map((item) => {
-        const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
-        return (
-          <UnifiedSessionItem
-            key={id}
-            item={item}
-            activeSessionId={activeSessionId}
-            isPinned={false}
-            restoring={restoring}
-            onActivate={handleActivate}
-            onLoad={handleLoad}
-          />
-        );
-      })}
-      {hiddenCount > 0 && (
+      <AnimatePresence initial={false}>
+        {visibleItems.map((item) => {
+          const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+          return (
+            <motion.li
+              key={id}
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0, transition: { duration: 0 } }}
+              transition={{ duration: 0.15 }}
+            >
+              <UnifiedSessionItem
+                item={item}
+                activeSessionId={activeSessionId}
+                isPinned={false}
+                restoring={restoring}
+                onActivate={handleActivate}
+                onLoad={handleLoad}
+              />
+            </motion.li>
+          );
+        })}
+      </AnimatePresence>
+      {remainingCount > 0 ? (
         <button
           className="cursor-pointer px-3 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => setVisibleCount((c) => c + DEFAULT_SESSION_LIMIT)}
         >
-          {expanded ? "Show less" : `Show ${hiddenCount} more`}
+          {`Show ${Math.min(DEFAULT_SESSION_LIMIT, remainingCount)} more of ${items.length}`}
         </button>
-      )}
+      ) : visibleCount > DEFAULT_SESSION_LIMIT && items.length > DEFAULT_SESSION_LIMIT ? (
+        <button
+          className="cursor-pointer px-3 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          onClick={() => setVisibleCount(DEFAULT_SESSION_LIMIT)}
+        >
+          Show less
+        </button>
+      ) : null}
     </ul>
   );
 });


### PR DESCRIPTION
## Summary

- Replace binary expand/collapse with incremental "show 5 more" pagination in per-project session accordion
- Default shows 5 sessions per project, each click reveals 5 more with label `Show N more of X`
- "Show less" resets to initial 5 (only appears when fully expanded)
- Animated reveal using `motion` (fade-in + height), instant collapse
- Guard against stale state when sessions are deleted below the default limit

## Test plan

- [ ] Open multi-project mode with a project that has >5 sessions
- [ ] Verify only 5 sessions shown initially
- [ ] Click "Show more" and verify 5 more appear with animation
- [ ] Continue clicking until all sessions are shown, verify "Show less" appears
- [ ] Click "Show less" and verify it resets to 5
- [ ] Delete sessions while expanded, verify no stale "Show less" button
- [ ] Verify chronological list view is unaffected