### PR TITLE
feat: show context window remaining % below message input

### DIFF
--- a/docs/designs/2026-03-23-context-left-indicator.md
+++ b/docs/designs/2026-03-23-context-left-indicator.md
@@ -1,0 +1,190 @@
+# Context Left Indicator
+
+**Date:** 2026-03-23
+**Status:** Draft
+
+## Goal
+
+Show remaining context window percentage as text below the message input, next to the branch switcher. Minimal, text-only — e.g. `ctx 78%`. Hover tooltip shows raw token counts.
+
+## Data Source
+
+Two pieces of data, combined on the **main process** side:
+
+1. **`stream_event` → `message_start`** (`BetaRawMessageStartEvent`): carries `BetaMessage.usage` with per-API-call token counts. The **last** `message_start` before a turn ends reflects the actual context window fill level, because each API call sends the full conversation as input.
+
+2. **`SDKResultMessage`** (type: `"result"`): carries `modelUsage: Record<string, ModelUsage>` which includes `contextWindow` (the total context window size for the model).
+
+### Why two sources?
+
+- `SDKResultMessage.usage` is **cumulative billing usage** across all API calls in the turn. Using it for context % would massively overcount, because the same conversation tokens are re-sent on every API call within a turn (tool-call loops).
+- `message_start.usage.input_tokens` reflects the **actual input** sent to the API on that specific call — i.e., how much of the context window is currently occupied.
+- `contextWindow` is only available on `ModelUsage` in the `result` message.
+
+### Channel problem and solution
+
+`message_start` and `result` flow through different renderer channels:
+
+- `message_start` → `SDKMessageTransformer` → message stream (UI rendering)
+- `result` → `toUIEvent()` → event stream → `chat.ts#handleEvent()`
+
+They never meet on the renderer side. But on the main process, both originate from the same loop in `session-manager.ts:stream()` (line ~840). **Solution: track `message_start` usage in the main process and attach context data to the `result` event before publishing it to the renderer.**
+
+### Why not live (mid-stream) updates?
+
+The `message_start` events fire during streaming, but we only update the displayed value at turn end:
+
+- During a turn with tool calls, intermediate `message_start` events show growing context, but the final value (after all tool results are appended) is what matters for the user's next decision.
+- Avoids flickering UI during rapid tool-call loops.
+- Keeps the renderer simple — just reads a pre-computed value from the event.
+
+## Computation (main process)
+
+In `session-manager.ts:stream()`, the loop that processes raw SDK messages:
+
+```ts
+// Per-session state, reset each turn
+let lastInputTokens = 0;
+
+for await (const value of query) {
+  // Track message_start usage (top-level only)
+  if (
+    value.type === "stream_event" &&
+    value.event.type === "message_start" &&
+    value.parent_tool_use_id === null
+  ) {
+    const usage = value.event.message.usage;
+    lastInputTokens =
+      (usage.input_tokens ?? 0) +
+      (usage.cache_creation_input_tokens ?? 0) +
+      (usage.cache_read_input_tokens ?? 0);
+  }
+
+  // When result arrives, compute context % and attach
+  if (value.type === "result") {
+    const contextWindowSize = Object.values(value.modelUsage)[0]?.contextWindow ?? 0;
+    const remainingPct =
+      contextWindowSize > 0
+        ? Math.max(0, Math.min(100, Math.round((1 - lastInputTokens / contextWindowSize) * 100)))
+        : 0;
+    // Attach to the event before publishing
+    // (extend the event type or publish a separate context_usage event)
+  }
+
+  // existing: toUIEvent + transformer
+}
+```
+
+## Architecture
+
+```
+session-manager.ts:stream() — single loop over raw SDKMessage
+  │
+  ├─ stream_event (message_start, parent_tool_use_id === null)
+  │    → update lastInputTokens (per-session state)
+  │
+  ├─ result
+  │    → read contextWindow from modelUsage
+  │    → compute remainingPct from lastInputTokens
+  │    → publish context_usage event via eventPublisher
+  │
+  ├─ toUIEvent(value) → eventPublisher (existing)
+  └─ transformer.transformWithAggregation(value) → message stream (existing)
+
+         ▼ (renderer)
+
+chat.ts #handleEvent()
+  → receives context_usage event
+  → calls agentStore.setSessionUsage()
+
+         ▼
+
+ContextLeftIndicator component (next to BranchSwitcher)
+  → reads from store
+  → displays "ctx 78%"
+  → tooltip: "85k / 200k tokens"
+  → color changes by threshold
+```
+
+## Event Type
+
+Add a new event to `ClaudeCodeUIEventPart` in `shared/claude-code/types.ts`:
+
+```ts
+type ContextUsageEvent = {
+  type: "context_usage";
+  contextWindowSize: number;
+  usedTokens: number;
+  remainingPct: number;
+};
+```
+
+Published from `session-manager.ts` alongside (or instead of extending) the `result` event.
+
+## Store Changes
+
+Extend existing `SessionUsage` in `features/agent/store.ts`:
+
+```ts
+export type SessionUsage = {
+  totalCostUsd: number;
+  totalDurationMs: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  // context window tracking
+  contextWindowSize: number;
+  contextUsedTokens: number;
+  remainingPct: number;
+};
+```
+
+Add `setSessionUsage` action to `AgentState`.
+
+## UI
+
+Position: below the input box, same row as `BranchSwitcher`, right-aligned.
+
+```
+┌──────────────────────────────────────┐
+│  [editor content]                    │
+│  [toolbar: model | mode | send]      │
+├──────────────────────────────────────┤
+│  branch: main              ctx 78%   │
+└──────────────────────────────────────┘
+```
+
+### Display
+
+- Text: `ctx {remainingPct}%` — small `text-xs` matching branch switcher style.
+- Color thresholds (using existing design tokens):
+  - `>50%` remaining: `text-muted-foreground` (calm, neutral)
+  - `20–50%`: `text-warning` or yellow-ish (heads up)
+  - `<20%`: `text-destructive` (context is running low)
+- Component returns `null` until the first `result` event arrives (no data = no display).
+
+### Tooltip
+
+On hover, show raw token counts via `title` attribute:
+
+- `≥1k`: format as `85k / 200k tokens used`
+- `<1k`: format as `850 / 200k tokens used`
+
+## Files to Change
+
+| File                                                  | Change                                                                                  |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `shared/claude-code/types.ts`                         | Add `ContextUsageEvent` to `ClaudeCodeUIEventPart`                                      |
+| `main/features/agent/session-manager.ts`              | Track `lastInputTokens` from `message_start`, publish `context_usage` event on `result` |
+| `renderer/features/agent/store.ts`                    | Add `setSessionUsage` action, extend `SessionUsage` type                                |
+| `renderer/features/agent/chat.ts`                     | Handle `context_usage` event in `#handleEvent`, call store                              |
+| `renderer/features/agent/components/context-left.tsx` | New component (~25 lines)                                                               |
+| `renderer/features/agent/components/agent-chat.tsx`   | Render `ContextLeft` next to `BranchSwitcher`                                           |
+
+## Edge Cases
+
+- **No data yet**: Hidden until first turn completes
+- **Compaction**: Next turn's `message_start` will have lower `input_tokens` — percentage naturally recovers
+- **Multiple models in `modelUsage`**: Use the first entry's `contextWindow` (typically only one model per session)
+- **Provider sessions (non-SDK)**: Same event structure from intercepted API responses — works identically
+- **Sub-agent `message_start` events**: Only track top-level (`parent_tool_use_id === null`) to avoid counting sub-agent context as the main session's context
+- **Token formatting**: `≥1k` → `85k`, `<1k` → raw number (e.g., `850`)

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -836,14 +836,53 @@ export class SessionManager {
       uuid: userMessageId,
     });
 
