### PR TITLE
fix: show relative file paths in Changes panel

### DIFF
--- a/docs/designs/2026-03-24-changes-relative-paths.md
+++ b/docs/designs/2026-03-24-changes-relative-paths.md
@@ -1,0 +1,31 @@
+# Changes Panel: Show Relative File Paths
+
+## 1. Background
+
+The Changes panel displays file paths that may be absolute (especially from the SDK's `rewindFiles` for the "last-turn" category). Users want shorter, relative paths for readability.
+
+## 2. Decision Log
+
+**1. Where to strip the prefix?**
+
+- Options: A) `useChanges` hook · B) `changes-view.tsx` display only
+- Decision: **A) Hook** — `relPath` is used as both display and API key. Making it relative at the source keeps everything consistent. The `lastTurnDiff` backend uses `path.resolve(cwd, file)` which handles relative paths correctly.
+
+**2. Which categories need fixing?**
+
+- Options: A) All · B) Only `last-turn`
+- Decision: **B) Only `last-turn`** — `unstaged`/`staged`/`branch` already return git-root-relative paths from `simple-git`.
+
+## 3. Design
+
+In `useChanges.ts`, when mapping `res.filesChanged` for the `last-turn` category, strip the `cwd` prefix from any absolute path before storing as `relPath`.
+
+## 4. Files Changed
+
+- `packages/desktop/src/renderer/src/plugins/changes/hooks/useChanges.ts` — strip cwd prefix from last-turn file paths
+
+## 5. Verification
+
+1. Open Changes panel → select "Last Turn" category
+2. File paths should show as relative (e.g., `src/main/foo.ts` not `/Users/.../src/main/foo.ts`)
+3. Clicking a file should still load the diff correctly

--- a/packages/desktop/src/renderer/src/plugins/changes/hooks/useChanges.ts
+++ b/packages/desktop/src/renderer/src/plugins/changes/hooks/useChanges.ts
@@ -94,11 +94,13 @@ export function useChanges(category: ChangesCategory) {
         if (res.filesChanged && res.filesChanged.length > 0) {
           setFiles(
             res.filesChanged.map((filePath: string) => {
-              const parts = filePath.split("/");
+              const relPath =
+                cwd && filePath.startsWith(cwd + "/") ? filePath.slice(cwd.length + 1) : filePath;
+              const parts = relPath.split("/");
               const fileName = parts[parts.length - 1];
               const extIdx = fileName.lastIndexOf(".");
               return {
-                relPath: filePath,
+                relPath,
                 fileName,
                 extName: extIdx >= 0 ? fileName.slice(extIdx + 1) : "",
                 status: "modified",


### PR DESCRIPTION
## Summary

- Strip the project `cwd` prefix from absolute file paths returned by the SDK's `rewindFiles()` in the "Last Turn" changes category
- Paths now display as repo-relative (e.g., `src/main/foo.ts`) instead of full absolute paths (e.g., `/Users/.../src/main/foo.ts`)
- Other categories (unstaged, staged, branch) already return relative paths and are unaffected

## Test plan

- [ ] Open Changes panel → select "Last Turn" category after an agent turn
- [ ] Verify file paths are short, relative paths (not absolute)
- [ ] Click a file to expand — verify diff loads correctly
- [ ] Verify unstaged/staged/branch categories still work as before