### PR TITLE
feat(plugin): support mcpServers in plugin contributions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/desktop": {
       "name": "neovate-desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ai-sdk/provider-utils": "^4.0.22",
         "@anthropic-ai/claude-agent-sdk": "0.2.97",

--- a/docs/designs/2026-04-12-plugin-mcp-servers-contributions.md
+++ b/docs/designs/2026-04-12-plugin-mcp-servers-contributions.md
@@ -1,0 +1,180 @@
+# Plugin MCP Servers Contributions
+
+**Date:** 2026-04-12
+**Status:** Draft
+**Prerequisite:** [Plugin Agent Hooks Contributions](2026-03-31-plugin-agent-hooks-contributions.md)
+
+## Problem
+
+Plugins can contribute hooks to Claude Agent SDK sessions via `ClaudeCodeContributions.options.hooks`, but cannot contribute MCP servers. The `mcpServers` field on SDK `Options` is never populated. Plugins that need to expose tools to Claude Code (e.g., a database explorer, a monitoring dashboard) have no way to register their MCP servers through the contribution system.
+
+## Solution
+
+Extend `ClaudeCodeContributions.options` to include `mcpServers`, following the same pattern established for hooks. Plugins declare MCP servers in `configContributions()`, contributions are merged by name, and `SessionManager` passes the merged record to the SDK `Options`.
+
+## Design Decisions
+
+### 1. Widen the `Pick<Options, ...>` — no new types
+
+The hooks design already established `ClaudeCodeContributions.options` as a subset of SDK `Options`. Adding `mcpServers` is a one-line change:
+
+```typescript
+interface ClaudeCodeContributions {
+  options?: Pick<Options, "hooks" | "mcpServers">;
+}
+```
+
+No wrapper types, no abstraction layer. Plugin authors work directly with SDK types.
+
+### 2. Merge strategy: first-win by server name, warn on conflict
+
+`Options.mcpServers` is `Record<string, McpServerConfig>`. When multiple plugins contribute servers:
+
+1. Iterate contributions in enforce order (pre → normal → post)
+2. For each server name, the **first** plugin to register it wins
+3. If a server name already exists, log a warning and skip: `"MCP server '%s' from plugin '%s' ignored — already registered by '%s'"`
+
+Rationale:
+
+- Consistent with plugin enforce ordering: `pre` plugins have higher priority, their registrations should not be overridden by later plugins
+- Consistent with `PluginManager`'s strict stance on conflicts (duplicate plugin names throw)
+- MCP server names are naturally namespaced (plugin authors use prefixes like `my-plugin:server`), so conflicts are unlikely in practice; a warning is sufficient
+
+### 3. Only process-transport configs (`McpServerConfigForProcessTransport`)
+
+The SDK defines two config union types:
+
+- `McpServerConfig` — includes `McpSdkServerConfigWithInstance` (contains a live `McpServer` object, not serializable)
+- `McpServerConfigForProcessTransport` — stdio, SSE, HTTP only (serializable, sent to CLI subprocess)
+
+Plugin contributions should use `McpServerConfigForProcessTransport` because:
+
+- Plugin configs are declared at startup and must survive serialization to the CLI process
+- SDK server instances (`McpSdkServerConfigWithInstance`) require in-process lifecycle management that doesn't fit the declarative contribution model
+- If a plugin needs an in-process MCP server, it should use `createSdkMcpServer()` directly and contribute via a different mechanism (out of scope)
+
+However, we use `Pick<Options, "hooks" | "mcpServers">` which types `mcpServers` as `Record<string, McpServerConfig>` (the full union). This is acceptable because:
+
+- TypeScript will enforce correct types at the plugin authoring site
+- The SDK handles both serializable and non-serializable configs internally
+- We don't need to restrict the type — the SDK is the authority
+
+### 4. Single merge function, not separate per-field functions
+
+Rather than `mergeAgentHooks()` + `mergeAgentMcpServers()`, introduce `mergeAgentContributions()` that returns the full merged `ClaudeCodeContributions.options`. This avoids proliferating merge functions as more fields are added.
+
+```typescript
+export function mergeAgentContributions(
+  agents: Contribution<AgentContributions>[],
+): Pick<Options, "hooks" | "mcpServers"> {
+  const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {};
+  const mcpServers: Record<string, McpServerConfig> = {};
+  const mcpServerSources: Record<string, string> = {}; // server name → plugin name
+
+  for (const { plugin, value } of agents) {
+    // Merge hooks (concat)
+    const pluginHooks = value.claudeCode?.options?.hooks;
+    if (pluginHooks) {
+      for (const [event, matchers] of Object.entries(pluginHooks)) {
+        if (!matchers) continue;
+        (hooks[event as HookEvent] ??= []).push(...matchers);
+      }
+    }
+
+    // Merge mcpServers (first-win with warning)
+    const pluginMcpServers = value.claudeCode?.options?.mcpServers;
+    if (pluginMcpServers) {
+      for (const [name, config] of Object.entries(pluginMcpServers)) {
+        if (mcpServerSources[name]) {
+          log(
+            "MCP server '%s' from plugin '%s' ignored — already registered by '%s'",
+            name,
+            plugin.name,
+            mcpServerSources[name],
+          );
+          continue;
+        }
+        mcpServers[name] = config;
+        mcpServerSources[name] = plugin.name;
+      }
+    }
+  }
+
+  return {
+    ...(Object.keys(hooks).length > 0 ? { hooks } : {}),
+    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+  };
+}
+```
+
+### 5. `mergeAgentHooks` becomes a thin wrapper (backwards compat)
+
+The existing `mergeAgentHooks()` is called in session-manager and tests. Rather than updating all call sites in this PR, keep it as a wrapper that delegates to `mergeAgentContributions()`. It can be removed in a follow-up.
+
+Alternatively, replace all usages directly. The call sites are few (session-manager + 1 test file), so either approach is low-risk.
+
+## API
+
+### Plugin Usage
+
+```typescript
+const myPlugin: MainPlugin = {
+  name: "db-explorer",
+  configContributions() {
+    return {
+      agents: {
+        claudeCode: {
+          options: {
+            mcpServers: {
+              "db-explorer:postgres": {
+                command: "node",
+                args: ["./mcp-server.js"],
+                env: { DATABASE_URL: "..." },
+              },
+            },
+          },
+        },
+      },
+    };
+  },
+};
+```
+
+### SessionManager Integration
+
+```typescript
+// session-manager.ts — initSession()
+const merged = mergeAgentContributions(this.getAgentContributions());
+
+// Add built-in RTK hook
+if (registerRtkHook) {
+  (merged.hooks ??= {} as any).PreToolUse ??= [];
+  (merged.hooks!.PreToolUse as HookCallbackMatcher[]).push({ matcher: "Bash", hooks: [rtkHook] });
+}
+
+const options: Options = {
+  ...queryOpts,
+  allowDangerouslySkipPermissions: true,
+  env,
+  settings: { ... },
+  hooks: merged.hooks ?? {},
+  mcpServers: merged.mcpServers,
+  ...(opts?.resume ? { resume: opts.resume, sessionId: undefined } : {}),
+  ...(spawnOverride ? { spawnClaudeCodeProcess: spawnOverride } : {}),
+};
+```
+
+## Merge Strategy Summary
+
+| Field        | Strategy      | Conflict Behavior                    |
+| ------------ | ------------- | ------------------------------------ |
+| `hooks`      | Concat arrays | All hooks execute (no conflict)      |
+| `mcpServers` | First-win     | Warning logged, later plugin skipped |
+
+## Files Changed
+
+| File                                         | Change                                               |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `src/main/core/plugin/contributions.ts`      | Widen `Pick<>`, add `mergeAgentContributions()`      |
+| `src/main/features/agent/session-manager.ts` | Use `mergeAgentContributions()`, spread `mcpServers` |
+| Tests                                        | Update to cover mcpServers merge + conflict warning  |

