### PR TITLE
fix: hide traffic lights when settings page is open

### DIFF
--- a/packages/desktop/src/renderer/src/App.tsx
+++ b/packages/desktop/src/renderer/src/App.tsx
@@ -58,7 +58,7 @@ export default function App() {
   return (
     <>
       <AppLayoutRoot>
-        <AppLayoutTrafficLights />
+        {!showSettings && <AppLayoutTrafficLights />}
 
         <AppLayoutPrimarySidebar>
           <div className="flex h-full flex-col">


### PR DESCRIPTION
## Summary

- Hide `AppLayoutTrafficLights` when the settings page is displayed to avoid visual overlap/conflict with the settings UI

## Test plan

- [ ] Open the app normally — traffic lights visible
- [ ] Open settings — traffic lights hidden
- [ ] Close settings — traffic lights reappear