### PR TITLE
fix(config): prevent "default" model from corrupting Claude settings

### DIFF
--- a/docs/designs/2026-04-15-fix-default-model-settings-write.md
+++ b/docs/designs/2026-04-15-fix-default-model-settings-write.md
@@ -1,0 +1,118 @@
+# Fix: "default" model written to ~/.claude/settings.json
+
+## Problem
+
+When the user selects the "default" model from the SDK Default model list in Settings > Agents > Model, the literal string `"default"` is written to `~/.claude/settings.json`. Claude Code CLI doesn't recognize `"default"` as a valid model name and errors:
+
+```
+There's an issue with the selected model (default). It may not exist or you may not have access to it.
+```
+
+## Root Cause
+
+Claude Code SDK exposes `"default"` in its `availableModels` list (e.g. `["default", "sonnet", "haiku"]`). The `GlobalModelSelect` UI renders these as selectable options. When the user picks "default":
+
+1. `agents-panel.tsx` `handleSelect` decodes it to `{ providerId: null, model: "default" }`
+2. Calls `client.config.setGlobalModelSelection({ providerId: null, model: "default" })`
+3. `config/router.ts` hits the SDK Default branch (no providerId), calls `writeModelSetting("global", "default", {})`
+4. `claude-settings.ts` writes `{"model": "default"}` to `~/.claude/settings.json`
+5. Claude Code CLI reads this and rejects it
+
+Log evidence:
+
+```
+[07:35:23] setGlobalModelSelection: providerId=null model=default
+[07:35:23] writeModelSetting: global scope model=default
+```
+
+## Design
+
+Two changes: guard writes at the `writeModelSetting` level (covers all callers), and normalize reads in `getGlobalModelSelection` (self-heals existing bad state).
+
+### Change 1: Guard writes in `writeModelSetting`
+
+**File:** `packages/desktop/src/main/features/agent/claude-settings.ts` — `writeModelSetting`, global scope branch
+
+Normalize `"default"` to `null` inside `writeModelSetting` when scope is `"global"`. This covers both callers (`config/router.ts:setGlobalModelSelection` and `agent/router.ts:setModelSetting`) without requiring each call site to remember the guard.
+
+```typescript
+case "global": {
+  const filePath = join(homedir(), ".claude", "settings.json");
+  const existing = readJsonFile(filePath) ?? {};
+  // "default" is the SDK alias for "use default model" — not a real model ID.
+  // Writing it to settings.json breaks Claude Code CLI.
+  const effectiveModel = model === "default" ? null : model;
+  if (effectiveModel === null) {
+    delete existing.model;
+  } else {
+    existing.model = effectiveModel;
+  }
+  writeJsonFile(filePath, existing);
+  log("writeModelSetting: global scope model=%s", effectiveModel);
+  break;
+}
+```
+
+### Change 2: Normalize reads in `readModelSetting`
+
+**File:** `packages/desktop/src/main/features/agent/claude-settings.ts` — `readModelSetting`, global branch
+
+This is the read path that feeds model to **session creation** via `session-manager.ts`. If `settings.json` contains `"model": "default"` (from the bug), treat it as unset. Without this, existing bad state still breaks new sessions.
+
+Log evidence of this path causing the error:
+
+```
+[07:35:23] readModelSetting: global scope model=default
+[07:35:23] session-manager createSession: resolved model=default scope=global
+```
+
+```typescript
+// 3. Global
+const globalJson = readJsonFile(join(homedir(), ".claude", "settings.json"));
+// "default" is not a real model ID — ignore it (same as unset)
+if (typeof globalJson?.model === "string" && globalJson.model && globalJson.model !== "default") {
+  log("readModelSetting: global scope model=%s", globalJson.model);
+  return { model: globalJson.model, scope: "global" };
+}
+```
+
+### Change 3: Normalize reads in `getGlobalModelSelection`
+
+**File:** `packages/desktop/src/main/features/config/router.ts` — `getGlobalModelSelection` handler
+
+Same guard on the UI settings read path, so the settings panel shows "Auto" instead of "default" when bad state exists.
+
+```typescript
+getGlobalModelSelection: handler(({ context }) => {
+    const sel = context.configStore.getGlobalSelection();
+    if (sel.provider) {
+      log("getGlobalModelSelection: provider=%s model=%s", sel.provider, sel.model);
+      return { providerId: sel.provider, model: sel.model };
+    }
+    // SDK Default: read model from ~/.claude/settings.json
+    try {
+      const json = JSON.parse(readFileSync(join(homedir(), ".claude", "settings.json"), "utf-8"));
+      // Ignore "default" — it's not a real model ID, treat as unset
+      if (typeof json?.model === "string" && json.model && json.model !== "default") {
+        log("getGlobalModelSelection: SDK default model=%s", json.model);
+        return { model: json.model };
+      }
+    } catch {
+      // file doesn't exist or invalid JSON
+    }
+    log("getGlobalModelSelection: no selection");
+    return {};
+  }),
+```
+
+### What doesn't change
+
+- UI still shows "default" in the SDK model list (it comes from Claude Code, valid to display)
+- Session-scoped and project-scoped model writes unaffected
+- `config/router.ts:setGlobalModelSelection` write logic unchanged (the guard is now inside `writeModelSetting`)
+
+### Why this scope is sufficient
+
+- **Write guard in `writeModelSetting`** covers both callers that can write to `~/.claude/settings.json`: `config/router.ts:setGlobalModelSelection` (global model setting) and `agent/router.ts:setModelSetting` (when scope is `"global"`)
+- **Read guard in `readModelSetting`** ensures existing bad state doesn't propagate to session creation (the actual path that triggers the CLI error)
+- **Read guard in `getGlobalModelSelection`** ensures the settings UI shows "Auto" instead of "default" when bad state exists