--- a/packages/desktop/src/main/core/plugin/__tests__/contributions.test.ts
+++ b/packages/desktop/src/main/core/plugin/__tests__/contributions.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+
+import type { Contribution } from "../contribution";
+import type { AgentContributions } from "../contributions";
+
+import { mergeAgentContributions } from "../contributions";
+
+function makeContribution(
+  pluginName: string,
+  value: AgentContributions,
+): Contribution<AgentContributions> {
+  return { plugin: { name: pluginName }, value };
+}
+
+const noopHook = async () => ({ continue: true as const });
+
+describe("mergeAgentContributions", () => {
+  it("returns empty hooks and mcpServers when no contributions", () => {
+    const result = mergeAgentContributions([]);
+    expect(result).toEqual({ hooks: {}, mcpServers: {} });
+  });
+
+  it("returns empty hooks and mcpServers when contributions have no claudeCode options", () => {
+    const result = mergeAgentContributions([
+      makeContribution("a", {}),
+      makeContribution("b", { claudeCode: {} }),
+      makeContribution("c", { claudeCode: { options: {} } }),
+    ]);
+    expect(result).toEqual({ hooks: {}, mcpServers: {} });
+  });
+
+  it("merges mcpServers from a single plugin", () => {
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: {
+          options: {
+            mcpServers: {
+              "a:db": { command: "node", args: ["db.js"] },
+            },
+          },
+        },
+      }),
+    ]);
+    expect(result.mcpServers).toEqual({
+      "a:db": { command: "node", args: ["db.js"] },
+    });
+  });
+
+  it("merges hooks from a single plugin", () => {
+    const matcher = { matcher: "Bash", hooks: [noopHook] };
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: { options: { hooks: { PreToolUse: [matcher] } } },
+      }),
+    ]);
+    expect(result.hooks).toEqual({ PreToolUse: [matcher] });
+  });
+
+  it("merges both hooks and mcpServers", () => {
+    const matcher = { matcher: "Bash", hooks: [noopHook] };
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: {
+          options: {
+            hooks: { PreToolUse: [matcher] },
+            mcpServers: { "a:srv": { command: "a" } },
+          },
+        },
+      }),
+    ]);
+    expect(result.hooks).toEqual({ PreToolUse: [matcher] });
+    expect(result.mcpServers).toEqual({ "a:srv": { command: "a" } });
+  });
+
+  it("merges mcpServers from multiple plugins without conflicts", () => {
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: { options: { mcpServers: { "a:db": { command: "a" } } } },
+      }),
+      makeContribution("b", {
+        claudeCode: { options: { mcpServers: { "b:api": { command: "b" } } } },
+      }),
+    ]);
+    expect(result.mcpServers).toEqual({
+      "a:db": { command: "a" },
+      "b:api": { command: "b" },
+    });
+  });
+
+  it("first-win on mcpServers name conflict", () => {
+    const result = mergeAgentContributions([
+      makeContribution("first", {
+        claudeCode: { options: { mcpServers: { shared: { command: "first" } } } },
+      }),
+      makeContribution("second", {
+        claudeCode: { options: { mcpServers: { shared: { command: "second" } } } },
+      }),
+    ]);
+    expect(result.mcpServers).toEqual({
+      shared: { command: "first" },
+    });
+  });
+
+  it("respects enforce ordering for mcpServers conflicts", () => {
+    // Contributions are passed in enforce order (pre → normal → post)
+    // so the first contribution in the array should win
+    const result = mergeAgentContributions([
+      makeContribution("pre-plugin", {
+        claudeCode: { options: { mcpServers: { db: { command: "pre" } } } },
+      }),
+      makeContribution("normal-plugin", {
+        claudeCode: { options: { mcpServers: { db: { command: "normal" } } } },
+      }),
+    ]);
+    expect(result.mcpServers).toEqual({
+      db: { command: "pre" },
+    });
+  });
+
+  it("concatenates hooks from multiple plugins", () => {
+    const matcherA = { matcher: "Bash", hooks: [noopHook] };
+    const matcherB = { matcher: "Read", hooks: [noopHook] };
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: { options: { hooks: { PreToolUse: [matcherA] } } },
+      }),
+      makeContribution("b", {
+        claudeCode: { options: { hooks: { PreToolUse: [matcherB] } } },
+      }),
+    ]);
+    expect(result.hooks).toEqual({
+      PreToolUse: [matcherA, matcherB],
+    });
+  });
+
+  it("returns empty mcpServers when plugins contribute empty mcpServers", () => {
+    const result = mergeAgentContributions([
+      makeContribution("a", {
+        claudeCode: { options: { mcpServers: {} } },
+      }),
+    ]);
+    expect(result.mcpServers).toEqual({});
+  });
+
+  it("gracefully handles undefined at every nesting level", () => {
+    const result = mergeAgentContributions([
+      makeContribution("a", {}),
+      makeContribution("b", { claudeCode: undefined }),
+      makeContribution("c", { claudeCode: { options: undefined } }),
+      makeContribution("d", {
+        claudeCode: { options: { hooks: undefined, mcpServers: undefined } },
+      }),
+    ]);
+    expect(result).toEqual({ hooks: {}, mcpServers: {} });
+  });
+});

