### PR TITLE
fix(files): stop tree copy shortcut from hijacking text copy

### DIFF
--- a/packages/desktop/src/renderer/src/plugins/files/hooks/useTreeKeyboardShortcuts.ts
+++ b/packages/desktop/src/renderer/src/plugins/files/hooks/useTreeKeyboardShortcuts.ts
@@ -126,6 +126,9 @@ export function useTreeKeyboardShortcuts(options: UseTreeKeyboardShortcutsOption
 
       // Cmd/Ctrl + C: copy
       if (e.key === "c" && isModKey) {
+        // Defer to native text copy when the user has an active text selection,
+        // otherwise this hijacks Cmd+C for any text anywhere in the window.
+        if (window.getSelection()?.toString()) return;
         e.preventDefault();
         onCopy(item);
         return;
@@ -133,6 +136,7 @@ export function useTreeKeyboardShortcuts(options: UseTreeKeyboardShortcutsOption
 
       // Cmd/Ctrl + X: cut
       if (e.key === "x" && isModKey) {
+        if (window.getSelection()?.toString()) return;
         e.preventDefault();
         onCut(item);
         return;


### PR DESCRIPTION
## Summary

- Workaround for #479: Cmd/Ctrl+C and Cmd/Ctrl+X in `useTreeKeyboardShortcuts` now defer to the native text copy/cut when `window.getSelection()` is non-empty, instead of unconditionally calling `preventDefault()` whenever a single tree item is selected.
- Minimal, low-risk change — file tree's own copy/cut still works when there is no active text selection.

This is only a short-term workaround. The structural fix described in #479 (TanStack Hotkeys migration + lint rule + e2e coverage) is **not** addressed here, so the issue should remain open after this merges.

Refs #479

## Test plan

- [ ] Click a file in the tree, select text in a chat message, Cmd+C, paste elsewhere — pasted content is the chat text
- [ ] Click a file in the tree (no text selection), Cmd+C then Cmd+V in another folder — file is copied
- [ ] Click a file in the tree (no text selection), Cmd+X then Cmd+V in another folder — file is moved
- [ ] Edit → Copy menu still works with a tree item selected