### PR TITLE
feat: add Cmd+R shortcut to refresh changes view

### DIFF
--- a/packages/desktop/src/renderer/src/plugins/changes/changes-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/changes/changes-view.tsx
@@ -83,7 +83,7 @@ export default memo(function ChangesView() {
   const { resolvedTheme } = useTheme();
   const activeProject = useProjectStore((s) => s.activeProject);
   const { sessionId } = useActiveSession();
-  const { viewId, viewState: savedState } = useContentPanelViewContext();
+  const { viewId, viewState: savedState, isActive } = useContentPanelViewContext();
 
   const [category, setCategory] = useState<ChangesCategory>(
     (savedState.category as ChangesCategory) || "unstaged",
@@ -229,6 +229,19 @@ export default memo(function ChangesView() {
     window.addEventListener("neovate:open-changes", handler);
     return () => window.removeEventListener("neovate:open-changes", handler);
   }, []);
+
+  // Cmd+R to refresh
+  useEffect(() => {
+    if (!isActive) return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "r") {
+        e.preventDefault();
+        refresh();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [refresh, isActive]);
 
   // Scroll to file from file tree — force visible to bypass intersection observer
   const diffContainerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- Adds `Cmd+R` (`Ctrl+R` on non-Mac) keyboard shortcut to refresh the changes panel
- Shortcut is scoped to only fire when the changes tab is the active content panel view

## Test plan
- [ ] Open the changes panel and press `Cmd+R` — should refresh the file list
- [ ] Switch to another content panel tab (e.g. terminal) and press `Cmd+R` — should not trigger refresh
- [ ] Verify refresh works for all categories (unstaged, staged, last-turn, branch)