### PR TITLE
fix: align changes popover padding & items with context menu

### DIFF
--- a/packages/desktop/src/renderer/src/components/ui/popover.tsx
+++ b/packages/desktop/src/renderer/src/components/ui/popover.tsx
@@ -25,6 +25,7 @@ function PopoverPopup({
   alignOffset = 0,
   tooltipStyle = false,
   anchor,
+  viewportClassName,
   ...props
 }: PopoverPrimitive.Popup.Props & {
   side?: PopoverPrimitive.Positioner.Props["side"];
@@ -33,6 +34,7 @@ function PopoverPopup({
   alignOffset?: PopoverPrimitive.Positioner.Props["alignOffset"];
   tooltipStyle?: boolean;
   anchor?: PopoverPrimitive.Positioner.Props["anchor"];
+  viewportClassName?: string;
 }) {
   return (
     <PopoverPrimitive.Portal>
@@ -61,6 +63,7 @@ function PopoverPopup({
               tooltipStyle
                 ? "py-1 [--viewport-inline-padding:--spacing(2)]"
                 : "not-data-transitioning:overflow-y-auto",
+              viewportClassName,
             )}
             data-slot="popover-viewport"
           >

--- a/packages/desktop/src/renderer/src/plugins/changes/changes-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/changes/changes-view.tsx
@@ -479,33 +479,33 @@ export default memo(function ChangesView() {
           <PopoverTrigger className="p-1 hover:bg-accent rounded">
             <Ellipsis className="w-3.5 h-3.5 text-muted-foreground" />
           </PopoverTrigger>
-          <PopoverPopup side="bottom" align="end" className="!p-0">
-            <div className="py-1 min-w-40">
+          <PopoverPopup side="bottom" align="end" viewportClassName="p-1">
+            <div className="min-w-32">
               <button
                 onClick={() => refresh()}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-sm hover:bg-accent text-left"
+                className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0"
               >
-                <RefreshCw className="w-3.5 h-3.5" />
+                <RefreshCw />
                 {t("review.menu.refresh")}
               </button>
               <button
                 onClick={toggleFileTree}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-sm hover:bg-accent text-left"
+                className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
               >
                 {showFileTree ? t("review.menu.hideFileTree") : t("review.menu.showFileTree")}
               </button>
-              <div className="h-px bg-border mx-2 my-1" />
+              <div className="mx-2 my-1 h-px bg-border" />
               <button
                 onClick={expandAll}
                 disabled={files.length === 0}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-sm hover:bg-accent text-left disabled:opacity-50"
+                className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-64"
               >
                 {t("review.menu.expandAll")}
               </button>
               <button
                 onClick={collapseAll}
                 disabled={expandedFiles.size === 0}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-sm hover:bg-accent text-left disabled:opacity-50"
+                className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-64"
               >
                 {t("review.menu.collapseAll")}
               </button>


### PR DESCRIPTION
## Summary

- Added `viewportClassName` prop to `PopoverPopup` — the existing `className` only targeted the Popup div, but padding lived on the inner Viewport and couldn't be overridden
- Changed ChangesView overflow menu to use `viewportClassName="p-1"` matching `MenuPopup` and `ContextMenuPopup` padding
- Aligned menu item styles (padding, border-radius, select behavior, disabled state) with `ContextMenuItem` conventions

## Test plan

- [ ] Open Changes view → click the `...` overflow menu
- [ ] Verify padding matches right-click context menus in the session list
- [ ] Verify disabled states (Expand All when no files, Collapse All when none expanded) look correct
- [ ] Verify hover highlights have rounded corners matching context menu items