### PR TITLE
feat: support GitHub tree URLs in GitInstaller

### DIFF
--- a/docs/designs/2026-03-21-git-tree-url.md
+++ b/docs/designs/2026-03-21-git-tree-url.md
@@ -1,0 +1,118 @@
+# Git Tree URL Support in GitInstaller
+
+## Problem
+
+The `GitInstaller` doesn't handle GitHub tree URLs with subdirectory paths. When given a URL like `https://github.com/piomin/claude-ai-spring-boot/tree/main/.claude/skills`:
+
+- `normalizeUrl()` passes the tree URL directly to `git clone` → **clone fails**
+- `scan()` always scans from repo root — no awareness of subdirectory
+- `install()` same issue
+- `getLatestVersion()` passes tree URL to `git ls-remote` → **fails**
+
+`extractFolderName()` in `skill-utils.ts` already parses tree URLs for naming purposes, but the actual git operations never use the parsed branch/subpath.
+
+## Scope
+
+**Single file change:** `packages/desktop/src/main/features/skills/installers/git.ts`
+
+No changes to `skill-utils.ts`, `skills-service.ts`, shared types, or renderer UI.
+
+## Design
+
+### New `parseSourceRef()` method
+
+Replace the existing `normalizeUrl(sourceRef): string` with:
+
+```ts
+private parseSourceRef(sourceRef: string): { url: string; branch?: string; subpath?: string }
+```
+
+**Parsing rules:**
+
+| Input                                                   | url                                | branch | subpath          |
+| ------------------------------------------------------- | ---------------------------------- | ------ | ---------------- |
+| `user/repo`                                             | `https://github.com/user/repo.git` | —      | —                |
+| `https://github.com/user/repo`                          | `https://github.com/user/repo.git` | —      | —                |
+| `https://github.com/user/repo.git`                      | `https://github.com/user/repo.git` | —      | —                |
+| `https://github.com/user/repo/tree/main`                | `https://github.com/user/repo.git` | `main` | —                |
+| `https://github.com/user/repo/tree/main/.claude/skills` | `https://github.com/user/repo.git` | `main` | `.claude/skills` |
+| `git:https://example.com/repo.git`                      | `https://example.com/repo.git`     | —      | —                |
+
+**Tree URL regex:** `/^(https?:\/\/[^/]+\/[^/]+\/[^/]+?)(?:\.git)?\/tree\/([^/]+)(?:\/(.+))?$/`
+
+Note: `.git` is stripped before matching the tree path to handle `repo.git/tree/...` URLs. Trailing slashes are stripped from `subpath` to handle URLs like `.../tree/main/.claude/skills/`.
+
+### Updated `scan()` — with sparse checkout optimization
+
+When `subpath` is specified, use sparse checkout to only download files under that path (much faster for large repos):
+
+```ts
+async scan(sourceRef: string) {
+  const { url, branch, subpath } = this.parseSourceRef(sourceRef);
+
+  if (subpath) {
+    // Sparse checkout: only download the subpath
+    const args = ["clone", "--depth", "1", "--filter=blob:none", "--sparse"];
+    if (branch) args.push("--branch", branch);
+    args.push(url, tmpDir);
+    await execFileAsync("git", args, { timeout: 60_000, env });
+    await execFileAsync("git", ["-C", tmpDir, "sparse-checkout", "set", subpath], {
+      timeout: 30_000, env,
+    });
+    const scanRoot = path.join(tmpDir, subpath);
+    return scanSkillDirs(scanRoot);
+  } else {
+    // Full shallow clone (existing behavior)
+    const args = ["clone", "--depth", "1"];
+    if (branch) args.push("--branch", branch);
+    args.push(url, tmpDir);
+    await execFileAsync("git", args, { timeout: 60_000, env });
+    return scanSkillDirs(tmpDir);
+  }
+}
+```
+
+### Updated `install()`
+
+Same pattern: parse, clone (sparse if subpath), resolve source from `subpath + skillName`.
+
+### Updated `installFromPreview()`
+
+When subpath is present, skill source paths need to be resolved relative to `subpath` within the clone. The `resolveSkillSource()` call must account for the subpath prefix stored during `scan()`.
+
+Store `subpath` in the preview metadata:
+
+```ts
+private previewDirs = new Map<string, { tmpDir: string; sourceRef: string; subpath?: string }>();
+```
+
+Then in `installFromPreview()`, prepend subpath when resolving skill source:
+
+```ts
+const basePath = preview.subpath ? path.join(preview.tmpDir, preview.subpath) : preview.tmpDir;
+const src = resolveSkillSource(basePath, sp);
+```
+
+### Updated `getLatestVersion()`
+
+Uses `parsed.url` (clean repo URL without tree path) for `git ls-remote`.
+
+### Conflict handling
+
+Existing behavior in the preview → select → install flow already handles this:
+
+- `scanSkillDirs()` lists what's available
+- User picks from the list in the UI
+- `installFromPreview()` copies selected skills to target
+
+### User selection
+
+Already handled by the 2-phase preview flow:
+
+1. `scan()` returns `PreviewSkill[]` — user sees checkboxes in `SkillAddModal`
+2. User selects which skills to install
+3. `installFromPreview()` installs only selected ones
+
+## Known Limitations
+
+- **Branch names with slashes** (e.g., `feature/v2`) are not supported in tree URLs. The parser takes the first path segment after `/tree/` as the branch name. Slashed branches will fail with a clear git clone error. This covers the vast majority of use cases since skill repos rarely use slashed branch names.

