### PR TITLE
refactor(ui): optimize skill and plugin card layout

### DIFF
--- a/packages/desktop/src/renderer/src/features/claude-code-plugins/components/discover-tab.tsx
+++ b/packages/desktop/src/renderer/src/features/claude-code-plugins/components/discover-tab.tsx
@@ -125,20 +125,35 @@ export const DiscoverTab = ({
           </button>
         </div>
       )}
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 gap-3">
         {plugins.map((plugin) => {
           const key = `${plugin.name}@${plugin.marketplace}`;
           const initials = getInitials(plugin.name);
           return (
             <div
               key={key}
-              className="group relative flex flex-col p-4 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
+              className="group relative flex gap-3 p-3.5 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
               onClick={() => setSelectedPlugin(plugin)}
             >
-              <div className="flex items-start justify-between mb-3">
-                <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0">
-                  {initials}
+              <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0 self-center">
+                {initials}
+              </div>
+
+              <div className="flex-1 min-w-0 py-0.5">
+                <div className="flex items-center gap-1.5">
+                  <h3 className="text-sm font-medium text-foreground truncate">{plugin.name}</h3>
+                  {plugin.category && (
+                    <Badge variant="secondary" size="sm" className="shrink-0">
+                      {plugin.category}
+                    </Badge>
+                  )}
                 </div>
+                <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                  {plugin.description || t("settings.plugins.noDescription")}
+                </p>
+              </div>
+
+              <div className="shrink-0 self-center h-7 flex items-center">
                 {plugin.installedScopes.length > 0 ? (
                   <Badge variant="secondary" size="sm">
                     {t("settings.plugins.installedBadge")}
@@ -160,23 +175,6 @@ export const DiscoverTab = ({
                       <Download className="size-3.5" />
                     )}
                   </Button>
-                )}
-              </div>
-
-              <h3 className="text-sm font-medium text-foreground truncate mb-1">{plugin.name}</h3>
-
-              <p className="text-xs text-muted-foreground line-clamp-2 mb-3 min-h-8">
-                {plugin.description || t("settings.plugins.noDescription")}
-              </p>
-
-              <div className="flex flex-wrap items-center gap-1.5 mt-auto">
-                <Badge variant="outline" size="sm">
-                  {plugin.marketplace}
-                </Badge>
-                {plugin.category && (
-                  <Badge variant="secondary" size="sm">
-                    {plugin.category}
-                  </Badge>
                 )}
               </div>
             </div>

--- a/packages/desktop/src/renderer/src/features/claude-code-plugins/components/installed-tab.tsx
+++ b/packages/desktop/src/renderer/src/features/claude-code-plugins/components/installed-tab.tsx
@@ -93,7 +93,7 @@ export const InstalledTab = ({ plugins, updates, projects, onRefresh }: Installe
         </div>
       )}
 
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 gap-3">
         {plugins.map((plugin) => {
           const key = `${plugin.pluginId}-${plugin.scope}`;
           const initials = getInitials(plugin.name);
@@ -101,45 +101,34 @@ export const InstalledTab = ({ plugins, updates, projects, onRefresh }: Installe
           return (
             <div
               key={key}
-              className="group relative flex flex-col p-4 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
+              className="group relative flex gap-3 p-3.5 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
               onClick={() => setSelectedPlugin(plugin)}
             >
-              <div className="flex items-start justify-between mb-3">
-                <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0">
-                  {initials}
-                </div>
-                <div onClick={(e) => e.stopPropagation()}>
-                  <Switch
-                    checked={plugin.enabled}
-                    disabled={togglingId !== null}
-                    onCheckedChange={() => handleToggle(plugin)}
-                  />
-                </div>
+              <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0 self-center">
+                {initials}
               </div>
 
-              <h3 className="text-sm font-medium text-foreground truncate mb-1">{plugin.name}</h3>
+              <div className="flex-1 min-w-0 py-0.5">
+                <div className="flex items-center gap-1.5">
+                  <h3 className="text-sm font-medium text-foreground truncate">{plugin.name}</h3>
+                  {update && (
+                    <Badge variant="default" size="sm" className="gap-0.5 shrink-0">
+                      <ArrowUpCircle className="size-3" />
+                      {t("settings.plugins.update")}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                  {plugin.description || t("settings.plugins.noDescription")}
+                </p>
+              </div>
 
-              <p className="text-xs text-muted-foreground line-clamp-2 mb-3 min-h-8">
-                {plugin.description || t("settings.plugins.noDescription")}
-              </p>
-
-              <div className="flex flex-wrap items-center gap-1.5 mt-auto">
-                <Badge variant="outline" size="sm">
-                  {plugin.scope === "user"
-                    ? t("settings.plugins.user")
-                    : `${plugin.scope}: ${plugin.projectPath?.split("/").pop() ?? t("settings.plugins.unknown")}`}
-                </Badge>
-                {plugin.version && (
-                  <Badge variant="secondary" size="sm">
-                    v{plugin.version}
-                  </Badge>
-                )}
-                {update && (
-                  <Badge variant="default" size="sm" className="gap-1">
-                    <ArrowUpCircle className="size-3" />
-                    {t("settings.plugins.update")}
-                  </Badge>
-                )}
+              <div className="shrink-0 self-center" onClick={(e) => e.stopPropagation()}>
+                <Switch
+                  checked={plugin.enabled}
+                  disabled={togglingId !== null}
+                  onCheckedChange={() => handleToggle(plugin)}
+                />
               </div>
             </div>
           );

--- a/packages/desktop/src/renderer/src/features/skills/components/skill-discover-tab.tsx
+++ b/packages/desktop/src/renderer/src/features/skills/components/skill-discover-tab.tsx
@@ -143,7 +143,7 @@ export const SkillDiscoverTab = ({
       <div
         key={skill.sourceRef}
         className={cn(
-          "group relative flex flex-col p-4 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200",
+          "group relative flex gap-3 p-3.5 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200",
           skill.installed && "opacity-60",
           isDeprecated && !skill.installed && "opacity-60",
         )}
@@ -156,10 +156,28 @@ export const SkillDiscoverTab = ({
           }
         }}
       >
-        <div className="flex items-start justify-between mb-3">
-          <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0">
-            {initials}
+        <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0 self-center">
+          {initials}
+        </div>
+
+        <div className="flex-1 min-w-0 py-0.5">
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-medium text-foreground truncate">{skill.name}</h3>
+            {sortedBadges?.slice(0, 1).map((badge) => (
+              <Badge
+                key={badge}
+                variant={skillBadgeVariantMap[badge]}
+                size="sm"
+                className="shrink-0"
+              >
+                {t(`settings.skills.badge.${badge}`)}
+              </Badge>
+            ))}
           </div>
+          <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">{skill.description}</p>
+        </div>
+
+        <div className="shrink-0 self-center h-7 flex items-center">
           {skill.installed ? (
             <Badge variant="secondary" size="sm">
               {t("settings.skills.installedBadge")}
@@ -179,28 +197,6 @@ export const SkillDiscoverTab = ({
             </Button>
           )}
         </div>
-
-        <h3 className="text-sm font-medium text-foreground truncate mb-1">{skill.name}</h3>
-
-        <p className="text-xs text-muted-foreground line-clamp-2 mb-3 min-h-8">
-          {skill.description}
-        </p>
-
-        <div className="flex flex-wrap items-center gap-1.5 mt-auto">
-          <Badge variant="outline" size="sm">
-            {skill.source}
-          </Badge>
-          {skill.version && (
-            <Badge variant="secondary" size="sm">
-              v{skill.version}
-            </Badge>
-          )}
-          {sortedBadges?.map((badge) => (
-            <Badge key={badge} variant={skillBadgeVariantMap[badge]} size="sm">
-              {t(`settings.skills.badge.${badge}`)}
-            </Badge>
-          ))}
-        </div>
       </div>
     );
   };
@@ -219,7 +215,7 @@ export const SkillDiscoverTab = ({
               </div>
             )}
 
-            <div className="grid grid-cols-3 gap-3">{group.skills.map(renderSkillCard)}</div>
+            <div className="grid grid-cols-2 gap-3">{group.skills.map(renderSkillCard)}</div>
 
             {group.url && (
               <div className="mt-3 text-center">

--- a/packages/desktop/src/renderer/src/features/skills/components/skill-installed-tab.tsx
+++ b/packages/desktop/src/renderer/src/features/skills/components/skill-installed-tab.tsx
@@ -100,8 +100,6 @@ export const SkillInstalledTab = ({
     }
   };
 
-  const showScopeBadge = scopeFilter === "all";
-
   if (error) {
     return (
       <div className="p-3 rounded-md bg-destructive/10 text-destructive text-sm">
@@ -150,55 +148,41 @@ export const SkillInstalledTab = ({
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 gap-3">
           {filteredSkills.map((skill) => {
             const initials = getInitials(skill.name);
             const update = getUpdate(skill);
             return (
               <div
                 key={`${skill.scope}-${skill.projectPath ?? ""}-${skill.dirName}`}
-                className="group relative flex flex-col p-4 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
+                className="group relative flex gap-3 p-3.5 rounded-xl bg-card/80 border border-border/40 cursor-pointer hover:bg-card hover:border-border/60 hover:shadow-sm transition-colors duration-200"
                 onClick={() => setSelectedSkill(skill)}
               >
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0">
-                    {initials}
-                  </div>
-                  <div onClick={(e) => e.stopPropagation()}>
-                    <Switch
-                      checked={skill.enabled}
-                      disabled={togglingSkill !== null}
-                      onCheckedChange={() => handleToggleEnabled(skill)}
-                    />
-                  </div>
+                <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground text-sm font-semibold shrink-0 self-center">
+                  {initials}
                 </div>
 
-                <h3 className="text-sm font-medium text-foreground truncate mb-1">{skill.name}</h3>
+                <div className="flex-1 min-w-0 py-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <h3 className="text-sm font-medium text-foreground truncate">{skill.name}</h3>
+                    {update && (
+                      <Badge variant="default" size="sm" className="gap-0.5 shrink-0">
+                        <ArrowUpCircle className="size-3" />
+                        {update.latestVersion}
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                    {skill.description || t("settings.skills.noDescription")}
+                  </p>
+                </div>
 
-                <p className="text-xs text-muted-foreground line-clamp-2 mb-3 min-h-8">
-                  {skill.description || t("settings.skills.noDescription")}
-                </p>
-
-                <div className="flex flex-wrap items-center gap-1.5 mt-auto">
-                  {showScopeBadge && (
-                    <Badge variant="outline" size="sm">
-                      {skill.scope === "global"
-                        ? t("settings.skills.scopeGlobal")
-                        : (skill.projectPath?.split("/").pop() ??
-                          t("settings.skills.scopeProject"))}
-                    </Badge>
-                  )}
-                  {skill.version && (
-                    <Badge variant="secondary" size="sm">
-                      v{skill.version}
-                    </Badge>
-                  )}
-                  {update && (
-                    <Badge variant="default" size="sm" className="gap-1">
-                      <ArrowUpCircle className="size-3" />
-                      {update.latestVersion}
-                    </Badge>
-                  )}
+                <div className="shrink-0 self-center" onClick={(e) => e.stopPropagation()}>
+                  <Switch
+                    checked={skill.enabled}
+                    disabled={togglingSkill !== null}
+                    onCheckedChange={() => handleToggleEnabled(skill)}
+                  />
                 </div>
               </div>
             );


### PR DESCRIPTION
- Change grid from 3 columns to 2 columns for better readability
- Switch from vertical stacking to horizontal layout (icon + content + action)
- Align icon, content, and switch/button vertically centered
- Simplify card structure by removing bottom badge area
- Keep update badge inline with title for installed items
- Keep category/official badges inline with title for discover items
<img width="1440" height="812" alt="image" src="https://github.com/user-attachments/assets/3c59f80a-edda-4edc-8af8-966184774827" />