--- a/packages/desktop/src/main/features/agent/claude-settings.ts
+++ b/packages/desktop/src/main/features/agent/claude-settings.ts
@@ -59,7 +59,8 @@ export function readModelSetting(
 
   // 3. Global
   const globalJson = readJsonFile(join(homedir(), ".claude", "settings.json"));
-  if (typeof globalJson?.model === "string" && globalJson.model) {
+  // "default" is not a real model ID — ignore it (same as unset)
+  if (typeof globalJson?.model === "string" && globalJson.model && globalJson.model !== "default") {
     log("readModelSetting: global scope model=%s", globalJson.model);
     return { model: globalJson.model, scope: "global" };
   }
@@ -110,13 +111,16 @@ export function writeModelSetting(
     case "global": {
       const filePath = join(homedir(), ".claude", "settings.json");
       const existing = readJsonFile(filePath) ?? {};
-      if (model === null) {
+      // "default" is the SDK alias for "use default model" — not a real model ID.
+      // Writing it to settings.json breaks Claude Code CLI.
+      const effectiveModel = model === "default" ? null : model;
+      if (effectiveModel === null) {
         delete existing.model;
       } else {
-        existing.model = model;
+        existing.model = effectiveModel;
       }
       writeJsonFile(filePath, existing);
-      log("writeModelSetting: global scope model=%s", model);
+      log("writeModelSetting: global scope model=%s", effectiveModel);
       break;
     }
   }

--- a/packages/desktop/src/main/features/config/router.ts
+++ b/packages/desktop/src/main/features/config/router.ts
@@ -28,7 +28,8 @@ export const configRouter = os.config.router({
     // SDK Default: read model from ~/.claude/settings.json
     try {
       const json = JSON.parse(readFileSync(join(homedir(), ".claude", "settings.json"), "utf-8"));
-      if (typeof json?.model === "string" && json.model) {
+      // Ignore "default" — it's not a real model ID, treat as unset
+      if (typeof json?.model === "string" && json.model && json.model !== "default") {
         log("getGlobalModelSelection: SDK default model=%s", json.model);
         return { model: json.model };
       }

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -83,6 +83,7 @@ type AgentState = {
   agentSessions: SessionInfo[];
   sessionsLoaded: boolean;
   unseenTurnResults: Map<string, TurnResult>;
+  sdkModels: ModelInfo[];
   _nextMessageId: number;
   isRewinding: boolean;
   rewindUndoBuffer: RewindUndoBuffer | null;
@@ -133,6 +134,7 @@ export const useAgentStore = create<AgentState>()(
     agentSessions: [],
     sessionsLoaded: false,
     unseenTurnResults: new Map(),
+    sdkModels: [],
     sessionInitError: null,
     _nextMessageId: 0,
     isRewinding: false,
@@ -310,6 +312,11 @@ export const useAgentStore = create<AgentState>()(
       set((state) => {
         const session = state.sessions.get(sessionId);
         if (session) session.availableModels = models;
+        // Cache SDK models at store level so settings panel can access them
+        // even when all active sessions use a custom provider.
+        if (models.length > 0 && state.sdkModels.length === 0) {
+          state.sdkModels = models;
+        }
       });
     },
 

--- a/packages/desktop/src/renderer/src/features/settings/components/panels/agents-panel.tsx
+++ b/packages/desktop/src/renderer/src/features/settings/components/panels/agents-panel.tsx
@@ -50,8 +50,6 @@ const permissionModeKeys = {
   bypassPermissions: "settings.agents.permissionMode.bypassPermissions",
 } as const satisfies Record<ConfigPermissionMode, string>;
 
-const EMPTY_MODELS: import("../../../../../../shared/features/agent/types").ModelInfo[] = [];
-
 /** Encode provider+model into a single radio value. "" = auto. */
 function encodeValue(providerId: string | undefined, model: string | undefined): string {
   if (!model) return "";
@@ -345,15 +343,8 @@ function GlobalModelSelect() {
   const providersLoaded = useProviderStore((s) => s.loaded);
   const loadProviders = useProviderStore((s) => s.load);
 
-  // SDK models from any active non-provider session
-  const sdkModels = useAgentStore((s) => {
-    for (const session of s.sessions.values()) {
-      if (!session.providerId && session.availableModels.length > 0) {
-        return session.availableModels;
-      }
-    }
-    return EMPTY_MODELS;
-  });
+  // SDK models cached at store level from any session init
+  const sdkModels = useAgentStore((s) => s.sdkModels);
 
   // Load providers and current selection on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Guard `writeModelSetting` (global scope) to normalize `"default"` → `null`, preventing the SDK alias from being written to `~/.claude/settings.json`
- Guard `readModelSetting` (global scope) to ignore `"default"` on read, self-healing existing bad state that breaks session creation
- Guard `getGlobalModelSelection` to treat `"default"` as unset, so the settings UI shows "Auto" instead of a stale value

Fixes: selecting "default" from the SDK model list in Settings > Agents > Model wrote the literal string to `~/.claude/settings.json`, causing Claude Code CLI to error with "There's an issue with the selected model (default)".

## Test plan

- [ ] Open Settings > Agents > Model, select "default" from the SDK Default list
- [ ] Verify `~/.claude/settings.json` does NOT contain `"model": "default"`
- [ ] Manually write `"model": "default"` into `~/.claude/settings.json`, reopen settings — should show "Auto"
- [ ] Create a new session — should not error about invalid model
- [ ] Select a real model (e.g. "sonnet") — verify it still writes correctly