--- a/packages/desktop/src/main/features/skills/installers/git.ts
+++ b/packages/desktop/src/main/features/skills/installers/git.ts
@@ -16,7 +16,7 @@ const execFileAsync = promisify(execFile);
 const log = debug("neovate:skills:git");
 
 export class GitInstaller implements SkillInstaller {
-  private previewDirs = new Map<string, { tmpDir: string; sourceRef: string }>();
+  private previewDirs = new Map<string, { tmpDir: string; sourceRef: string; subpath?: string }>();
 
   detect(sourceRef: string): boolean {
     if (sourceRef.startsWith("prebuilt:") || sourceRef.startsWith("npm:")) return false;
@@ -30,33 +30,29 @@ export class GitInstaller implements SkillInstaller {
   async scan(sourceRef: string): Promise<{ previewId: string; skills: PreviewSkill[] }> {
     log("scan", { sourceRef });
     const env = await shellEnvService.getEnv();
-    const url = this.normalizeUrl(sourceRef);
+    const { url, branch, subpath } = this.parseSourceRef(sourceRef);
     const previewId = randomUUID();
     const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${previewId}`);
 
-    await execFileAsync("git", ["clone", "--depth", "1", url, tmpDir], {
-      timeout: 60_000,
-      env,
-    });
+    await this.cloneRepo({ url, branch, subpath, tmpDir, env });
 
-    this.previewDirs.set(previewId, { tmpDir, sourceRef });
-    const skills = await scanSkillDirs(tmpDir);
+    this.previewDirs.set(previewId, { tmpDir, sourceRef, subpath });
+    const scanRoot = subpath ? path.join(tmpDir, subpath) : tmpDir;
+    const skills = await scanSkillDirs(scanRoot);
     return { previewId, skills };
   }
 
   async install(sourceRef: string, skillName: string, targetDir: string): Promise<void> {
     log("install", { sourceRef, skillName, targetDir });
     const env = await shellEnvService.getEnv();
-    const url = this.normalizeUrl(sourceRef);
+    const { url, branch, subpath } = this.parseSourceRef(sourceRef);
     const tmpId = randomUUID();
     const tmpDir = path.join(tmpdir(), `neovate-skill-preview-${tmpId}`);
 
     try {
-      await execFileAsync("git", ["clone", "--depth", "1", url, tmpDir], {
-        timeout: 60_000,
-        env,
-      });
-      const src = resolveSkillSource(tmpDir, skillName);
+      await this.cloneRepo({ url, branch, subpath, tmpDir, env });
+      const baseDir = subpath ? path.join(tmpDir, subpath) : tmpDir;
+      const src = resolveSkillSource(baseDir, skillName);
       const destName = deriveInstallName(skillName, sourceRef);
       const dest = path.join(targetDir, destName);
       const filter = (s: string) => path.basename(s) !== ".git";
@@ -77,9 +73,10 @@ export class GitInstaller implements SkillInstaller {
 
     const installed: string[] = [];
     const filter = (s: string) => path.basename(s) !== ".git";
+    const baseDir = preview.subpath ? path.join(preview.tmpDir, preview.subpath) : preview.tmpDir;
     for (const sp of skillPaths) {
       const destName = deriveInstallName(sp, preview.sourceRef);
-      const src = resolveSkillSource(preview.tmpDir, sp);
+      const src = resolveSkillSource(baseDir, sp);
       const dest = path.join(targetDir, destName);
       await cp(src, dest, { recursive: true, filter });
       installed.push(destName);
@@ -101,7 +98,7 @@ export class GitInstaller implements SkillInstaller {
     log("getLatestVersion", { sourceRef });
     try {
       const env = await shellEnvService.getEnv();
-      const url = this.normalizeUrl(sourceRef);
+      const { url } = this.parseSourceRef(sourceRef);
       const { stdout } = await execFileAsync("git", ["ls-remote", url, "HEAD"], {
         timeout: 15_000,
         env,
@@ -122,12 +119,56 @@ export class GitInstaller implements SkillInstaller {
     }
   }
 
-  private normalizeUrl(sourceRef: string): string {
-    let url = sourceRef.replace(/^git:/, "");
+  private parseSourceRef(sourceRef: string): {
+    url: string;
+    branch?: string;
+    subpath?: string;
+  } {
+    let raw = sourceRef.replace(/^git:/, "");
+
     // user/repo shorthand → github URL
-    if (/^[\w.-]+\/[\w.-]+$/.test(url)) {
-      url = `https://github.com/${url}.git`;
+    if (/^[\w.-]+\/[\w.-]+$/.test(raw)) {
+      return { url: `https://github.com/${raw}.git` };
     }
-    return url;
+
+    // GitHub/GitLab/Bitbucket tree URLs: .../tree/<branch>[/<subpath>]
+    const treeMatch = raw.match(
+      /^(https?:\/\/[^/]+\/[^/]+\/[^/]+?)(?:\.git)?\/tree\/([^/]+)(?:\/(.+))?$/,
+    );
+    if (treeMatch) {
+      const url = `${treeMatch[1]}.git`;
+      const branch = treeMatch[2]!;
+      const subpath = treeMatch[3]?.replace(/\/+$/, ""); // strip trailing slashes
+      return { url, branch, subpath: subpath || undefined };
+    }
+
+    return { url: raw };
+  }
+
+  private async cloneRepo(opts: {
+    url: string;
+    branch?: string;
+    subpath?: string;
+    tmpDir: string;
+    env: Record<string, string>;
+  }): Promise<void> {
+    const { url, branch, subpath, tmpDir, env } = opts;
+
+    if (subpath) {
+      // Sparse checkout: only download files under the subpath
+      const cloneArgs = ["clone", "--depth", "1", "--filter=blob:none", "--sparse"];
+      if (branch) cloneArgs.push("--branch", branch);
+      cloneArgs.push(url, tmpDir);
+      await execFileAsync("git", cloneArgs, { timeout: 60_000, env });
+      await execFileAsync("git", ["-C", tmpDir, "sparse-checkout", "set", subpath], {
+        timeout: 30_000,
+        env,
+      });
+    } else {
+      const cloneArgs = ["clone", "--depth", "1"];
+      if (branch) cloneArgs.push("--branch", branch);
+      cloneArgs.push(url, tmpDir);
+      await execFileAsync("git", cloneArgs, { timeout: 60_000, env });
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Replace `normalizeUrl()` with `parseSourceRef()` that extracts `{ url, branch, subpath }` from GitHub tree URLs (e.g., `https://github.com/user/repo/tree/main/.claude/skills`)
- Use sparse checkout (`--filter=blob:none --sparse`) when subpath is specified, so large repos only download the needed files
- Update `scan()`, `install()`, `installFromPreview()`, and `getLatestVersion()` to use parsed source ref
- Handle edge cases: `.git` suffix in URLs, trailing slashes in subpath

## Test plan

- [ ] Install skills from a plain repo URL (e.g., `user/repo`) — existing behavior unchanged
- [ ] Install skills from a tree URL with subpath (e.g., `https://github.com/piomin/claude-ai-spring-boot/tree/main/.claude/skills`)
- [ ] Verify skill selection UI shows only skills under the subpath
- [ ] Verify `getLatestVersion` works with tree URLs (update check)
- [ ] Verify sparse checkout is used when subpath is present (check clone speed on large repo)