### PR TITLE
fix: make layout service methods return Promise for reliable await

### DIFF
--- a/packages/desktop/src/renderer/src/core/workbench/layout/service.ts
+++ b/packages/desktop/src/renderer/src/core/workbench/layout/service.ts
@@ -16,23 +16,23 @@ export class WorkbenchLayoutService implements IWorkbenchLayoutService {
   // to consume workbench.layout as its state source.
   constructor(private readonly adapter: LayoutAdapter) {}
 
-  expandPart(part: CollapsibleWorkbenchPartId): void | Promise<void> {
+  async expandPart(part: CollapsibleWorkbenchPartId): Promise<void> {
     if (this.adapter.isExpanded(part)) return;
-    return this.adapter.togglePart(part);
+    await this.adapter.togglePart(part);
   }
 
-  collapsePart(part: CollapsibleWorkbenchPartId): void | Promise<void> {
+  async collapsePart(part: CollapsibleWorkbenchPartId): Promise<void> {
     if (!this.adapter.isExpanded(part)) return;
-    return this.adapter.togglePart(part);
+    await this.adapter.togglePart(part);
   }
 
-  togglePart(part: CollapsibleWorkbenchPartId): void | Promise<void> {
-    return this.adapter.togglePart(part);
+  async togglePart(part: CollapsibleWorkbenchPartId): Promise<void> {
+    await this.adapter.togglePart(part);
   }
 
-  maximizePart(part: MaximizableWorkbenchPartId): void | Promise<void> {
+  async maximizePart(part: MaximizableWorkbenchPartId): Promise<void> {
     if (part !== "contentPanel") return;
     if (!this.adapter.isExpanded("contentPanel")) return;
-    return this.adapter.maximizeContentPanel();
+    await this.adapter.maximizeContentPanel();
   }
 }

--- a/packages/desktop/src/renderer/src/core/workbench/layout/types.ts
+++ b/packages/desktop/src/renderer/src/core/workbench/layout/types.ts
@@ -19,8 +19,8 @@ export type CollapsibleWorkbenchPartId =
 export type MaximizableWorkbenchPartId = "contentPanel";
 
 export interface IWorkbenchLayoutService {
-  expandPart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
-  collapsePart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
-  togglePart(part: CollapsibleWorkbenchPartId): void | Promise<void>;
-  maximizePart(part: MaximizableWorkbenchPartId): void | Promise<void>;
+  expandPart(part: CollapsibleWorkbenchPartId): Promise<void>;
+  collapsePart(part: CollapsibleWorkbenchPartId): Promise<void>;
+  togglePart(part: CollapsibleWorkbenchPartId): Promise<void>;
+  maximizePart(part: MaximizableWorkbenchPartId): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Changed `IWorkbenchLayoutService` methods to return `Promise<void>` instead of `void | Promise<void>`
- Enables callers to `await expandPart()` before calling `maximizePart()`, fixing a race condition where `maximizePart` would no-op on first content panel open because the panel was still collapsed

## Test plan

- [x] All 261 existing tests pass
- [ ] Verify plugin can `await layout.expandPart("contentPanel")` then `layout.maximizePart("contentPanel")` on first app start