### PR TITLE
feat: add quick model connectivity check for providers

### DIFF
--- a/docs/designs/2026-03-23-quick-model-test.md
+++ b/docs/designs/2026-03-23-quick-model-test.md
@@ -1,0 +1,119 @@
+# Quick Model Test for Provider Settings
+
+## Problem
+
+The current "Test" button runs a full benchmark (streams 100 tokens, measures TTFT/TPOT/TPS). This takes several seconds per model — too slow when you just want to verify your API key and models are configured correctly.
+
+## Solution
+
+Add a **quick connectivity check** alongside the existing benchmark. The default "Test" click does a fast check (~200-500ms per model). The full benchmark is still accessible via the dropdown menu.
+
+## Contract Change
+
+New `quickCheck` endpoint in `providerContract`:
+
+```ts
+quickCheck: oc
+  .input(z.object({
+    baseURL: z.string().url(),
+    apiKey: z.string().min(1),
+    modelId: z.string(),
+  }))
+  .output(z.object({
+    success: z.boolean(),
+    error: z.string().optional(),
+  })),
+```
+
+## Backend (`router.ts`)
+
+New `quickCheck` handler:
+
+- Creates an Anthropic client with the given baseURL/apiKey
+- Sends a non-streaming `messages.create` with `max_tokens: 1` and a minimal prompt (e.g. `"hi"`)
+- 10s timeout (vs 30s for benchmark)
+- Returns `{ success: true }` or `{ success: false, error: "401 — invalid_api_key" }`
+- Same error formatting as the existing benchmark error handler
+
+## Types (`types.ts`)
+
+No standalone `QuickCheckResult` type — the contract zod schema defines the wire format, and the store maps it directly to the unified `ModelTestResult` (see below).
+
+## Types (`types.ts`) — Unified Result
+
+Replace separate result types with a single discriminated union:
+
+```ts
+export type ModelTestResult =
+  | { type: "quick"; success: boolean; error?: string }
+  | {
+      type: "benchmark";
+      success: boolean;
+      error?: string;
+      ttftMs: number;
+      tpot: number;
+      tps: number;
+      totalTimeMs: number;
+      tokensGenerated: number;
+    };
+```
+
+The existing `BenchmarkResult` type is removed in favor of `ModelTestResult`.
+
+## Store (`store.ts`)
+
+Unified state (replaces separate `benchmarkResults` / `benchmarkingModels`):
+
+- `modelTestResults: Record<string, ModelTestResult>` — keyed by `baseURL:modelId`
+- `testingModels: Record<string, boolean>` — loading state per model
+
+New/changed actions:
+
+- `quickCheckAll(baseURL, apiKey, modelIds)` — **parallel** check of all models via `Promise.all` (fast, ~500ms for 5 models)
+- `checkAll(baseURL, apiKey, modelIds)` — unchanged (sequential benchmark, streams tokens)
+- `clearTestResults(baseURL)` — replaces `clearBenchmarkResults`
+- `cancelTests()` — replaces `cancelBenchmarks`
+
+Quick check results and benchmark results share the same map. Running a full benchmark on a model overwrites its previous quick check result.
+
+## UI Changes (`benchmark-button.tsx`)
+
+The `BenchmarkButton` component changes behavior:
+
+1. **Default click** (main button) -> calls `quickCheckAll` instead of `checkAll`
+2. **Dropdown menu** gains a new structure:
+   - "Full Benchmark" (all models) — calls existing `checkAll`
+   - Per-model items like "Test: model-a" — calls `quickCheckAll` for single model
+3. Single-model providers always show the split button (dropdown with "Full Benchmark") so users can access the full benchmark regardless of model count.
+
+## UI Changes (`providers-panel.tsx`)
+
+Per-model row display:
+
+- **Quick check running**: spinner (same as now)
+- **Quick check success**: green `Check` icon (lucide)
+- **Quick check failure**: red error badge + error text (same as current benchmark failure)
+- **Benchmark results**: same TTFT/TPOT/TPS badges as today (shown when a full benchmark completes, overrides the quick check display)
+
+Both result types live in a single `modelTestResults` map — a benchmark result naturally supersedes a quick check result since they share the same `baseURL:modelId` key.
+
+## Key Design Decision: Parallel Quick Checks
+
+Quick checks use `Promise.all` instead of sequential execution. Since each check is a single non-streaming request (`max_tokens: 1`), there's no reason to serialize them. This means testing 5 models completes in ~500ms (one round-trip) rather than ~2.5s (five sequential round-trips).
+
+Full benchmarks remain sequential because they stream tokens and measuring TPOT/TPS accurately requires dedicated bandwidth.
+
+## Files Changed
+
+| File                                                                       | Change                                                                                                                                                                      |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/shared/features/provider/contract.ts`                                 | Add `quickCheck` endpoint                                                                                                                                                   |
+| `src/shared/features/provider/types.ts`                                    | Add `ModelTestResult` union, remove `BenchmarkResult`                                                                                                                       |
+| `src/main/features/provider/router.ts`                                     | Add `quickCheck` handler (non-streaming, `max_tokens: 1`)                                                                                                                   |
+| `src/renderer/src/features/provider/store.ts`                              | Replace `benchmarkResults`/`benchmarkingModels` with unified `modelTestResults`/`testingModels`; add parallel `quickCheckAll`; update `checkAll` to write `ModelTestResult` |
+| `src/renderer/src/features/provider/benchmark-button.tsx`                  | Default click -> quick check; dropdown adds "Full Benchmark"                                                                                                                |
+| `src/renderer/src/features/provider/benchmark-metrics.tsx`                 | Accept `ModelTestResult` instead of `BenchmarkResult`                                                                                                                       |
+| `src/renderer/src/features/provider/benchmark-tooltip.tsx`                 | Accept `ModelTestResult` instead of `BenchmarkResult`                                                                                                                       |
+| `src/renderer/src/features/settings/components/panels/providers-panel.tsx` | Show quick check results (check icon / error) per model row; read from unified `modelTestResults`                                                                           |
+
+No new files needed. New i18n keys: `settings.providers.benchmark.quickTest` and `settings.providers.benchmark.fullBenchmark` for the dropdown labels.

--- a/packages/desktop/src/main/features/provider/router.ts
+++ b/packages/desktop/src/main/features/provider/router.ts
@@ -2,7 +2,7 @@ import { Anthropic } from "@anthropic-ai/sdk";
 import { ORPCError, implement } from "@orpc/server";
 import debug from "debug";
 
-import type { BenchmarkResult, Provider } from "../../../shared/features/provider/types";
+import type { BenchmarkModelTestResult, Provider } from "../../../shared/features/provider/types";
 import type { AppContext } from "../../router";
 
 import { providerContract } from "../../../shared/features/provider/contract";
@@ -18,6 +18,7 @@ const BENCHMARK_PROMPT =
   "Write a short paragraph explaining what a benchmark test measures in software engineering.";
 const BENCHMARK_MAX_TOKENS = 100;
 const BENCHMARK_TIMEOUT_MS = 30_000;
+const QUICK_CHECK_TIMEOUT_MS = 10_000;
 
 function createBenchmarkClient(provider: Provider): Anthropic {
   return new Anthropic({
@@ -32,11 +33,57 @@ function calculateAvg(values: number[]): number | null {
   return nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
 }
 
+async function runQuickCheck(
+  provider: Provider,
+  modelId: string,
+  externalSignal?: AbortSignal,
+): Promise<{ success: boolean; error?: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), QUICK_CHECK_TIMEOUT_MS);
+  const onExternalAbort = () => controller.abort();
+  externalSignal?.addEventListener("abort", onExternalAbort);
+
+  try {
+    const client = createBenchmarkClient(provider);
+    await client.messages.create(
+      {
+        model: modelId,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { signal: controller.signal },
+    );
+    return { success: true };
+  } catch (err) {
+    log("quickCheck failed: provider=%s model=%s error=%s", provider.id, modelId, err);
+
+    let error: string;
+    if (err instanceof Anthropic.APIError) {
+      const parts = [`${err.status}`];
+      const body = err.error as Record<string, unknown> | undefined;
+      const inner = body?.error as Record<string, unknown> | undefined;
+      if (inner?.type) parts.push(String(inner.type));
+      if (inner?.message) parts.push(String(inner.message));
+      else if (err.message) parts.push(err.message);
+      error = parts.join(" — ");
+    } else if (err instanceof Error) {
+      error = err.message;
+    } else {
+      error = String(err);
+    }
+
+    return { success: false, error };
+  } finally {
+    clearTimeout(timeout);
+    externalSignal?.removeEventListener("abort", onExternalAbort);
+  }
+}
+
 async function runBenchmark(
   provider: Provider,
   modelId: string,
   externalSignal?: AbortSignal,
-): Promise<BenchmarkResult> {
+): Promise<Omit<BenchmarkModelTestResult, "type">> {
   const startTime = performance.now();
   let firstTokenTime: number | null = null;
   const tpotValues: number[] = [];
@@ -222,6 +269,12 @@ export const providerRouter = os.provider.router({
   remove: os.provider.remove.handler(({ input, context }) => {
     context.configStore.removeProvider(input.id);
     log("remove: id=%s", input.id);
+  }),
+
+  quickCheck: os.provider.quickCheck.handler(async ({ input, signal }) => {
+    const { baseURL, apiKey, modelId } = input;
+    log("quickCheck: baseURL=%s model=%s", baseURL, modelId);
+    return runQuickCheck({ id: "_check", baseURL, apiKey } as Provider, modelId, signal);
   }),
 
   checkModel: os.provider.checkModel.handler(async ({ input, signal }) => {

--- a/packages/desktop/src/renderer/src/features/provider/benchmark-button.tsx
+++ b/packages/desktop/src/renderer/src/features/provider/benchmark-button.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Gauge, Square } from "lucide-react";
+import { ChevronDown, Gauge, Square, Zap } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -28,53 +28,53 @@ export function BenchmarkButton({
   className,
 }: BenchmarkButtonProps) {
   const { t } = useTranslation();
-  const checkAll = useProviderStore((s) => s.checkAll);
-  const cancelBenchmarks = useProviderStore((s) => s.cancelBenchmarks);
-  const benchmarkingModels = useProviderStore((s) => s.benchmarkingModels);
+  const quickCheckAll = useProviderStore((s) => s.quickCheckAll);
+  const benchmarkAll = useProviderStore((s) => s.benchmarkAll);
+  const cancelTests = useProviderStore((s) => s.cancelTests);
+  const testingModels = useProviderStore((s) => s.testingModels);
   const [running, setRunning] = useState(false);
 
   const modelIds = Object.keys(models);
-  const isAnyRunning = running || modelIds.some((id) => benchmarkingModels[`${baseURL}:${id}`]);
+  const isAnyRunning = running || modelIds.some((id) => testingModels[`${baseURL}:${id}`]);
 
   const showLabel = size !== "icon" && size !== "icon-sm" && size !== "icon-xs";
-  const hasMultipleModels = modelIds.length > 1;
 
-  const handleTestAll = useCallback(async () => {
-    if (isAnyRunning) {
-      cancelBenchmarks();
-      setRunning(false);
-      return;
-    }
-    if (modelIds.length === 0) return;
-    setRunning(true);
-    try {
-      await checkAll(baseURL, apiKey, modelIds);
-      onComplete?.();
-    } catch (e) {
-      if (!(e instanceof DOMException && e.name === "AbortError")) {
-        console.error("Benchmark failed:", e);
+  const runAction = useCallback(
+    async (action: () => Promise<void>) => {
+      if (isAnyRunning) {
+        cancelTests();
+        setRunning(false);
+        return;
       }
-    } finally {
-      setRunning(false);
-    }
-  }, [isAnyRunning, modelIds, baseURL, apiKey, checkAll, cancelBenchmarks, onComplete]);
-
-  const handleTestSingle = useCallback(
-    async (modelId: string) => {
-      if (isAnyRunning) return;
+      if (modelIds.length === 0) return;
       setRunning(true);
       try {
-        await checkAll(baseURL, apiKey, [modelId]);
+        await action();
         onComplete?.();
       } catch (e) {
         if (!(e instanceof DOMException && e.name === "AbortError")) {
-          console.error("Benchmark failed:", e);
+          console.error("Test failed:", e);
         }
       } finally {
         setRunning(false);
       }
     },
-    [isAnyRunning, baseURL, apiKey, checkAll, onComplete],
+    [isAnyRunning, modelIds, cancelTests, onComplete],
+  );
+
+  const handleQuickTest = useCallback(
+    () => runAction(() => quickCheckAll(baseURL, apiKey, modelIds)),
+    [runAction, quickCheckAll, baseURL, apiKey, modelIds],
+  );
+
+  const handleBenchmark = useCallback(
+    () => runAction(() => benchmarkAll(baseURL, apiKey, modelIds)),
+    [runAction, benchmarkAll, baseURL, apiKey, modelIds],
+  );
+
+  const handleQuickTestSingle = useCallback(
+    (modelId: string) => runAction(() => quickCheckAll(baseURL, apiKey, [modelId])),
+    [runAction, quickCheckAll, baseURL, apiKey],
   );
 
   if (isAnyRunning) {
@@ -83,27 +83,11 @@ export function BenchmarkButton({
         variant="destructive-outline"
         size={size}
         className={className}
-        onClick={handleTestAll}
+        onClick={handleQuickTest}
         aria-label={t("settings.providers.benchmark.cancel")}
       >
         <Square className="h-3 w-3" />
         {showLabel && <span>{t("settings.providers.benchmark.cancel")}</span>}
-      </Button>
-    );
-  }
-
-  if (!hasMultipleModels) {
-    return (
-      <Button
-        variant={variant}
-        size={size}
-        className={className}
-        disabled={disabled || modelIds.length === 0}
-        onClick={handleTestAll}
-        aria-label={t("settings.providers.benchmark.testAll")}
-      >
-        <Gauge className="h-3.5 w-3.5" />
-        {showLabel && <span>{t("settings.providers.benchmark.test")}</span>}
       </Button>
     );
   }
@@ -114,23 +98,27 @@ export function BenchmarkButton({
         variant={variant}
         size={size}
         className={`${className ?? ""} rounded-r-none border-r-0`}
-        disabled={disabled}
-        onClick={handleTestAll}
-        aria-label={t("settings.providers.benchmark.testAll")}
+        disabled={disabled || modelIds.length === 0}
+        onClick={handleQuickTest}
+        aria-label={t("settings.providers.benchmark.quickTest")}
       >
-        <Gauge className="h-3.5 w-3.5" />
+        <Zap className="h-3.5 w-3.5" />
         {showLabel && <span>{t("settings.providers.benchmark.test")}</span>}
       </Button>
       <Menu>
         <MenuTrigger
           className={`inline-flex items-center justify-center rounded-l-none border border-input bg-popover px-1 text-foreground shadow-xs/5 hover:bg-accent/50 disabled:pointer-events-none disabled:opacity-64 ${size === "xs" ? "h-7 sm:h-6" : size === "sm" ? "h-8 sm:h-7" : "h-9 sm:h-8"}`}
-          disabled={disabled}
+          disabled={disabled || modelIds.length === 0}
         >
           <ChevronDown className="h-3 w-3" />
         </MenuTrigger>
         <MenuPopup align="end" side="bottom" sideOffset={4}>
+          <MenuItem onClick={handleBenchmark}>
+            <Gauge className="h-3.5 w-3.5" />
+            <span className="text-xs">{t("settings.providers.benchmark.fullBenchmark")}</span>
+          </MenuItem>
           {modelIds.map((id) => (
-            <MenuItem key={id} onClick={() => handleTestSingle(id)}>
+            <MenuItem key={id} onClick={() => handleQuickTestSingle(id)}>
               <code className="text-xs">{id}</code>
               {models[id]?.displayName && (
                 <span className="text-muted-foreground text-xs ml-2">{models[id].displayName}</span>

--- a/packages/desktop/src/renderer/src/features/provider/benchmark-tooltip.tsx
+++ b/packages/desktop/src/renderer/src/features/provider/benchmark-tooltip.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import type { BenchmarkResult } from "../../../../shared/features/provider/types";
+import type { ModelTestResult } from "../../../../shared/features/provider/types";
 
 import {
   formatMs,
@@ -12,7 +12,7 @@ import {
 } from "./benchmark-utils";
 
 interface BenchmarkTooltipProps {
-  result: BenchmarkResult;
+  result: ModelTestResult;
 }
 
 export function BenchmarkTooltipContent({ result }: BenchmarkTooltipProps) {
@@ -24,6 +24,10 @@ export function BenchmarkTooltipContent({ result }: BenchmarkTooltipProps) {
         {result.error || t("settings.providers.benchmark.failed")}
       </div>
     );
+  }
+
+  if (result.type === "quick") {
+    return null;
   }
 
   return (

--- a/packages/desktop/src/renderer/src/features/provider/store.ts
+++ b/packages/desktop/src/renderer/src/features/provider/store.ts
@@ -2,7 +2,7 @@ import debug from "debug";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
-import type { BenchmarkResult, Provider } from "../../../../shared/features/provider/types";
+import type { ModelTestResult, Provider } from "../../../../shared/features/provider/types";
 
 import { client } from "../../orpc";
 
@@ -14,8 +14,8 @@ let benchmarkController: AbortController | null = null;
 type ProviderState = {
   providers: Provider[];
   loaded: boolean;
-  benchmarkResults: Record<string, BenchmarkResult>;
-  benchmarkingModels: Record<string, boolean>;
+  modelTestResults: Record<string, ModelTestResult>;
+  testingModels: Record<string, boolean>;
 
   load: () => Promise<void>;
   addProvider: (input: {
@@ -29,17 +29,18 @@ type ProviderState = {
   }) => Promise<Provider>;
   updateProvider: (id: string, updates: Partial<Omit<Provider, "id">>) => Promise<Provider>;
   removeProvider: (id: string) => Promise<void>;
-  checkAll: (baseURL: string, apiKey: string, modelIds: string[]) => Promise<void>;
-  cancelBenchmarks: () => void;
-  clearBenchmarkResults: (baseURL: string) => void;
+  quickCheckAll: (baseURL: string, apiKey: string, modelIds: string[]) => Promise<void>;
+  benchmarkAll: (baseURL: string, apiKey: string, modelIds: string[]) => Promise<void>;
+  cancelTests: () => void;
+  clearTestResults: (baseURL: string) => void;
 };
 
 export const useProviderStore = create<ProviderState>()(
   immer((set, get) => ({
     providers: [],
     loaded: false,
-    benchmarkResults: {},
-    benchmarkingModels: {},
+    modelTestResults: {},
+    testingModels: {},
 
     load: async () => {
       const providers = await client.provider.list();
@@ -77,8 +78,52 @@ export const useProviderStore = create<ProviderState>()(
       });
     },
 
-    checkAll: async (baseURL, apiKey, modelIds) => {
-      log("checkAll: baseURL=%s models=%o", baseURL, modelIds);
+    quickCheckAll: async (baseURL, apiKey, modelIds) => {
+      log("quickCheckAll: baseURL=%s models=%o", baseURL, modelIds);
+      benchmarkController?.abort();
+
+      const controller = new AbortController();
+      benchmarkController = controller;
+
+      const keys = modelIds.map((id) => `${baseURL}:${id}`);
+
+      // Mark all as testing
+      set((state) => {
+        for (const key of keys) {
+          delete state.modelTestResults[key];
+          state.testingModels[key] = true;
+        }
+      });
+
+      try {
+        const results = await Promise.all(
+          modelIds.map((modelId) =>
+            client.provider
+              .quickCheck({ baseURL, apiKey, modelId }, { signal: controller.signal })
+              .then((r) => ({ modelId, ...r })),
+          ),
+        );
+
+        set((state) => {
+          for (const { modelId, success, error } of results) {
+            const key = `${baseURL}:${modelId}`;
+            state.modelTestResults[key] = { type: "quick", success, error };
+          }
+        });
+      } finally {
+        set((state) => {
+          for (const key of keys) {
+            delete state.testingModels[key];
+          }
+        });
+        if (benchmarkController === controller) {
+          benchmarkController = null;
+        }
+      }
+    },
+
+    benchmarkAll: async (baseURL, apiKey, modelIds) => {
+      log("benchmarkAll: baseURL=%s models=%o", baseURL, modelIds);
       benchmarkController?.abort();
 
       const controller = new AbortController();
@@ -88,25 +133,25 @@ export const useProviderStore = create<ProviderState>()(
         for (const modelId of modelIds) {
           if (controller.signal.aborted) break;
           const key = `${baseURL}:${modelId}`;
-          if (get().benchmarkingModels[key]) continue;
+          if (get().testingModels[key]) continue;
 
-          log("checking model: %s", modelId);
+          log("benchmarking model: %s", modelId);
           set((state) => {
-            delete state.benchmarkResults[key];
-            state.benchmarkingModels[key] = true;
+            delete state.modelTestResults[key];
+            state.testingModels[key] = true;
           });
           try {
             const result = await client.provider.checkModel(
               { baseURL, apiKey, modelId },
               { signal: controller.signal },
             );
-            log("model check result: %s success=%s", modelId, result.success);
+            log("benchmark result: %s success=%s", modelId, result.success);
             set((state) => {
-              state.benchmarkResults[key] = result;
+              state.modelTestResults[key] = { type: "benchmark", ...result };
             });
           } finally {
             set((state) => {
-              delete state.benchmarkingModels[key];
+              delete state.testingModels[key];
             });
           }
         }
@@ -117,22 +162,22 @@ export const useProviderStore = create<ProviderState>()(
       }
     },
 
-    cancelBenchmarks: () => {
+    cancelTests: () => {
       if (benchmarkController) {
-        log("canceling benchmarks");
+        log("canceling tests");
         benchmarkController.abort();
         benchmarkController = null;
         set((state) => {
-          state.benchmarkingModels = {};
+          state.testingModels = {};
         });
       }
     },
 
-    clearBenchmarkResults: (baseURL) => {
+    clearTestResults: (baseURL) => {
       set((state) => {
-        for (const key of Object.keys(state.benchmarkResults)) {
+        for (const key of Object.keys(state.modelTestResults)) {
           if (key.startsWith(`${baseURL}:`)) {
-            delete state.benchmarkResults[key];
+            delete state.modelTestResults[key];
           }
         }
       });

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/providers-panel.tsx
@@ -132,10 +132,10 @@ export const ProvidersPanel = () => {
   const addProvider = useProviderStore((s) => s.addProvider);
   const updateProvider = useProviderStore((s) => s.updateProvider);
   const removeProvider = useProviderStore((s) => s.removeProvider);
-  const benchmarkResults = useProviderStore((s) => s.benchmarkResults);
-  const benchmarkingModels = useProviderStore((s) => s.benchmarkingModels);
-  const cancelBenchmarks = useProviderStore((s) => s.cancelBenchmarks);
-  const clearBenchmarkResults = useProviderStore((s) => s.clearBenchmarkResults);
+  const modelTestResults = useProviderStore((s) => s.modelTestResults);
+  const testingModels = useProviderStore((s) => s.testingModels);
+  const cancelTests = useProviderStore((s) => s.cancelTests);
+  const clearTestResults = useProviderStore((s) => s.clearTestResults);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
@@ -168,8 +168,8 @@ export const ProvidersPanel = () => {
 
   // Cancel in-flight benchmarks when leaving the providers panel
   useEffect(() => {
-    return () => cancelBenchmarks();
-  }, [cancelBenchmarks]);
+    return () => cancelTests();
+  }, [cancelTests]);
 
   const usedBuiltInIds = useMemo(
     () => new Set(providers.map((p) => p.builtInId).filter(Boolean)),
@@ -200,7 +200,7 @@ export const ProvidersPanel = () => {
     setShowTemplatePicker(true);
     setIsCreating(false);
     useProviderStore.setState((state) => {
-      state.benchmarkResults = {};
+      state.modelTestResults = {};
     });
   }, []);
 
@@ -220,14 +220,14 @@ export const ProvidersPanel = () => {
 
   const startEdit = useCallback(
     (p: Provider) => {
-      clearBenchmarkResults(p.baseURL);
+      clearTestResults(p.baseURL);
       setEditingId(p.id);
       setIsCreating(false);
       setShowApiKey(false);
       setForm(providerToForm(p));
       setError(null);
     },
-    [clearBenchmarkResults],
+    [clearTestResults],
   );
 
   const cancel = useCallback(() => {
@@ -686,9 +686,9 @@ export const ProvidersPanel = () => {
             </div>
             <div className="mt-1 space-y-1">
               {Object.entries(form.models).map(([key, entry]) => {
-                const benchKey = `${form.baseURL}:${key}`;
-                const result = benchmarkResults[benchKey];
-                const isRunning = benchmarkingModels[benchKey] ?? false;
+                const testKey = `${form.baseURL}:${key}`;
+                const result = modelTestResults[testKey];
+                const isRunning = testingModels[testKey] ?? false;
                 const failed = result && !isRunning && !result.success;
 
                 return (
@@ -700,7 +700,10 @@ export const ProvidersPanel = () => {
                       )}
                       <div className="ml-auto flex items-center gap-1.5">
                         {isRunning && <Spinner className="h-3 w-3" />}
-                        {result && !isRunning && result.success && (
+                        {result && !isRunning && result.success && result.type === "quick" && (
+                          <Check className="h-3.5 w-3.5 text-success-foreground" />
+                        )}
+                        {result && !isRunning && result.success && result.type === "benchmark" && (
                           <Tooltip>
                             <TooltipTrigger className="cursor-default">
                               <BenchmarkMetrics

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -156,6 +156,8 @@
   "settings.providers.benchmark.total": "Total",
   "settings.providers.benchmark.failed": "Failed",
   "settings.providers.benchmark.cancel": "Cancel",
+  "settings.providers.benchmark.quickTest": "Quick test all models",
+  "settings.providers.benchmark.fullBenchmark": "Full Benchmark",
   "settings.providers.validation.nameRequired": "Name is required",
   "settings.providers.validation.invalidURL": "Invalid base URL",
   "settings.providers.validation.apiKeyRequired": "API key is required",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -156,6 +156,8 @@
   "settings.providers.benchmark.total": "总耗时",
   "settings.providers.benchmark.failed": "失败",
   "settings.providers.benchmark.cancel": "取消",
+  "settings.providers.benchmark.quickTest": "快速测试所有模型",
+  "settings.providers.benchmark.fullBenchmark": "完整基准测试",
   "settings.providers.validation.nameRequired": "名称不能为空",
   "settings.providers.validation.invalidURL": "无效的 API 地址",
   "settings.providers.validation.apiKeyRequired": "API 密钥不能为空",

--- a/packages/desktop/src/shared/features/provider/contract.ts
+++ b/packages/desktop/src/shared/features/provider/contract.ts
@@ -54,6 +54,21 @@ export const providerContract = {
 
   remove: oc.input(z.object({ id: z.string() })).output(type<void>()),
 
+  quickCheck: oc
+    .input(
+      z.object({
+        baseURL: z.string().url(),
+        apiKey: z.string().min(1),
+        modelId: z.string(),
+      }),
+    )
+    .output(
+      z.object({
+        success: z.boolean(),
+        error: z.string().optional(),
+      }),
+    ),
+
   checkModel: oc
     .input(
       z.object({

--- a/packages/desktop/src/shared/features/provider/types.ts
+++ b/packages/desktop/src/shared/features/provider/types.ts
@@ -19,15 +19,24 @@ export type Provider = {
   builtInId?: string;
 };
 
-export type BenchmarkResult = {
+export type QuickCheckModelTestResult = {
+  type: "quick";
+  success: boolean;
+  error?: string;
+};
+
+export type BenchmarkModelTestResult = {
+  type: "benchmark";
+  success: boolean;
+  error?: string;
   ttftMs: number;
   tpot: number;
   tps: number;
   totalTimeMs: number;
   tokensGenerated: number;
-  success: boolean;
-  error?: string;
 };
+
+export type ModelTestResult = QuickCheckModelTestResult | BenchmarkModelTestResult;
 
 export type ProjectProviderConfig = {
   provider?: string;


### PR DESCRIPTION
## Summary

- Add a fast connectivity check (`max_tokens=1`, non-streaming, 10s timeout) as the default "Test" action in provider settings
- Quick checks run in parallel via `Promise.all` (~500ms for 5 models vs several seconds per model with full benchmark)
- Full benchmark remains available via the dropdown menu
- Unify `BenchmarkResult` into a discriminated `ModelTestResult` union (`"quick" | "benchmark"`) with a single results map in the store
- Quick check success shows a green check icon; full benchmark shows TTFT/TPOT/TPS metric badges as before

## Test plan

- [ ] Add a provider with valid API key and multiple models, click "Test" — all models should show green check icons within ~1s
- [ ] Add a provider with invalid API key, click "Test" — all models should show red error badges with error details
- [ ] Use dropdown menu to run "Full Benchmark" — should show TTFT/TPOT/TPS metrics as before
- [ ] Use dropdown to quick-test a single model — only that model should be tested
- [ ] Cancel mid-test — spinner should stop, no results shown for incomplete tests
- [ ] Single-model providers still show the split button with dropdown for full benchmark access