--- a/packages/desktop/src/main/core/plugin/contributions.ts
+++ b/packages/desktop/src/main/core/plugin/contributions.ts
@@ -27,7 +27,7 @@ export type Contributions = {
   deeplinkHandlers: Contribution<DeeplinkHandler>[];
 };
 
-type MergedAgentOptions = Pick<Options, "hooks" | "mcpServers">;
+type MergedAgentOptions = Required<Pick<Options, "hooks" | "mcpServers">>;
 
 /** Merge all agent contributions into a single SDK-compatible options subset. */
 export function mergeAgentContributions(

--- a/packages/desktop/src/main/core/plugin/contributions.ts
+++ b/packages/desktop/src/main/core/plugin/contributions.ts
@@ -1,15 +1,24 @@
-import type { HookCallbackMatcher, HookEvent, Options } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  HookCallbackMatcher,
+  HookEvent,
+  McpServerConfig,
+  Options,
+} from "@anthropic-ai/claude-agent-sdk";
 import type { AnyRouter } from "@orpc/server";
+
+import debug from "debug";
 
 import type { DeeplinkHandler } from "../deeplink/types";
 import type { Contribution } from "./contribution";
+
+const log = debug("neovate:plugin:contributions");
 
 export interface AgentContributions {
   claudeCode?: ClaudeCodeContributions;
 }
 
 export interface ClaudeCodeContributions {
-  options?: Pick<Options, "hooks">;
+  options?: Pick<Options, "hooks" | "mcpServers">;
 }
 
 export type Contributions = {
@@ -18,18 +27,42 @@ export type Contributions = {
   deeplinkHandlers: Contribution<DeeplinkHandler>[];
 };
 
-/** Merge agent hook contributions into a single SDK-compatible hooks record. */
-export function mergeAgentHooks(
+type MergedAgentOptions = Pick<Options, "hooks" | "mcpServers">;
+
+/** Merge all agent contributions into a single SDK-compatible options subset. */
+export function mergeAgentContributions(
   agents: Contribution<AgentContributions>[],
-): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
-  const merged: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {};
-  for (const { value } of agents) {
-    const hooks = value.claudeCode?.options?.hooks;
-    if (!hooks) continue;
-    for (const [event, matchers] of Object.entries(hooks)) {
-      if (!matchers) continue;
-      (merged[event as HookEvent] ??= []).push(...matchers);
+): MergedAgentOptions {
+  const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {};
+  const mcpServers: Record<string, McpServerConfig> = {};
+  const mcpServerSources: Record<string, string> = {};
+
+  for (const { plugin, value } of agents) {
+    const pluginHooks = value.claudeCode?.options?.hooks;
+    if (pluginHooks) {
+      for (const [event, matchers] of Object.entries(pluginHooks)) {
+        if (!matchers) continue;
+        (hooks[event as HookEvent] ??= []).push(...matchers);
+      }
+    }
+
+    const pluginMcpServers = value.claudeCode?.options?.mcpServers;
+    if (pluginMcpServers) {
+      for (const [name, config] of Object.entries(pluginMcpServers)) {
+        if (mcpServerSources[name]) {
+          log(
+            "MCP server '%s' from plugin '%s' ignored — already registered by '%s'",
+            name,
+            plugin.name,
+            mcpServerSources[name],
+          );
+          continue;
+        }
+        mcpServers[name] = config;
+        mcpServerSources[name] = plugin.name;
+      }
     }
   }
-  return merged;
+
+  return { hooks, mcpServers };
 }

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -1,5 +1,4 @@
 import type {
-  HookCallbackMatcher,
   Query,
   Options,
   SDKUserMessage,
@@ -572,12 +571,11 @@ export class SessionManager {
     log(
       "initSession: merged contributions sessionId=%s mcpServers=%o hookEvents=%o",
       sessionId,
-      Object.keys(merged.mcpServers ?? {}),
-      Object.keys(merged.hooks ?? {}),
+      Object.keys(merged.mcpServers),
+      Object.keys(merged.hooks),
     );
     if (registerRtkHook) {
-      const hooks = merged.hooks as Record<string, HookCallbackMatcher[]>;
-      (hooks.PreToolUse ??= []).push({ matcher: "Bash", hooks: [rtkHook] });
+      (merged.hooks.PreToolUse ??= []).push({ matcher: "Bash", hooks: [rtkHook] });
     }
 
     // Build spawnClaudeCodeProcess override:

--- a/packages/desktop/src/main/features/agent/session-manager.ts
+++ b/packages/desktop/src/main/features/agent/session-manager.ts
@@ -1,4 +1,5 @@
 import type {
+  HookCallbackMatcher,
   Query,
   Options,
   SDKUserMessage,
@@ -35,7 +36,7 @@ import type {
 } from "../../../shared/features/agent/types";
 import type { Contributions } from "../../core/plugin/contributions";
 
-import { mergeAgentHooks } from "../../core/plugin/contributions";
+import { mergeAgentContributions } from "../../core/plugin/contributions";
 
 const execFileAsync = promisify(execFile);
 import type { Provider } from "../../../shared/features/provider/types";
@@ -566,10 +567,17 @@ export class SessionManager {
       cwd,
       model: opts?.model,
     });
-    // Merge plugin-contributed hooks with built-in hooks (RTK)
-    const mergedHooks = mergeAgentHooks(this.getAgentContributions());
+    // Merge plugin-contributed hooks and MCP servers
+    const merged = mergeAgentContributions(this.getAgentContributions());
+    log(
+      "initSession: merged contributions sessionId=%s mcpServers=%o hookEvents=%o",
+      sessionId,
+      Object.keys(merged.mcpServers ?? {}),
+      Object.keys(merged.hooks ?? {}),
+    );
     if (registerRtkHook) {
-      (mergedHooks.PreToolUse ??= []).push({ matcher: "Bash", hooks: [rtkHook] });
+      const hooks = merged.hooks as Record<string, HookCallbackMatcher[]>;
+      (hooks.PreToolUse ??= []).push({ matcher: "Bash", hooks: [rtkHook] });
     }
 
     // Build spawnClaudeCodeProcess override:
@@ -652,7 +660,8 @@ export class SessionManager {
         ...(settingsEnv ? { env: settingsEnv } : {}),
         ...(agentLanguage !== "English" ? { language: agentLanguage.toLowerCase() } : {}),
       },
-      hooks: mergedHooks,
+      hooks: merged.hooks,
+      mcpServers: merged.mcpServers,
       ...(opts?.resume ? { resume: opts.resume, sessionId: undefined } : {}),
       ...(spawnOverride ? { spawnClaudeCodeProcess: spawnOverride } : {}),
     };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -26,6 +26,7 @@ import { SkillsService } from "./features/skills/skills-service";
 import { StateStore } from "./features/state/state-store";
 import { UpdaterService } from "./features/updater/service";
 import changesPlugin from "./plugins/changes";
+// import demoMcpLivePreviewPlugin from "./plugins/demo-mcp-live-preview";
 import editorPlugin from "./plugins/editor";
 import filesPlugin from "./plugins/files";
 import gitPlugin from "./plugins/git";
@@ -85,7 +86,14 @@ const stateStore = new StateStore();
 const llmService = new LlmService(configStore, shellEnvService);
 const mainApp = new MainApp({
   appName: app.getName(),
-  plugins: [gitPlugin, filesPlugin, terminalPlugin, editorPlugin, changesPlugin],
+  plugins: [
+    gitPlugin,
+    filesPlugin,
+    terminalPlugin,
+    editorPlugin,
+    changesPlugin,
+    // demoMcpLivePreviewPlugin,
+  ],
   llmService,
 });
 const updaterService = new UpdaterService({

--- a/packages/desktop/src/main/plugins/demo-mcp-live-preview/index.ts
+++ b/packages/desktop/src/main/plugins/demo-mcp-live-preview/index.ts
@@ -1,0 +1,53 @@
+import type { MainPlugin } from "../../core/plugin/types";
+
+import { PreviewManager } from "./preview-manager";
+import { createLivePreviewRouter } from "./router";
+
+/**
+ * Demo: MCP Live Preview.
+ *
+ * Contributes an in-process MCP server with a `preview` tool.
+ * When the Agent calls `preview` with HTML, the content is streamed
+ * to a ContentPanel view in the renderer for real-time rendering.
+ */
+export default {
+  name: "demo-mcp-live-preview",
+
+  async configContributions(ctx) {
+    const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
+    const { z } = await import("zod");
+
+    const previewManager = new PreviewManager();
+
+    const server = createSdkMcpServer({
+      name: "live-preview",
+      version: "0.0.1",
+      tools: [
+        tool(
+          "preview",
+          "Render HTML content in the Live Preview panel. Use this to show visual previews to the user.",
+          { html: z.string().describe("Complete HTML content to render") },
+          async ({ html }) => {
+            previewManager.setHtml(html);
+            return {
+              content: [{ type: "text" as const, text: "Preview updated." }],
+            };
+          },
+        ),
+      ],
+    });
+
+    return {
+      router: createLivePreviewRouter(ctx.orpcServer, previewManager),
+      agents: {
+        claudeCode: {
+          options: {
+            mcpServers: {
+              "live-preview": server,
+            },
+          },
+        },
+      },
+    };
+  },
+} satisfies MainPlugin;

--- a/packages/desktop/src/main/plugins/demo-mcp-live-preview/preview-manager.ts
+++ b/packages/desktop/src/main/plugins/demo-mcp-live-preview/preview-manager.ts
@@ -1,0 +1,15 @@
+import { EventPublisher } from "@orpc/server";
+
+export class PreviewManager {
+  #html = "";
+  readonly publisher = new EventPublisher<{ update: string }>();
+
+  setHtml(html: string) {
+    this.#html = html;
+    this.publisher.publish("update", html);
+  }
+
+  getHtml() {
+    return this.#html;
+  }
+}

--- a/packages/desktop/src/main/plugins/demo-mcp-live-preview/router.ts
+++ b/packages/desktop/src/main/plugins/demo-mcp-live-preview/router.ts
@@ -1,0 +1,29 @@
+import { eventIterator } from "@orpc/server";
+import { z } from "zod";
+
+import type { PluginContext } from "../../core/plugin/types";
+import type { PreviewManager } from "./preview-manager";
+
+export function createLivePreviewRouter(
+  orpcServer: PluginContext["orpcServer"],
+  previewManager: PreviewManager,
+) {
+  return orpcServer.router({
+    getPreview: orpcServer.handler(async () => {
+      return { html: previewManager.getHtml() };
+    }),
+
+    stream: orpcServer.output(eventIterator(z.string())).handler(async function* ({ signal }) {
+      const current = previewManager.getHtml();
+      if (current) yield current;
+
+      try {
+        for await (const html of previewManager.publisher.subscribe("update", { signal })) {
+          yield html;
+        }
+      } catch (err) {
+        if ((err as Error)?.name !== "AbortError") throw err;
+      }
+    }),
+  });
+}

--- a/packages/desktop/src/renderer/src/core/app.tsx
+++ b/packages/desktop/src/renderer/src/core/app.tsx
@@ -37,6 +37,7 @@ import { useSettingsStore } from "../features/settings/store";
 import { client } from "../orpc";
 import changesPlugin from "../plugins/changes";
 import debugPlugin from "../plugins/debug";
+// import demoMcpLivePreviewPlugin from "../plugins/demo-mcp-live-preview";
 // import contentPanelDemoPlugin from "../plugins/content-panel-demo";
 // import demoWindowPlugin from "../plugins/demo-window";
 import editorPlugin from "../plugins/editor";
@@ -202,6 +203,7 @@ const BUILTIN_PLUGINS: RendererPlugin[] = [
   changesPlugin,
   networkPlugin,
   debugPlugin,
+  // demoMcpLivePreviewPlugin,
   providersPlugin,
   popupWindowPlugin,
   // TODO: Remove in the future

--- a/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/index.tsx
@@ -1,0 +1,55 @@
+import { EyeIcon } from "lucide-react";
+
+import type { RendererPlugin } from "../../core/plugin";
+
+const PreviewIcon = ({ className }: { className?: string }) => (
+  <EyeIcon className={className} size={16} />
+);
+
+let cleanup: (() => void) | null = null;
+
+const plugin: RendererPlugin = {
+  name: "demo-mcp-live-preview",
+
+  configViewContributions() {
+    return {
+      contentPanelViews: [
+        {
+          viewType: "live-preview",
+          name: "Live Preview",
+          singleton: true,
+          icon: PreviewIcon,
+          component: () => import("./preview-view"),
+        },
+      ],
+    };
+  },
+
+  activate(ctx) {
+    const client = ctx.orpcClient as any;
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const stream = await client["demo-mcp-live-preview"].stream(undefined, {
+          signal: controller.signal,
+        });
+        for await (const _chunk of stream) {
+          ctx.app.workbench.contentPanel.openView("live-preview");
+          break;
+        }
+      } catch {
+        // stream aborted on deactivate — ignore
+      }
+    })();
+
+    cleanup = () => controller.abort();
+  },
+
+  deactivate() {
+    cleanup?.();
+    cleanup = null;
+  },
+};
+
+export default plugin;

--- a/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/index.tsx
+++ b/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/index.tsx
@@ -26,6 +26,7 @@ const plugin: RendererPlugin = {
   },
 
   activate(ctx) {
+    cleanup?.();
     const client = ctx.orpcClient as any;
     const controller = new AbortController();
 

--- a/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/preview-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/demo-mcp-live-preview/preview-view.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+
+import { usePluginContext } from "../../core/app";
+
+export default function PreviewView() {
+  const { orpcClient } = usePluginContext();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [html, setHtml] = useState("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const client = orpcClient as any;
+
+    (async () => {
+      try {
+        const stream = await client["demo-mcp-live-preview"].stream(undefined, {
+          signal: controller.signal,
+        });
+        for await (const chunk of stream) {
+          setHtml(chunk as string);
+        }
+      } catch (err) {
+        if ((err as Error)?.name !== "AbortError") {
+          console.error("[live-preview] stream error:", err);
+        }
+      }
+    })();
+
+    return () => controller.abort();
+  }, [orpcClient]);
+
+  useEffect(() => {
+    if (iframeRef.current) {
+      iframeRef.current.srcdoc = html;
+    }
+  }, [html]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {html ? (
+        <iframe
+          ref={iframeRef}
+          title="Live Preview"
+          className="h-full w-full border-0"
+          sandbox="allow-scripts allow-same-origin"
+        />
+      ) : (
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+          Waiting for Agent to call the{" "}
+          <code className="mx-1 rounded bg-muted px-1.5 py-0.5 font-mono text-xs">preview</code>{" "}
+          tool…
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extend the plugin contribution system to support `mcpServers` alongside existing `hooks` — plugins can now declare MCP server configurations via `configContributions()`, merged across plugins with first-win-by-name strategy and passed to the SDK when creating sessions.
- Replace `mergeAgentHooks()` with `mergeAgentContributions()` that handles both hooks (concat) and mcpServers (first-win with debug warning on conflicts).
- Add `demo-mcp-live-preview` plugin as a reference implementation using `createSdkMcpServer` from the Agent SDK (commented out in registration, kept as example code).
- Add comprehensive unit tests (11 cases) covering empty contributions, single/multi-plugin merges, first-win conflict resolution, and hook concatenation.
- Include design doc for the contribution merge strategy.

## Test plan
- [x] `bun ready` passes (format + typecheck + lint + tests)
- [ ] Uncomment demo plugin registration, verify MCP server appears in Agent session tools
- [ ] Verify existing hook contributions still work correctly
- [ ] Verify first-win conflict warning appears in debug logs when two plugins register same server name