### PR TITLE
feat: add prompt suggestion follow-up in message input

### DIFF
--- a/docs/designs/2026-03-23-prompt-suggestion-follow-up.md
+++ b/docs/designs/2026-03-23-prompt-suggestion-follow-up.md
@@ -1,0 +1,156 @@
+# Prompt Suggestion (Follow-Up) for Message Input
+
+**Date:** 2026-03-23
+**Status:** Approved
+
+## Overview
+
+After each assistant turn, the Claude Agent SDK can predict what the user might type next and emit a `prompt_suggestion` event. This design adds support for displaying that suggestion as dynamic placeholder text inside the TipTap message input, with Tab to accept and Enter to send directly.
+
+The SDK plumbing is already 90% in place — `SDKPromptSuggestionMessage` is imported in shared types, the main process routes `prompt_suggestion` events through the event publisher, but the renderer currently ignores them.
+
+## Data Flow
+
+```
+SDK Query (main process)
+  → emits SDKPromptSuggestionMessage { type: "prompt_suggestion", suggestion: "run the tests" }
+  → sdk-message-transformer routes to event publisher (already works)
+  → ClaudeCodeChat.#handleEvent captures it (NEW)
+  → stores in ClaudeCodeChatStoreState.promptSuggestion (NEW)
+  → MessageInput reads it, swaps TipTap placeholder text (NEW)
+  → User presses Tab → fills editor with suggestion text
+  → User presses Enter on empty input → sends suggestion directly as message
+  → Any typing or new turn → clears suggestion, placeholder reverts
+```
+
+## Changes by Layer
+
+### Main Process (`session-manager.ts`)
+
+Add `promptSuggestions: true` to the `Options` object passed to `query()` (1 line change).
+
+### Shared Types
+
+No changes needed. `SDKPromptSuggestionMessage` is already part of `ClaudeCodeUIEventPart`.
+
+The SDK type shape:
+
+```ts
+type SDKPromptSuggestionMessage = {
+  type: "prompt_suggestion";
+  suggestion: string;
+  uuid: string;
+  session_id: string;
+};
+```
+
+### Renderer — Chat State (`chat-state.ts`)
+
+Add to `ClaudeCodeChatStoreState`:
+
+```ts
+promptSuggestion: string | null; // default: null
+```
+
+### Renderer — Chat Event Handler (`chat.ts`)
+
+In `#handleEvent`:
+
+- Handle `type === "prompt_suggestion"` → store `event.suggestion` in chat state
+- On turn start (status changes to `submitted`/`streaming`) → clear suggestion to `null`
+
+### Renderer — Display Approach: Dynamic Placeholder
+
+Instead of a separate `Decoration.widget`, dynamically swap the TipTap Placeholder extension's text when a suggestion exists. This avoids a visual collision — the editor already renders `Placeholder.configure({ placeholder: t("chat.placeholder") })` ("Send a message...") when empty, and a second decoration would overlap.
+
+When `promptSuggestion` is non-null:
+
+- Replace the placeholder text with the suggestion (e.g. "run the tests")
+- Style it slightly differently (`text-primary/30` instead of the default placeholder color) to hint it's actionable
+- Append a subtle hint: `Tab to fill · Enter to send`
+- Apply `truncate` (text-overflow: ellipsis) to prevent layout breakage from unexpectedly long suggestions
+
+When `promptSuggestion` is null:
+
+- Revert to the default placeholder text
+
+Implementation: update the Placeholder extension's `placeholder` option reactively when the suggestion changes. TipTap supports reconfiguring extensions via `editor.extensionManager.extensions`.
+
+### Renderer — Keyboard Handling (in `message-input.tsx` chatKeymap plugin)
+
+Add to the existing `chatKeymap` ProseMirror plugin:
+
+**Tab key** (new handler):
+
+- Guard: skip if `document.querySelector("[data-suggestion-popup]")` exists (mention/slash-command popup open)
+- Guard: skip if `Shift+Tab` (already used for plan mode toggle)
+- If editor is empty and suggestion exists → set editor content to suggestion, clear suggestion
+- Otherwise → default behavior
+
+**Escape key** (modify existing handler):
+
+- If suggestion exists → clear suggestion from store, prevent editor blur
+- Otherwise → existing behavior (blur editor / clear input via double-press)
+
+**Enter key** (modify existing handler):
+
+- If editor is empty and suggestion exists → send suggestion text directly via `onSend`, clear suggestion, show brief notification ("Sent suggested follow-up") via the existing `addNotification` system so the user understands what happened
+- Otherwise → existing behavior unchanged
+
+### Renderer — MessageInput (`message-input.tsx`)
+
+- Read `promptSuggestion` from the chat store via `useStore(chatStore, s => s.promptSuggestion)`
+- Dynamically update the Placeholder extension text when suggestion changes
+- Wire Tab/Enter handling in existing `chatKeymap` plugin (no new extension file needed)
+- On send: if editor is empty and suggestion exists, send the suggestion text instead
+
+### Race Condition: Suggestion Arrives While User Is Typing
+
+If the user starts typing before the suggestion arrives (there's SDK-side latency after the turn), the suggestion is stored but **not displayed** — the placeholder only shows when the editor is empty. If the user clears their input later, the suggestion will appear then (if still valid). No special handling needed beyond the "only show when empty" rule.
+
+## Ghost Text Visual Behavior
+
+```
+- Empty editor + suggestion exists → placeholder shows "run the tests  Tab to fill · Enter to send"
+                                     (styled text-primary/30, truncated with ellipsis if too long)
+- Empty editor + no suggestion    → placeholder shows "Send a message..." (default muted style)
+- User types anything             → placeholder disappears (standard TipTap behavior)
+- User presses Tab                → editor content becomes "run the tests", suggestion clears
+- User presses Enter              → suggestion sent as message directly, brief notification shown
+- User presses Escape             → suggestion dismissed, placeholder reverts to default
+- New turn starts                 → suggestion clears, placeholder reverts
+- Session changes                 → suggestion clears, placeholder reverts
+```
+
+## Dismissal Rules
+
+Suggestion is set to `null` when:
+
+- User sends a message (whether typed or suggestion-accepted)
+- User presses Escape (explicit dismiss)
+- A new turn starts (streaming begins)
+- Session changes (activeSessionId changes)
+- A new `prompt_suggestion` event arrives (replaces the previous one)
+
+Note: typing does NOT clear the suggestion from the store — it just hides it because the placeholder only renders when the editor is empty. If the user deletes what they typed, the suggestion reappears.
+
+## Files to Change
+
+| File                                                           | Change                                                |
+| -------------------------------------------------------------- | ----------------------------------------------------- |
+| `src/main/features/agent/session-manager.ts`                   | Add `promptSuggestions: true` to query options        |
+| `src/renderer/src/features/agent/chat-state.ts`                | Add `promptSuggestion` field to store state           |
+| `src/renderer/src/features/agent/chat.ts`                      | Handle `prompt_suggestion` event, clear on turn start |
+| `src/renderer/src/features/agent/components/message-input.tsx` | Dynamic placeholder, Tab/Enter handling in chatKeymap |
+
+No new files needed — all renderer changes fit in existing files.
+
+## Non-Goals
+
+- No telemetry (SDK already tracks prompt suggestion outcomes)
+- No custom suggestion generation (we consume what the SDK provides)
+- No speculation/auto-execute (Claude Code CLI has this infrastructure but it's disabled there too)
+
+## Future Enhancements
+
+- Config UI toggle in chat settings panel (SDK already respects `promptSuggestionEnabled` setting)

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -154,6 +154,7 @@ export class SessionManager {
       enableFileCheckpointing: true,
       includePartialMessages: true,
       permissionMode: this.configStore.get("permissionMode") ?? "default",
+      promptSuggestions: true,
       systemPrompt: {
         type: "preset",
         preset: "claude_code",

--- a/packages/desktop/src/renderer/src/assets/globals.css
+++ b/packages/desktop/src/renderer/src/assets/globals.css
@@ -212,6 +212,11 @@
     height: 0;
   }
 
+  /* Prompt suggestion placeholder: different color */
+  [data-has-suggestion] .tiptap p.is-editor-empty:first-child::before {
+    color: --alpha(var(--primary) / 50%);
+  }
+
   .tiptap .mention {
     background: --alpha(var(--primary) / 15%);
     color: var(--primary);

--- a/packages/desktop/src/renderer/src/features/agent/chat-state.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-state.ts
@@ -29,6 +29,9 @@ export interface ClaudeCodeChatStoreState {
   capabilities: ClaudeCodeChatCapabilities | null;
   pendingContextClear?: PendingContextClear;
 
+  // Prompt suggestion (follow-up)
+  promptSuggestion: string | null;
+
   // Query status timing
   turnStartedAt: number | null;
   thinkingStartedAt: number | null;
@@ -47,6 +50,7 @@ export class ClaudeCodeChatState implements ChatState<ClaudeCodeUIMessage> {
       eventError: undefined,
       pendingRequests: [],
       capabilities: null,
+      promptSuggestion: null,
       turnStartedAt: null,
       thinkingStartedAt: null,
       thinkingDuration: null,

--- a/packages/desktop/src/renderer/src/features/agent/chat.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat.ts
@@ -73,6 +73,9 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
         if (status === prev) return;
 
         if (status === "submitted" || status === "streaming") {
+          if (cur.promptSuggestion !== null) {
+            this.store.setState({ promptSuggestion: null });
+          }
           onTurnStart?.(id);
         } else if (
           (prev === "streaming" && (status === "ready" || status === "error")) ||
@@ -125,6 +128,10 @@ export class ClaudeCodeChat extends AbstractChat<ClaudeCodeUIMessage> {
         usedTokens,
         remainingPct,
       });
+    } else if (event.type === "prompt_suggestion") {
+      const suggestion = (event as { suggestion: string }).suggestion;
+      log("prompt_suggestion: sessionId=%s suggestion=%s", this.id, suggestion);
+      this.store.setState({ promptSuggestion: suggestion });
     }
   }
 

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ImageAttachment, PermissionMode } from "../../../../../shared/features/agent/types";
 
+import { toastManager } from "../../../components/ui/toast";
 import { useEventCallback } from "../../../hooks/use-event-callback";
 import { useLatestRef } from "../../../hooks/use-latest-ref";
 import { cn } from "../../../lib/utils";
@@ -60,6 +61,31 @@ export function MessageInput({
   const { createNewSession } = useNewSession();
 
   const activeSessionId = useAgentStore((s) => s.activeSessionId);
+
+  // Subscribe to prompt suggestion from the per-session chat store.
+  // Uses useState+useEffect instead of useStore to avoid conditional hook calls
+  // (chatStore may be undefined when no session is active).
+  const [promptSuggestion, setPromptSuggestion] = useState<string | null>(null);
+  useEffect(() => {
+    const store = activeSessionId
+      ? claudeCodeChatManager.getChat(activeSessionId)?.store
+      : undefined;
+    if (!store) {
+      setPromptSuggestion(null);
+      return;
+    }
+    setPromptSuggestion(store.getState().promptSuggestion);
+    return store.subscribe((state) => {
+      setPromptSuggestion(state.promptSuggestion);
+    });
+  }, [activeSessionId]);
+  const promptSuggestionRef = useLatestRef(promptSuggestion);
+
+  const clearSuggestion = useEventCallback(() => {
+    if (!activeSessionId) return;
+    claudeCodeChatManager.getChat(activeSessionId)?.store.setState({ promptSuggestion: null });
+  });
+
   const permissionMode = useAgentStore(
     (s) =>
       (activeSessionId ? s.sessions.get(activeSessionId)?.permissionMode : undefined) ?? "default",
@@ -129,7 +155,11 @@ export function MessageInput({
         blockquote: false,
       }),
       Placeholder.configure({
-        placeholder: t("chat.placeholder"),
+        placeholder: () => {
+          const suggestion = promptSuggestionRef.current;
+          if (suggestion) return suggestion + "    Tab to fill · Enter to send";
+          return t("chat.placeholder");
+        },
       }),
       mentionExtension,
       slashCommandsExtension,
@@ -144,6 +174,19 @@ export function MessageInput({
               props: {
                 handleKeyDown(_view, event) {
                   const mode = sendMessageWithRef.current;
+
+                  // Tab: accept prompt suggestion (fill editor)
+                  if (event.key === "Tab" && !event.shiftKey) {
+                    if (document.querySelector("[data-suggestion-popup]")) return false;
+                    const suggestion = promptSuggestionRef.current;
+                    if (suggestion && editor.isEmpty) {
+                      event.preventDefault();
+                      editor.commands.setContent(suggestion);
+                      clearSuggestion();
+                      return true;
+                    }
+                    return false;
+                  }
 
                   // Bare Enter (no modifier)
                   if (
@@ -161,6 +204,20 @@ export function MessageInput({
 
                     event.preventDefault();
                     const text = extractText(editor.getJSON()).trim();
+
+                    // Empty input + suggestion → send suggestion directly
+                    const suggestion = promptSuggestionRef.current;
+                    if (!text && suggestion) {
+                      clearSuggestion();
+                      onSend(suggestion);
+                      toastManager.add({
+                        type: "info",
+                        title: t("chat.suggestionSent"),
+                        timeout: 2000,
+                      });
+                      return true;
+                    }
+
                     if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
                       editor.commands.clearContent();
                       createNewSession(cwdRef.current);
@@ -176,6 +233,20 @@ export function MessageInput({
                     if (mode === "cmdEnter") {
                       event.preventDefault();
                       const text = extractText(editor.getJSON()).trim();
+
+                      // Empty input + suggestion → send suggestion directly
+                      const suggestion = promptSuggestionRef.current;
+                      if (!text && suggestion) {
+                        clearSuggestion();
+                        onSend(suggestion);
+                        toastManager.add({
+                          type: "info",
+                          title: t("chat.suggestionSent"),
+                          timeout: 2000,
+                        });
+                        return true;
+                      }
+
                       if (NEW_CHAT_EASTER_EGGS.has(text.toLowerCase())) {
                         editor.commands.clearContent();
                         createNewSession(cwdRef.current);
@@ -198,6 +269,11 @@ export function MessageInput({
                     return true;
                   }
                   if (event.key === "Escape") {
+                    // Dismiss suggestion first, then blur on next Escape
+                    if (promptSuggestionRef.current) {
+                      clearSuggestion();
+                      return true;
+                    }
                     editor.commands.blur();
                     return true;
                   }
@@ -250,6 +326,12 @@ export function MessageInput({
   useEffect(() => {
     editor?.setEditable(!disabled && !streaming);
   }, [editor, disabled, streaming]);
+
+  // Force placeholder re-render when suggestion changes
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return;
+    editor.view.dispatch(editor.state.tr.setMeta("promptSuggestion", promptSuggestion));
+  }, [editor, promptSuggestion]);
 
   // Close suggestion popups when settings opens
   const showSettings = useSettingsStore((s) => s.showSettings);
@@ -345,7 +427,9 @@ export function MessageInput({
               </motion.div>
             )}
           </AnimatePresence>
-          <EditorContent editor={editor} />
+          <div data-has-suggestion={promptSuggestion ? "" : undefined}>
+            <EditorContent editor={editor} />
+          </div>
           <AttachmentPreview attachments={attachments} onRemove={removeAttachment} />
           <InputToolbar
             streaming={streaming}

--- a/packages/desktop/src/renderer/src/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/locales/en-US.json
@@ -343,6 +343,7 @@
   "chat.sendCmdEnter": "Send (⌘Enter)",
   "chat.planMode": "Plan mode",
   "chat.planModeExit": "Shift+Tab to exit",
+  "chat.suggestionSent": "Sent suggested follow-up",
   "chat.sdkDefault": "SDK Default",
   "chat.manageProviders": "Manage Providers...",
   "chat.setProjectDefault": "Set as project default",

--- a/packages/desktop/src/renderer/src/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/locales/zh-CN.json
@@ -345,6 +345,7 @@
   "chat.sendCmdEnter": "发送 (⌘Enter)",
   "chat.planMode": "计划模式",
   "chat.planModeExit": "Shift+Tab 退出",
+  "chat.suggestionSent": "已发送建议的后续消息",
   "chat.sdkDefault": "SDK 默认",
   "chat.manageProviders": "管理服务商...",
   "chat.setProjectDefault": "设为项目默认",

--- a/packages/desktop/src/renderer/src/plugins/debug/debug-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/debug/debug-view.tsx
@@ -1,4 +1,4 @@
-import { Maximize2, RefreshCw, X, ChevronDown, ChevronRight } from "lucide-react";
+import { Lightbulb, Maximize2, RefreshCw, X, ChevronDown, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -6,6 +6,7 @@ import type { ActiveSessionInfo } from "../../../../shared/features/agent/types"
 
 import { Button } from "../../components/ui/button";
 import { useRendererApp } from "../../core/app";
+import { claudeCodeChatManager } from "../../features/agent/chat-manager";
 import { useAgentStore } from "../../features/agent/store";
 import { useProjectStore } from "../../features/project/store";
 import { client } from "../../orpc";
@@ -101,6 +102,20 @@ export default function DebugView() {
     void app.workbench.layout.maximizePart("contentPanel");
   };
 
+  const activeSessionId = useAgentStore((s) => s.activeSessionId);
+  const handleSimulateSuggestion = () => {
+    if (!activeSessionId) return;
+    const store = claudeCodeChatManager.getChat(activeSessionId)?.store;
+    if (!store) return;
+    const suggestions = [
+      "run the tests",
+      "now refactor the authentication module to use the new token validation strategy we discussed and make sure all edge cases are covered",
+    ];
+    const current = store.getState().promptSuggestion;
+    const next = current === suggestions[0] ? suggestions[1] : suggestions[0];
+    store.setState({ promptSuggestion: next });
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between px-3 py-2 border-b border-border">
@@ -108,6 +123,15 @@ export default function DebugView() {
           {t("debug.activeSessions")}
         </span>
         <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleSimulateSuggestion}
+            title="Simulate prompt suggestion"
+            className="size-5"
+          >
+            <Lightbulb className="size-3" />
+          </Button>
           <Button
             variant="ghost"
             size="icon-sm"


### PR DESCRIPTION

<img width="444" height="181" alt="Electron 2026-03-24 11 39 20" src="https://github.com/user-attachments/assets/34e320dc-b871-4f36-98c6-1c0c0bc8deef" />


## Summary

- After each assistant turn, the Claude Agent SDK predicts what the user might type next and emits a `prompt_suggestion` event
- Display the suggestion as placeholder text in the TipTap editor, styled with primary color at 50% opacity
- **Tab** fills the editor with the suggestion text
- **Enter** on empty input sends the suggestion directly (with brief toast notification)
- **Escape** dismisses the suggestion
- Suggestion auto-clears on turn start or session change
- Debug panel gets a lightbulb button to simulate suggestions (toggles short/long text)

## Test plan

- [ ] Click the lightbulb button in the debug panel — suggestion appears as placeholder text
- [ ] Click again — toggles to a long suggestion string
- [ ] Press Tab — editor fills with the suggestion text
- [ ] Clear editor, trigger suggestion again, press Enter — sends suggestion directly, toast shown
- [ ] Press Escape — suggestion dismissed, default placeholder returns
- [ ] Send a message — suggestion clears during streaming
- [ ] Verify placeholder is visible in both light and dark themes