### PR TITLE
feat(desktop): improve ExitPlanMode plan display and dialog layout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/desktop": {
       "name": "neovate-desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ai-sdk/provider-utils": "^4.0.22",
         "@anthropic-ai/claude-agent-sdk": "0.2.97",

--- a/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/agent-chat.tsx
@@ -305,7 +305,7 @@ function AgentChatSession({ sessionId, cwd }: { sessionId: string; cwd: string }
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="@container/chat flex h-full flex-col">
       <Conversation contextRef={conversationContextRef} initial={initialScrollBehavior}>
         <ConversationContent>
           {messages.map((message, i) => (

--- a/packages/desktop/src/renderer/src/features/agent/components/exit-plan-mode-request-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/exit-plan-mode-request-dialog.tsx
@@ -80,22 +80,22 @@ export function ExitPlanModeRequestDialog({ plan, onChoice }: Props) {
   };
 
   return (
-    <div className="relative bg-background-secondary">
-      <Plan defaultOpen>
-        <PlanHeader>
-          <PlanTitle>{t("plan.title")}</PlanTitle>
+    <div className="relative max-h-[calc(100cqh-8rem)] bg-background-secondary flex flex-col overflow-hidden">
+      <Plan defaultOpen className="m-2 min-h-0 flex-1 flex flex-col">
+        <PlanHeader className="px-4 py-2.5 gap-1 items-center">
+          <PlanTitle className="text-sm">{t("plan.title")}</PlanTitle>
           <PlanAction>
             <PlanTrigger />
           </PlanAction>
         </PlanHeader>
-        <PlanContent>
-          <div className="max-h-[40vh] overflow-y-auto px-4 pb-4">
+        <PlanContent className="min-h-0 overflow-y-auto px-4 pb-3 pt-0">
+          <div className="text-sm">
             <MessageResponse>{plan}</MessageResponse>
           </div>
         </PlanContent>
       </Plan>
 
-      <div className="space-y-3 px-4 py-3">
+      <div className="shrink-0 space-y-3 border-t border-border/50 px-4 py-3">
         <p className="text-sm font-medium text-foreground">{t("plan.readyToImplement")}</p>
 
         <RadioGroup

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
@@ -125,13 +125,13 @@ export function PermissionDialog({ sessionId }: Props) {
     });
 
     // 4. Save plan to disk
-    client.agent.savePlan({ sessionId, plan: input.plan }).catch(() => {});
+    client.agent.savePlan({ sessionId, plan: input.plan! }).catch(() => {});
 
     // 5. If clear context, register pending action
     if (choice.clearContext) {
       const cwd = useAgentStore.getState().sessions.get(sessionId)?.cwd;
       chat?.store.setState({
-        pendingContextClear: { plan: input.plan, mode: choice.mode, cwd },
+        pendingContextClear: { plan: input.plan!, mode: choice.mode, cwd },
       });
     }
   };

--- a/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/permission-dialog.tsx
@@ -164,7 +164,7 @@ export function PermissionDialog({ sessionId }: Props) {
     content = (
       <ExitPlanModeRequestDialog
         key={requestId}
-        plan={exitPlanMode.data.plan}
+        plan={exitPlanMode.data.plan!}
         onChoice={handleExitPlanModeChoice}
       />
     );

--- a/packages/desktop/src/renderer/src/features/agent/components/tool-parts/exit-plan-mode-tool.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/tool-parts/exit-plan-mode-tool.tsx
@@ -1,24 +1,22 @@
 import type { ExitPlanModeUIToolInvocation } from "../../../../../../shared/claude-code/types";
 
+import { MessageResponse } from "../../../../components/ai-elements/message";
 import { Tool, ToolContent, ToolHeader } from "../../../../components/ai-elements/tool";
 
 export function ExitPlanModeTool({ invocation }: { invocation: ExitPlanModeUIToolInvocation }) {
-  // Hide while approval dialog is active (same pattern as AskUserQuestionTool)
-  if (
-    !invocation ||
-    invocation.state === "input-streaming" ||
-    invocation.state === "input-available" ||
-    !invocation.output
-  ) {
-    return null;
-  }
-  const { state, output } = invocation;
+  if (!invocation || invocation.state === "input-streaming") return null;
+
+  const { state, input, output } = invocation;
 
   return (
     <Tool>
       <ToolHeader type="tool-ExitPlanMode" state={state} title="Exit Plan Mode" />
       <ToolContent>
-        <p className="text-sm text-muted-foreground">{output}</p>
+        {state === "input-available" && input?.plan ? (
+          <MessageResponse>{input.plan}</MessageResponse>
+        ) : (state === "output-available" || state === "output-denied") && output ? (
+          <p className="text-sm text-muted-foreground">{output}</p>
+        ) : null}
       </ToolContent>
     </Tool>
   );

--- a/packages/desktop/src/shared/claude-code/tools/exit-plan-mode.ts
+++ b/packages/desktop/src/shared/claude-code/tools/exit-plan-mode.ts
@@ -2,10 +2,12 @@ import { tool, type UIToolInvocation } from "ai";
 import { z } from "zod";
 
 export const ExitPlanModeInputSchema = z.object({
-  /**
-   * The plan to run by the user for approval
-   */
-  plan: z.string(),
+  /** Prompt-based permissions needed to implement the plan (model-provided). */
+  allowedPrompts: z.array(z.object({ tool: z.string(), prompt: z.string() })).optional(),
+  /** The plan content (injected by SDK from disk). */
+  plan: z.string().optional(),
+  /** The plan file path (injected by SDK). */
+  planFilePath: z.string().optional(),
 });
 
 export const ExitPlanMode = tool({


### PR DESCRIPTION
## Summary

- Align `ExitPlanModeInputSchema` with SDK actual data (`allowedPrompts`, `plan`, `planFilePath`)
- Show plan content inline in message list during `input-available` state
- Constrain permission dialog height relative to chat container via `@container` query
- Improve dialog layout: scrollable plan area, smaller text, border separator for approval controls

## Test plan

- [ ] Trigger ExitPlanMode in a `default` permission mode session — plan renders in message list and permission dialog
- [ ] Approve/deny plan — tool part switches to output text
- [ ] Long plan content — dialog scrolls, approve/dismiss buttons stay visible
- [ ] Collapse/expand plan in dialog — header stays vertically centered