+    // Track the latest top-level message_start usage to compute context window fill
+    let lastInputTokens = 0;
+
     while (true) {
       const { value, done } = await session.query.next();
       if (done || !value) break;
+
+      // Track context window usage from top-level message_start events
+      if (
+        value.type === "stream_event" &&
+        value.event.type === "message_start" &&
+        value.parent_tool_use_id === null
+      ) {
+        const usage = value.event.message.usage;
+        lastInputTokens =
+          (usage.input_tokens ?? 0) +
+          (usage.cache_creation_input_tokens ?? 0) +
+          (usage.cache_read_input_tokens ?? 0);
+      }
 
       // Publish to subscribe stream (result event included — carries cost/usage/stop_reason)
       const event = toUIEvent(value);
       if (event) {
         this.eventPublisher.publish(sessionId, event);
+      }
+
+      // On result, publish context_usage event with computed remaining %
+      if (value.type === "result") {
+        const modelEntries = Object.values(value.modelUsage ?? {});
+        const contextWindowSize = modelEntries[0]?.contextWindow ?? 0;
+        const remainingPct =
+          contextWindowSize > 0
+            ? Math.max(
+                0,
+                Math.min(100, Math.round((1 - lastInputTokens / contextWindowSize) * 100)),
+              )
+            : 0;
+        this.eventPublisher.publish(sessionId, {
+          kind: "event",
+          event: {
+            id: randomUUID(),
+            type: "context_usage",
+            contextWindowSize,
+            usedTokens: lastInputTokens,
+            remainingPct,
+          },
+        });
       }
 
       // Route to message stream (result → finish-step + finish, error → error chunk)

--- a/packages/desktop/src/renderer/src/features/agent/chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat.ts
@@ -13,10 +13,12 @@ import type {
   ClaudeCodeUIEvent,
   ClaudeCodeUIEventMessage,
   ClaudeCodeUIMessage,
+  ContextUsageEvent,
 } from "../../../../shared/claude-code/types";
 import type { ClaudeCodeChatTransport } from "./chat-transport";
 
 import { ClaudeCodeChatState, ClaudeCodeChatStoreState } from "./chat-state";
+import { useAgentStore } from "./store";
 
 export interface ClaudeCodeChatInit extends Omit<ChatInit<ClaudeCodeUIMessage>, "transport"> {
   id: string;
@@ -114,10 +116,15 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
   }
 
   #handleEvent(event: ClaudeCodeUIEventMessage) {
-    if (event.type === "result" && event.is_error) {
-      // this.stateStore.store.setState({
-      //   eventError: new Error(event.errors.join("\n") || event.subtype),
-      // });
+    if (event.type === "context_usage") {
+      const { contextWindowSize, usedTokens, remainingPct } = event as ContextUsageEvent & {
+        id: string;
+      };
+      useAgentStore.getState().setSessionUsage(this.id, {
+        contextWindowSize,
+        usedTokens,
+        remainingPct,
+      });
     }
   }
 

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -36,6 +36,7 @@ import { useClaudeCodeChat } from "../hooks/use-claude-code-chat";
 import { useNewSession } from "../hooks/use-new-session";
 import { useScrollPosition } from "../hooks/use-scroll-position";
 import { BranchSwitcher } from "./branch-switcher";
+import { ContextLeft } from "./context-left";
 import { MessageInput } from "./message-input";
 import { MessageParts } from "./message-parts";
 import { PermissionDialog } from "./permission-dialog";
@@ -307,8 +308,10 @@ function AgentChatSession({
           </div>
         </div>
         {cwd && (
-          <div className="px-4 pb-2">
+          <div className="flex items-center px-4 pb-2">
             <BranchSwitcher cwd={cwd} disabled={status === "streaming"} />
+            <div className="flex-1" />
+            <ContextLeft sessionId={sessionId} />
           </div>
         )}
       </div>

--- a/packages/desktop/src/renderer/src/features/agent/components/context-left.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/context-left.tsx
@@ -1,0 +1,28 @@
+import { cn } from "../../../lib/utils";
+import { useAgentStore } from "../store";
+
+function formatTokens(n: number): string {
+  return n >= 1000 ? `${Math.round(n / 1000)}k` : String(n);
+}
+
+export function ContextLeft({ sessionId }: { sessionId: string }) {
+  const usage = useAgentStore((s) => s.sessions.get(sessionId)?.usage);
+  if (!usage || !usage.contextWindowSize) return null;
+
+  const { remainingPct, contextUsedTokens, contextWindowSize } = usage;
+  const color =
+    remainingPct > 50
+      ? "text-muted-foreground"
+      : remainingPct > 20
+        ? "text-yellow-600 dark:text-yellow-500"
+        : "text-destructive";
+
+  return (
+    <span
+      className={cn("text-xs", color)}
+      title={`${formatTokens(contextUsedTokens)} / ${formatTokens(contextWindowSize)} tokens used`}
+    >
+      ctx {remainingPct}%
+    </span>
+  );
+}

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -48,6 +48,9 @@ export type SessionUsage = {
   totalDurationMs: number;
   totalInputTokens: number;
   totalOutputTokens: number;
+  contextWindowSize: number;
+  contextUsedTokens: number;
+  remainingPct: number;
 };
 
 export type ChatSession = {
@@ -97,6 +100,10 @@ type AgentState = {
   setModelScope: (sessionId: string, scope: ModelScope | undefined) => void;
   setProviderId: (sessionId: string, providerId: string | undefined) => void;
   setPermissionMode: (sessionId: string, mode: PermissionMode) => void;
+  setSessionUsage: (
+    sessionId: string,
+    usage: { contextWindowSize: number; usedTokens: number; remainingPct: number },
+  ) => void;
   renameSession: (sessionId: string, title: string) => Promise<void>;
   sessionInitError: string | null;
   setSessionInitError: (error: string | null) => void;
@@ -271,6 +278,24 @@ export const useAgentStore = create<AgentState>()(
       set((state) => {
         const session = state.sessions.get(sessionId);
         if (session) session.permissionMode = mode;
+      });
+    },
+
+    setSessionUsage: (sessionId, usage) => {
+      storeLog("setSessionUsage: sid=%s remaining=%d%%", sessionId, usage.remainingPct);
+      set((state) => {
+        const session = state.sessions.get(sessionId);
+        if (!session) return;
+        session.usage = {
+          ...session.usage,
+          totalCostUsd: session.usage?.totalCostUsd ?? 0,
+          totalDurationMs: session.usage?.totalDurationMs ?? 0,
+          totalInputTokens: session.usage?.totalInputTokens ?? 0,
+          totalOutputTokens: session.usage?.totalOutputTokens ?? 0,
+          contextWindowSize: usage.contextWindowSize,
+          contextUsedTokens: usage.usedTokens,
+          remainingPct: usage.remainingPct,
+        };
       });
     },
 

--- a/packages/desktop/src/shared/claude-code/types.ts
+++ b/packages/desktop/src/shared/claude-code/types.ts
@@ -56,6 +56,13 @@ export function isClaudeCodeUIMessage(value: unknown): value is ClaudeCodeUIMess
 
 // ─── Subscribe (event) ───────────────────────────────────────────────────────
 
+export type ContextUsageEvent = {
+  type: "context_usage";
+  contextWindowSize: number;
+  usedTokens: number;
+  remainingPct: number;
+};
+
 export type ClaudeCodeUIEventPart =
   | SDKResultMessage
   | SDKSystemMessage
@@ -73,7 +80,8 @@ export type ClaudeCodeUIEventPart =
   | SDKToolUseSummaryMessage
   | SDKAuthStatusMessage
   | SDKRateLimitEvent
-  | SDKPromptSuggestionMessage;
+  | SDKPromptSuggestionMessage
+  | ContextUsageEvent;
 
 export type ClaudeCodeUIEventMessage = { id: string } & ClaudeCodeUIEventPart;
 


### PR DESCRIPTION

<img width="604" height="194" alt="Electron 2026-03-23 21 02 56" src="https://github.com/user-attachments/assets/acf73bd4-25fe-4af9-881f-ba1d60387fe1" />


## Summary

- Display remaining context window percentage (`ctx 78%`) below the message input, right-aligned next to the branch switcher
- Track usage from SDK `stream_event` → `message_start` (per-API-call input tokens) combined with `result` → `modelUsage.contextWindow` on the main process side, then publish a `context_usage` event to the renderer
- Color thresholds: muted (>50%), yellow (20–50%), red (<20%); hover tooltip shows raw token counts
- Hidden until first turn completes; clamped to 0–100%

## Test plan

- [ ] Start a new chat session — verify no context indicator is shown
- [ ] Send a message and wait for the turn to complete — verify `ctx N%` appears next to the branch switcher
- [ ] Verify hover tooltip shows token counts (e.g. `85k / 200k tokens used`)
- [ ] Send multiple messages to increase context usage — verify percentage decreases
- [ ] Verify color changes: green/muted when >50%, yellow at 20–50%, red at <20%
- [ ] Run `bun ready` — all checks pass