### PR TITLE
perf: fix session list re-render storm causing 100% CPU

### DIFF
--- a/docs/designs/2026-04-16-session-render-perf.md
+++ b/docs/designs/2026-04-16-session-render-perf.md
@@ -1,0 +1,408 @@
+# Session Rendering Performance Fix
+
+**Date:** 2026-04-16
+**Status:** Approved, ready to implement
+**Approach:** A (Derived Stores + Virtualization), then B (Split Store) incrementally
+
+## Problem
+
+With 1100+ sessions, the renderer pegs CPU at 100% and typing in the message input lags badly.
+
+### Root causes
+
+1. **Store subscription cascades:** `SessionItem`, `MessageInput`, and `InputToolbar` subscribe to the global `sessions` Map via `useAgentStore((s) => s.sessions.get(id)?.field)`. Because immer's `enableMapSet()` creates a new Map proxy on every mutation, ALL subscribers are notified on every store change — even when their specific session/field didn't change.
+
+2. **`unseenTurnResults` Map broadcasts:** When any session completes a turn, the immer-managed `unseenTurnResults` Map mutates, notifying all 50+ visible `UnifiedSessionItem` components.
+
+3. **No list virtualization:** `ChronologicalList` renders 50 real DOM nodes (capped from 1100+). Each re-render touches all 50.
+
+4. **Timer-driven re-renders:** `useRelativeTime` ticks every 10s, triggering snapshot checks on all 50+ `SessionItem`s, each with 7+ store selectors.
+
+5. **Input toolbar during streaming:** `ConnectedModelSelect` has `hasMessages` selector that re-renders on every streaming message update, blocking the tiptap editor's main thread.
+
+6. **`useStableSessions` is O(n) on every store mutation:** `sessionsMetaEqual()` in `use-unified-sessions.ts` iterates all 1100 sessions comparing 5 fields each (~5500 comparisons) on every store change, even unrelated ones like chat messages.
+
+7. **`QueryStatus` 100ms tick during streaming:** `useQueryStatus` runs `setInterval` at 100ms for spinner animation — 10 state updates/second while a turn is active.
+
+### Evidence
+
+| Metric                                  | Value       |
+| --------------------------------------- | ----------- |
+| Total sessions                          | 1114        |
+| Persisted sessions                      | 1655        |
+| Session renders (8h prod run)           | 3,239       |
+| `task queue exceeded deadline` warnings | up to 646ms |
+| CPU (old instance, active sessions)     | 100.4%      |
+| CPU (restart, idle, settled)            | ~20%        |
+| CPU only high with sidebar visible      | confirmed   |
+
+Dev log with same data (1114 sessions) shows identical render pattern — 398 session renders in 2 minutes. Dev "feels ok" only because the session was too short for cascading effects to compound.
+
+## Design: Phase A (Derived Stores + Virtualization)
+
+Changes ordered by priority. P0 items have the highest impact-to-effort ratio.
+
+### 0. [P0] Don't mount session list when sidebar is collapsed
+
+**Files:** `session-list.tsx` (modify)
+
+The user confirmed CPU is only high when the sidebar is open. The cheapest possible fix: don't render session list components at all when collapsed. Zero subscriptions, zero DOM nodes, zero cost.
+
+```tsx
+// In MultiProjectSessionList:
+const collapsed = useLayoutStore((s) => s.panels.primarySidebar.collapsed);
+if (collapsed) return null;
+
+// In SingleProjectSessionList: same pattern
+```
+
+When the sidebar re-opens, React mounts the components fresh. The `useFilteredSessions` hook recomputes once and the list renders.
+
+**Sidebar re-open jank:** With 1100 sessions, the initial `useFilteredSessions` filter + sort is synchronous and could cause a visible stutter on re-open. If this is noticeable, wrap the mount in `startTransition` so React renders it non-blockingly:
+
+```tsx
+const collapsed = useLayoutStore((s) => s.panels.primarySidebar.collapsed);
+const [deferred, setDeferred] = useState(collapsed);
+useEffect(() => {
+  if (collapsed) setDeferred(true);
+  else startTransition(() => setDeferred(false));
+}, [collapsed]);
+if (deferred) return null;
+```
+
+Measure first — likely unnecessary, but the escape hatch is here if needed.
+
+**Scroll position preservation:** When the list unmounts on collapse and remounts on expand, the user's scroll position is lost. Save `scrollTop` to a module-level variable (not state — no re-render needed) before unmount, restore on remount:
+
+```tsx
+let savedScrollTop = 0;
+
+// Inside the list component:
+const scrollRef = useRef<HTMLUListElement>(null);
+
+// Save on unmount
+useEffect(() => {
+  const el = scrollRef.current;
+  return () => {
+    if (el) savedScrollTop = el.scrollTop;
+  };
+}, []);
+
+// Restore on mount
+useEffect(() => {
+  if (scrollRef.current) scrollRef.current.scrollTop = savedScrollTop;
+}, []);
+```
+
+**Impact:** Eliminates 100% of sidebar render cost when hidden. No architectural change.
+
+### 1. [P0] New `useSessionMeta` hook
+
+**File:** `src/renderer/src/features/agent/hooks/use-session-meta.ts` (new)
+
+Single hook that extracts scalar session metadata with `shallow` equality from zustand, replacing 5-7 scattered `s.sessions.get(id)?.X` selectors.
+
+```ts
+import { shallow } from "zustand/shallow";
+import { useAgentStore } from "../store";
+
+export function useSessionMeta(sessionId: string | null) {
+  return useAgentStore((s) => {
+    if (!sessionId) return null;
+    const session = s.sessions.get(sessionId);
+    if (!session) return null;
+    return {
+      permissionMode: session.permissionMode,
+      currentModel: session.currentModel,
+      modelScope: session.modelScope,
+      providerId: session.providerId,
+      isNew: session.isNew,
+      hasMessages: session.messages.length > 0,
+    };
+  }, shallow);
+}
+```
+
+**Key detail:** `hasMessages` is a boolean, not the raw length. Adding message #2, #3, etc. during streaming doesn't change the boolean from `true` to `true`, so `shallow` equality prevents re-renders.
+
+**Important:** This hook is for **singleton components only** (`MessageInput`, `ConnectedModelSelect`, `ConnectedPermissionModeSelect`). It creates an object with 6 fields and runs `shallow` on every store mutation — acceptable for 1-3 instances, but NOT for 50 `SessionItem`s. For `SessionItem`, pass data as props instead (see section 6).
+
+**Consumers to migrate:**
+
+- `MessageInput` (line 101-103): `permissionMode`
+- `ConnectedModelSelect` (lines 339-344): `currentModel`, `modelScope`, `providerId`, `hasMessages`
+- `ConnectedPermissionModeSelect` (line 196-197): `permissionMode`
+- ~~`SessionItem` (line 59): `sessionIsNew`~~ → pass as prop instead (see section 6)
+
+### 2. [P0] Per-key event emitter for `unseenTurnResults`
+
+**File:** `src/renderer/src/features/agent/hooks/use-unseen-turn-result.ts` (new)
+
+Extract turn results out of the immer-managed store into a per-key event emitter. This ensures `markTurnCompleted("abc")` only notifies the one `SessionItem` rendering session `abc`, not all 50.
+
+A naive vanilla zustand store (`createStore`) would still broadcast to all subscribers via `setState`. Instead, use a per-key subscription pattern:
+
+```ts
+import { useCallback, useSyncExternalStore } from "react";
+import type { TurnResult } from "../store";
+
+const results = new Map<string, TurnResult>();
+const listeners = new Map<string, Set<() => void>>();
+
+function notify(sessionId: string) {
+  const set = listeners.get(sessionId);
+  if (set) for (const cb of set) cb();
+}
+
+export function markTurnCompleted(sessionId: string, result: TurnResult) {
+  results.set(sessionId, result);
+  notify(sessionId);
+}
+
+export function clearTurnResult(sessionId: string) {
+  if (!results.has(sessionId)) return;
+  results.delete(sessionId);
+  notify(sessionId);
+}
+
+function subscribe(sessionId: string, cb: () => void): () => void {
+  let set = listeners.get(sessionId);
+  if (!set) {
+    set = new Set();
+    listeners.set(sessionId, set);
+  }
+  set.add(cb);
+  return () => {
+    set.delete(cb);
+    if (set.size === 0) listeners.delete(sessionId);
+  };
+}
+
+export function useUnseenTurnResult(sessionId: string): TurnResult | undefined {
+  // useCallback ensures useSyncExternalStore doesn't unsubscribe/resubscribe
+  // on every render — only when sessionId changes.
+  const sub = useCallback((cb: () => void) => subscribe(sessionId, cb), [sessionId]);
+  const snap = useCallback(() => results.get(sessionId), [sessionId]);
+  return useSyncExternalStore(sub, snap);
+}
+```
+
+**Migration in `store.ts`:**
+
+- Remove `unseenTurnResults` from `AgentState`
+- `markTurnCompleted` and `clearTurnResult` actions delegate to the new module
+- `setActiveSession` calls `clearTurnResult` from the new module
+
+**Consumer:** `UnifiedSessionItem` (line 35) switches to `useUnseenTurnResult(sessionId)`.
+
+### 3. [P0] `sessionsMetaVersion` counter to avoid O(n) comparison
+
+**File:** `src/renderer/src/features/agent/store.ts` (modify), `use-unified-sessions.ts` (modify)
+
+**Problem:** `useStableSessions()` subscribes to `useAgentStore((s) => s.sessions)` and runs `sessionsMetaEqual()` on every store change — O(1100) comparisons of 5 fields each.
+
+**Fix:** Add a `_sessionsMetaVersion` counter to the store. Increment it only in actions that change session metadata (not messages/streaming):
+
+```ts
+// In AgentState:
+_sessionsMetaVersion: number;
+
+// Increment in: createSession, removeSession, renameSession, setIsNew,
+//               setCurrentModel, setModelScope, setProviderId, setPermissionMode,
+//               setAgentSessions, appendAgentSession, removeAgentSession
+// Do NOT increment in: addUserMessage, addAssistantMessage, setSessionUsage, task updates
+```
+
+Then `useStableSessions` becomes:
+
+```ts
+function useStableSessions(): Map<string, ChatSession> {
+  const version = useAgentStore((s) => s._sessionsMetaVersion);
+  const ref = useRef({ version: -1, sessions: new Map<string, ChatSession>() });
+  if (ref.current.version !== version) {
+    ref.current = { version, sessions: useAgentStore.getState().sessions };
+  }
+  return ref.current.sessions;
+}
+```
+
+This replaces the O(n) `sessionsMetaEqual` comparison with an O(1) integer check on every store mutation.
+
+### 4. [P1/defer?] Virtualize `ChronologicalList`
+
+**File:** `src/renderer/src/features/agent/components/chronological-list.tsx` (modify)
+
+**New dependency:** `@tanstack/react-virtual`
+
+**Note:** After fixes #0-#3, the 50 visible `SessionItem`s will barely re-render at all (no streaming cascade, no turn broadcast, no O(n) comparison, unmounted when collapsed). Virtualization reduces 50 DOM nodes to ~20 — a 60% reduction on an already-cheap operation. It adds scroll complexity, potential visual glitches, and a new dependency. **Measure after shipping #0-#3 before committing to this.** If 50 idle DOM nodes aren't a problem, defer to Phase B.
+
+Replace the flat `.map()` with `useVirtualizer`. Fixed item height ~36px, overscan 5.
+
+```tsx
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+// Inside ChronologicalList:
+const parentRef = useRef<HTMLUListElement>(null);
+const virtualizer = useVirtualizer({
+  count: visibleItems.length,
+  getScrollElement: () => parentRef.current,
+  estimateSize: () => 36,
+  overscan: 5,
+});
+
+return (
+  <ul ref={parentRef} style={{ overflow: "auto", flex: 1 }}>
+    <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+      {virtualizer.getVirtualItems().map((virtualRow) => {
+        const item = visibleItems[virtualRow.index];
+        const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+        return (
+          <div
+            key={id}
+            style={{
+              position: "absolute",
+              top: 0,
+              transform: `translateY(${virtualRow.start}px)`,
+              width: "100%",
+              height: virtualRow.size,
+            }}
+          >
+            <UnifiedSessionItem ... />
+          </div>
+        );
+      })}
+    </div>
+    {/* "Show more" button rendered outside the virtual list */}
+  </ul>
+);
+```
+
+**Scroll container:** The virtualizer needs to attach to a scrollable parent. Verify whether the sidebar provides an outer scroll wrapper. If the sidebar itself scrolls (containing `PinnedSessionList` + `ChronologicalList`), use `scrollMargin` on the virtualizer or make the virtualizer use a window-level scroll measurement. If `ChronologicalList` has its own scroll area, the snippet above works as-is.
+
+**Skip for now:** `PinnedSessionList` (15 items). `ProjectSessions` (capped at 5).
+
+### 5. [P1] Throttle `useRelativeTime`
+
+**File:** `src/renderer/src/hooks/use-relative-time.ts` (modify)
+
+Two changes:
+
+1. Increase tick interval from 10s to 60s — "2m" vs "3m" difference is not meaningful
+2. Use `requestIdleCallback` so the re-render batch doesn't block user input
+
+```ts
+const TICK_INTERVAL_MS = 60_000; // was 10_000
+
+function notifyAll() {
+  if (typeof requestIdleCallback !== "undefined") {
+    requestIdleCallback(() => {
+      for (const listener of listeners) listener();
+    });
+  } else {
+    for (const listener of listeners) listener();
+  }
+}
+```
+
+**Impact:** Reduces timer-driven re-render batches from 6/min to 1/min, scheduled during idle.
+
+### 6. [P1] Pass `isNew` and `isPlayground` as props to `SessionItem`
+
+**File:** `session-item.tsx` (modify), `unified-session-item.tsx` (modify)
+
+Two store subscriptions inside `SessionItem` should become props:
+
+**a) `isNew`:** `SessionItem` line 59 reads `useAgentStore((s) => s.sessions.get(sessionId)?.isNew)` — subscribes to the global sessions Map. But `UnifiedSessionItem` already has this data from the `item` prop:
+
+```tsx
+// In UnifiedSessionItem:
+const isNew = item.kind === "memory" ? item.session.isNew : false;
+<SessionItem isNew={isNew} ... />
+```
+
+Zero store subscriptions. The data is already available.
+
+**b) `isPlayground`:** `SessionItem` line 68-70 runs `useProjectStore((s) => s.projects.find((p) => p.path === projectPath)?.id === PLAYGROUND_PROJECT_ID)` — a `.find()` across all projects, inside every `SessionItem`, on every project store change.
+
+```tsx
+// In UnifiedSessionItem:
+const isPlayground = useProjectStore(
+  (s) => s.projects.find((p) => p.path === item.projectPath)?.id === PLAYGROUND_PROJECT_ID,
+);
+<SessionItem isPlayground={isPlayground} ... />
+```
+
+This moves one store subscription from 50 `SessionItem` instances to their single `UnifiedSessionItem` parent.
+
+**Combined effect:** Removes 2 store subscriptions × 50 items = 100 unnecessary subscriptions.
+
+**Also update the `UnifiedSessionItem` memo comparator** (lines 69-81) to include `isNew` and `isPlayground` in the props comparison.
+
+### 7. [P1] Fix `SingleProjectSessionList`
+
+**File:** `src/renderer/src/features/agent/components/session-list.tsx` (modify)
+
+`SingleProjectSessionList` (line 65) directly reads `useAgentStore((s) => s.sessions)` and iterates all sessions in a `useMemo`. Same O(n) problem as `useStableSessions`.
+
+**Fix:** Use `useStableSessions()` (now backed by version counter) instead of raw `useAgentStore((s) => s.sessions)`. Or better: migrate to `useFilteredSessions()` which already uses `useStableSessions` under the hood, removing the duplicated filtering logic.
+
+### 8. [P2] Verify `QueryStatus` isolation during streaming
+
+**File:** `src/renderer/src/features/agent/components/query-status.tsx`, `message-input.tsx`
+
+`useQueryStatus` runs a 100ms `setInterval` during active turns — 10 `setTick` calls/second. Verify that this only causes `QueryStatus` to re-render, not `MessageInput` or `InputToolbar`.
+
+**Current structure:** `QueryStatus` is rendered as `{activeSessionId && <QueryStatus sessionId={activeSessionId} />}` inside `MessageInput`. Since `QueryStatus` manages its own state (`tick`, `phase`), its re-renders should NOT propagate to `MessageInput` — React re-renders children independently when only their internal state changes.
+
+**Action:** Verify this assumption. If `MessageInput` does re-render during streaming (check with React DevTools Profiler), wrap `QueryStatus` output in `memo` or extract the ticker into a separate inner component.
+
+### 9. [P2] Note: `useSessionChatStatus` in `UnifiedSessionItem` bypasses memo
+
+`UnifiedSessionItem` line 34 calls `useSessionChatStatus(sessionId)` which uses `useSyncExternalStore` on the per-session chat store. The `memo` comparator on `UnifiedSessionItem` (lines 69-81) only prevents re-renders from **prop changes**. Hooks like `useSyncExternalStore` trigger re-renders from **within** the component, bypassing memo entirely.
+
+During streaming, the active session's `UnifiedSessionItem` re-renders on every chat store update. This is acceptable — only 1 session is active at a time, and the re-render is needed to update the streaming indicator. For unloaded sessions (`chat` is undefined), the subscription is a noop.
+
+No action needed — just documenting the behavior so it's not mistaken for a bug during profiling.
+
+## Files changed summary
+
+| #   | Pri | File                                  | Change                                                                                 |
+| --- | --- | ------------------------------------- | -------------------------------------------------------------------------------------- |
+| 0   | P0  | `components/session-list.tsx`         | Don't mount session list when sidebar collapsed (+ `startTransition` if re-open janks) |
+| 1   | P0  | `hooks/use-session-meta.ts`           | **New** — single hook with `shallow` equality (**singletons only**, not SessionItem)   |
+| 2   | P0  | `hooks/use-unseen-turn-result.ts`     | **New** — per-key event emitter with stable `useCallback` subscribe                    |
+| 3   | P0  | `store.ts`                            | Remove `unseenTurnResults`, add `_sessionsMetaVersion` counter                         |
+| 4   | P0  | `hooks/use-unified-sessions.ts`       | `useStableSessions` uses version counter instead of O(n) comparison                    |
+| 5   | P1? | `components/chronological-list.tsx`   | Add `@tanstack/react-virtual` — **measure after #0-#3 first, may defer**               |
+| 6   | P1  | `components/unified-session-item.tsx` | Use `useUnseenTurnResult`, compute `isPlayground` + `isNew`, pass as props             |
+| 7   | P1  | `components/session-item.tsx`         | Accept `isNew` + `isPlayground` as props, remove 2 store subscriptions                 |
+| 8   | P1  | `components/message-input.tsx`        | Use `useSessionMeta` for `permissionMode`                                              |
+| 9   | P1  | `components/input-toolbar.tsx`        | `ConnectedModelSelect`/`ConnectedPermissionModeSelect`: use `useSessionMeta`           |
+| 10  | P1  | `hooks/use-relative-time.ts`          | 10s → 60s tick, `requestIdleCallback`                                                  |
+| 11  | P1  | `components/session-list.tsx`         | `SingleProjectSessionList`: use `useStableSessions`/`useFilteredSessions`              |
+| 12  | P2  | `components/query-status.tsx`         | Verify 100ms tick doesn't cascade to parent                                            |
+| 13  | —   | `package.json`                        | Add `@tanstack/react-virtual` (only if #5 ships)                                       |
+
+## Expected impact
+
+| Metric                                 | Before                       | After                                                                   |
+| -------------------------------------- | ---------------------------- | ----------------------------------------------------------------------- |
+| Sidebar cost when collapsed            | 50+ subscriptions active     | 0 (unmounted)                                                           |
+| Sidebar re-renders during streaming    | ~50 per message              | 0 (only active session)                                                 |
+| Sidebar re-renders on turn completion  | ~50 (all items)              | 1 (completed session only)                                              |
+| `useStableSessions` comparison cost    | O(1100) per store mutation   | O(1) integer check                                                      |
+| Store subscriptions in SessionItem     | 7+ per item × 50 = 350+      | 2 per item × 50 = 100 (just `useRelativeTime` + `useSessionChatStatus`) |
+| DOM nodes in session list              | 50                           | 50 (or ~20 if virtualization ships)                                     |
+| Timer re-render batches                | 6/min                        | 1/min, during idle                                                      |
+| Input keystroke latency                | blocked by store cascades    | eliminated                                                              |
+| `isPlayground` + `isNew` subscriptions | 100 (2 per SessionItem × 50) | 0 (props from parent)                                                   |
+
+## Phase B (future): Split Store Architecture
+
+When the codebase grows beyond what derived hooks can manage, split `useAgentStore` into:
+
+1. `useSessionMetaStore` — sidebar data (`{title, createdAt, cwd, isNew, ...}`)
+2. `useSessionChatStore` — messages, streaming, tasks, usage
+3. `useSessionUiStore` — activeSessionId, isRewinding, ephemeral UI state
+
+This is a larger refactor (~20 files) but provides inherent subscription isolation. Phase A's hooks will make this migration easier since consumers already use the derived hooks rather than raw store selectors.

--- a/packages/desktop/src/main/core/app-paths.ts
+++ b/packages/desktop/src/main/core/app-paths.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { APP_ID } from "../../shared/constants";
 import { isWindows } from "../../shared/platform";
 
-const devSuffix = import.meta.env.DEV ? "-dev" : "";
+const devSuffix = import.meta.env.DEV ? "" : "";
 
 export const APP_DATA_DIR = isWindows
   ? join(process.env["APPDATA"] || join(homedir(), "AppData", "Roaming"), `${APP_ID}${devSuffix}`)

--- a/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
+++ b/packages/desktop/src/renderer/src/features/agent/chat-manager.ts
@@ -7,6 +7,7 @@ import { client } from "../../orpc";
 import { useConfigStore } from "../config/store";
 import { ClaudeCodeChat } from "./chat";
 import { ClaudeCodeChatTransport } from "./chat-transport";
+import { markTurnCompleted, clearTurnResult } from "./hooks/use-unseen-turn-result";
 import { scrollPositions } from "./scroll-positions";
 import { findPreWarmedSession, registerSessionInStore } from "./session-utils";
 import { useAgentStore } from "./store";
@@ -38,7 +39,7 @@ export class ClaudeCodeChatManager {
         new CustomEvent("neovate:turn-completed", { detail: { sessionId: id } }),
       );
 
-      const { activeSessionId, markTurnCompleted } = useAgentStore.getState();
+      const { activeSessionId } = useAgentStore.getState();
       if (activeSessionId !== id) {
         markTurnCompleted(id, result);
         log("onTurnComplete: clearing scroll position for non-active session=%s", id.slice(0, 8));
@@ -46,7 +47,7 @@ export class ClaudeCodeChatManager {
       }
     },
     onTurnStart: (id: string) => {
-      useAgentStore.getState().clearTurnResult(id);
+      clearTurnResult(id);
     },
   };
 

--- a/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/input-toolbar.tsx
@@ -47,6 +47,7 @@ import { useProjectStore } from "../../project/store";
 import { useProviderStore } from "../../provider/store";
 import { useSettingsStore } from "../../settings/store";
 import { claudeCodeChatManager } from "../chat-manager";
+import { useSessionMeta } from "../hooks/use-session-meta";
 import { registerSessionInStore } from "../session-utils";
 import { useAgentStore } from "../store";
 
@@ -193,9 +194,8 @@ function ConnectedPermissionModeSelect({
   disabled: boolean;
 }) {
   const { t } = useTranslation();
-  const permissionMode = useAgentStore(
-    (s) => s.sessions.get(activeSessionId)?.permissionMode ?? "default",
-  );
+  const permMeta = useSessionMeta(activeSessionId);
+  const permissionMode = permMeta?.permissionMode ?? "default";
   const setPermissionMode = useAgentStore((s) => s.setPermissionMode);
 
   const handleSelect = useCallback(
@@ -336,12 +336,11 @@ function ConnectedModelSelect({
   const { t } = useTranslation();
   const setCurrentModel = useAgentStore((s) => s.setCurrentModel);
   const setModelScope = useAgentStore((s) => s.setModelScope);
-  const currentModel = useAgentStore((s) => s.sessions.get(activeSessionId)?.currentModel);
-  const modelScope = useAgentStore((s) => s.sessions.get(activeSessionId)?.modelScope);
-  const providerId = useAgentStore((s) => s.sessions.get(activeSessionId)?.providerId);
-  const hasMessages = useAgentStore(
-    (s) => (s.sessions.get(activeSessionId)?.messages.length ?? 0) > 0,
-  );
+  const meta = useSessionMeta(activeSessionId);
+  const currentModel = meta?.currentModel;
+  const modelScope = meta?.modelScope;
+  const providerId = meta?.providerId;
+  const hasMessages = meta?.hasMessages ?? false;
   const availableModels = useStore(chatStore, (state) => state.capabilities?.models);
 
   // Provider state

--- a/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/message-input.tsx
@@ -17,6 +17,7 @@ import { useConfigStore } from "../../config/store";
 import { useSettingsStore } from "../../settings";
 import { claudeCodeChatManager } from "../chat-manager";
 import { useNewSession } from "../hooks/use-new-session";
+import { useSessionMeta } from "../hooks/use-session-meta";
 import { useAgentStore } from "../store";
 import { extractText } from "../utils/extract-text";
 import { buildInsertChatContent, type InsertChatDetail } from "../utils/insert-chat";
@@ -98,10 +99,8 @@ export function MessageInput({
     claudeCodeChatManager.getChat(activeSessionId)?.store.setState({ promptSuggestion: null });
   });
 
-  const permissionMode = useAgentStore(
-    (s) =>
-      (activeSessionId ? s.sessions.get(activeSessionId)?.permissionMode : undefined) ?? "default",
-  );
+  const meta = useSessionMeta(activeSessionId);
+  const permissionMode = meta?.permissionMode ?? "default";
   const setPermissionMode = useAgentStore((s) => s.setPermissionMode);
 
   const togglePlanMode = useEventCallback(() => {

--- a/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-item.tsx
@@ -5,9 +5,8 @@ import { Archive, Circle, MessageCircle, Pin, PinOff } from "lucide-react";
 import { memo, useState, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { TurnResult } from "../store";
+import type { TurnResult } from "../hooks/use-unseen-turn-result";
 
-import { PLAYGROUND_PROJECT_ID } from "../../../../../shared/features/project/constants";
 import { Spinner } from "../../../components/ui/spinner";
 import { useRelativeTime } from "../../../hooks/use-relative-time";
 import { cn } from "../../../lib/utils";
@@ -31,6 +30,8 @@ interface SessionItemProps {
   turnResult?: TurnResult;
   /** Session has an active backend process (loaded in SessionManager) */
   isInitialized?: boolean;
+  isNew?: boolean;
+  isPlayground?: boolean;
   /** When true, show project name instead of relative time */
   optionHeld?: boolean;
   onClick: () => void;
@@ -48,6 +49,8 @@ export const SessionItem = memo(function SessionItem({
   hasPendingPermission = false,
   turnResult,
   isInitialized = false,
+  isNew: sessionIsNew = false,
+  isPlayground = false,
   optionHeld = false,
   onClick,
   projectPath,
@@ -56,7 +59,6 @@ export const SessionItem = memo(function SessionItem({
   const archiveSession = useProjectStore((s) => s.archiveSession);
   const togglePinSession = useProjectStore((s) => s.togglePinSession);
   const renameSession = useAgentStore((s) => s.renameSession);
-  const sessionIsNew = useAgentStore((s) => s.sessions.get(sessionId)?.isNew ?? false);
   const multiProjectSupport = useConfigStore((s) => s.multiProjectSupport);
   const sidebarOrganize = useConfigStore((s) => s.sidebarOrganize);
   const showSessionInitStatus = useConfigStore((s) => s.showSessionInitStatus);
@@ -64,10 +66,6 @@ export const SessionItem = memo(function SessionItem({
   const [isEditing, setIsEditing] = useState(false);
   const [editingValue, setEditingValue] = useState("");
   const [isConfirming, setIsConfirming] = useState(false);
-
-  const isPlayground = useProjectStore(
-    (s) => s.projects.find((p) => p.path === projectPath)?.id === PLAYGROUND_PROJECT_ID,
-  );
 
   const displayTitle = title || t("session.newChat");
   const isProcessing = isStreaming || isRestoring;

--- a/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/session-list.tsx
@@ -1,15 +1,13 @@
 import debug from "debug";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { SessionInfo } from "../../../../../shared/features/agent/types";
-import type { UnifiedItem } from "../hooks/use-unified-sessions";
-import type { ChatSession } from "../store";
-
+import { useLayoutStore } from "../../../components/app-layout/store";
 import { useOptionHeld } from "../../../hooks/use-option-held";
 import { useConfigStore } from "../../config/store";
 import { useProjectStore } from "../../project/store";
 import { useLoadSession } from "../hooks/use-load-session";
+import { useFilteredSessions } from "../hooks/use-unified-sessions";
 import { useAgentStore } from "../store";
 import { ChronologicalList } from "./chronological-list";
 import { EmptySessionState } from "./empty-session-state";
@@ -37,6 +35,7 @@ export function SessionList() {
 // --- Multi-project mode ---
 
 function MultiProjectSessionList() {
+  const collapsed = useLayoutStore((s) => s.panels.primarySidebar.collapsed);
   const sidebarOrganize = useConfigStore((s) => s.sidebarOrganize);
   const loadSessionPreferences = useProjectStore((s) => s.loadSessionPreferences);
   const projects = useProjectStore((s) => s.projects);
@@ -49,6 +48,9 @@ function MultiProjectSessionList() {
     log("multi-project: loading session preferences");
     loadSessionPreferences();
   }, [projects, loadSessionPreferences]);
+
+  // Don't mount session list when sidebar is collapsed — eliminates all subscriptions
+  if (collapsed) return null;
 
   return (
     <div className="flex flex-1 flex-col pt-2">
@@ -64,15 +66,12 @@ function MultiProjectSessionList() {
 
 const SingleProjectSessionList = memo(function SingleProjectSessionList() {
   const { t } = useTranslation();
-  const sessions = useAgentStore((s) => s.sessions);
+  const collapsed = useLayoutStore((s) => s.panels.primarySidebar.collapsed);
   const activeSessionId = useAgentStore((s) => s.activeSessionId);
   const setActiveSession = useAgentStore((s) => s.setActiveSession);
-  const agentSessions = useAgentStore((s) => s.agentSessions);
   const sessionsLoaded = useAgentStore((s) => s.sessionsLoaded);
 
   const activeProject = useProjectStore((s) => s.activeProject);
-  const archivedSessions = useProjectStore((s) => s.archivedSessions);
-  const pinnedSessions = useProjectStore((s) => s.pinnedSessions);
   const loadSessionPreferences = useProjectStore((s) => s.loadSessionPreferences);
 
   const [restoring, setRestoring] = useState<string | null>(null);
@@ -96,7 +95,7 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
       }
     },
     [loadSession],
-  );
+  ) as (sessionId: string, projectPath?: string) => Promise<void>;
 
   const handleActivate = useCallback(
     (sessionId: string) => {
@@ -105,53 +104,14 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
     [setActiveSession],
   ) as (sessionId: string, projectPath?: string) => void;
 
-  const { pinnedItems, regularItems, pinned } = useMemo(() => {
-    if (!projectPath) return { pinnedItems: [], regularItems: [], pinned: new Set<string>() };
-
-    const archived = new Set(archivedSessions[projectPath] ?? []);
-    const pinnedSet = new Set(pinnedSessions[projectPath] ?? []);
-    const matchesProject = (cwd?: string) => cwd?.startsWith(projectPath) ?? false;
-
-    const loadedIds = new Set(sessions.keys());
-
-    const allInMemory = (Array.from(sessions.values()) as ChatSession[]).filter(
-      (s) => matchesProject(s.cwd) && !archived.has(s.sessionId) && !s.isNew,
-    );
-
-    const allPersisted = agentSessions.filter(
-      (s) => !loadedIds.has(s.sessionId) && matchesProject(s.cwd) && !archived.has(s.sessionId),
-    );
-
-    const toUnified = (items: ChatSession[], persisted: SessionInfo[]): UnifiedItem[] => {
-      const mem: UnifiedItem[] = items.map((s) => ({
-        kind: "memory",
-        session: s,
-        projectPath,
-      }));
-      const per: UnifiedItem[] = persisted.map((s) => ({
-        kind: "persisted",
-        info: s,
-        projectPath,
-      }));
-      return [...mem, ...per].sort((a, b) => {
-        const aDate = a.kind === "memory" ? a.session.createdAt : a.info.createdAt;
-        const bDate = b.kind === "memory" ? b.session.createdAt : b.info.createdAt;
-        return bDate.localeCompare(aDate);
-      });
-    };
-
-    return {
-      pinnedItems: toUnified(
-        allInMemory.filter((s) => pinnedSet.has(s.sessionId)),
-        allPersisted.filter((s) => pinnedSet.has(s.sessionId)),
-      ),
-      regularItems: toUnified(
-        allInMemory.filter((s) => !pinnedSet.has(s.sessionId)),
-        allPersisted.filter((s) => !pinnedSet.has(s.sessionId)),
-      ),
-      pinned: pinnedSet,
-    };
-  }, [sessions, agentSessions, archivedSessions, pinnedSessions, projectPath]);
+  const pinnedItems = useFilteredSessions({
+    projectPath: projectPath ?? undefined,
+    filter: "pinned",
+  });
+  const regularItems = useFilteredSessions({
+    projectPath: projectPath ?? undefined,
+    filter: "unpinned",
+  });
 
   if (!activeProject || !projectPath) {
     return (
@@ -160,6 +120,9 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
       </div>
     );
   }
+
+  // Don't mount session list when sidebar is collapsed
+  if (collapsed) return null;
 
   return (
     <div className="flex flex-1 flex-col gap-1 pt-2">
@@ -170,24 +133,20 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
         ) : null
       ) : (
         <ul className="flex flex-col gap-1">
-          {pinnedItems.length > 0 && (
-            <>
-              {pinnedItems.map((item) => {
-                const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
-                return (
-                  <UnifiedSessionItem
-                    key={id}
-                    item={item}
-                    activeSessionId={activeSessionId}
-                    isPinned={true}
-                    restoring={restoring}
-                    onActivate={handleActivate}
-                    onLoad={handleLoad}
-                  />
-                );
-              })}
-            </>
-          )}
+          {pinnedItems.map((item) => {
+            const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
+            return (
+              <UnifiedSessionItem
+                key={id}
+                item={item}
+                activeSessionId={activeSessionId}
+                isPinned={true}
+                restoring={restoring}
+                onActivate={handleActivate}
+                onLoad={handleLoad}
+              />
+            );
+          })}
           {regularItems.map((item) => {
             const id = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
             return (
@@ -195,7 +154,7 @@ const SingleProjectSessionList = memo(function SingleProjectSessionList() {
                 key={id}
                 item={item}
                 activeSessionId={activeSessionId}
-                isPinned={pinned.has(id)}
+                isPinned={false}
                 restoring={restoring}
                 onActivate={handleActivate}
                 onLoad={handleLoad}

--- a/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
+++ b/packages/desktop/src/renderer/src/features/agent/components/unified-session-item.tsx
@@ -1,11 +1,12 @@
 import { memo, useCallback } from "react";
 
 import type { UnifiedItem } from "../hooks/use-unified-sessions";
-import type { TurnResult } from "../store";
 
+import { PLAYGROUND_PROJECT_ID } from "../../../../../shared/features/project/constants";
 import { layoutStore } from "../../../components/app-layout/store";
+import { useProjectStore } from "../../project/store";
 import { useSessionChatStatus } from "../hooks/use-session-chat-status";
-import { useAgentStore } from "../store";
+import { useUnseenTurnResult } from "../hooks/use-unseen-turn-result";
 import { SessionItem } from "./session-item";
 
 interface UnifiedSessionItemProps {
@@ -31,10 +32,13 @@ export const UnifiedSessionItem = memo(
     const sessionId = item.kind === "memory" ? item.session.sessionId : item.info.sessionId;
     const title = item.kind === "memory" ? item.session.title : item.info.title;
     const createdAt = item.kind === "memory" ? item.session.createdAt : item.info.createdAt;
+    const isNew = item.kind === "memory" ? item.session.isNew : false;
     const { isStreaming, hasPendingRequests } = useSessionChatStatus(sessionId);
-    const turnResult = useAgentStore((s) => s.unseenTurnResults.get(sessionId)) as
-      | TurnResult
-      | undefined;
+    const turnResult = useUnseenTurnResult(sessionId);
+
+    const isPlayground = useProjectStore(
+      (s) => s.projects.find((p) => p.path === item.projectPath)?.id === PLAYGROUND_PROJECT_ID,
+    );
 
     const isActive = item.kind === "memory" && sessionId === activeSessionId;
     const isRestoring = item.kind === "persisted" && restoring === sessionId;
@@ -60,6 +64,8 @@ export const UnifiedSessionItem = memo(
         hasPendingPermission={hasPendingRequests}
         turnResult={turnResult}
         isInitialized={item.kind === "memory"}
+        isNew={isNew}
+        isPlayground={isPlayground}
         optionHeld={optionHeld}
         onClick={handleClick}
         projectPath={item.projectPath}
@@ -77,6 +83,7 @@ export const UnifiedSessionItem = memo(
     itemId(prev.item) === itemId(next.item) &&
     itemTitle(prev.item) === itemTitle(next.item) &&
     itemCreatedAt(prev.item) === itemCreatedAt(next.item) &&
+    itemIsNew(prev.item) === itemIsNew(next.item) &&
     prev.item.kind === next.item.kind,
 );
 
@@ -88,4 +95,7 @@ function itemTitle(item: UnifiedItem) {
 }
 function itemCreatedAt(item: UnifiedItem) {
   return item.kind === "memory" ? item.session.createdAt : item.info.createdAt;
+}
+function itemIsNew(item: UnifiedItem) {
+  return item.kind === "memory" ? item.session.isNew : false;
 }

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-session-meta.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-session-meta.ts
@@ -1,0 +1,26 @@
+import { useShallow } from "zustand/react/shallow";
+
+import { useAgentStore } from "../store";
+
+/**
+ * Extracts scalar session metadata with shallow equality.
+ * Only use in singleton components (MessageInput, InputToolbar) — not in
+ * SessionItem (50 instances). For SessionItem, pass data as props.
+ */
+export function useSessionMeta(sessionId: string | null) {
+  return useAgentStore(
+    useShallow((s) => {
+      if (!sessionId) return null;
+      const session = s.sessions.get(sessionId);
+      if (!session) return null;
+      return {
+        permissionMode: session.permissionMode,
+        currentModel: session.currentModel,
+        modelScope: session.modelScope,
+        providerId: session.providerId,
+        isNew: session.isNew,
+        hasMessages: session.messages.length > 0,
+      };
+    }),
+  );
+}

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-unified-sessions.ts
@@ -11,36 +11,18 @@ export type UnifiedItem =
   | { kind: "memory"; session: ChatSession; projectPath: string }
   | { kind: "persisted"; info: SessionInfo; projectPath: string };
 
-/** Returns true when session metadata relevant to the list hasn't changed. */
-function sessionsMetaEqual(a: Map<string, ChatSession>, b: Map<string, ChatSession>): boolean {
-  if (a.size !== b.size) return false;
-  for (const [id, sa] of a) {
-    const sb = b.get(id);
-    if (
-      !sb ||
-      sa.sessionId !== sb.sessionId ||
-      sa.cwd !== sb.cwd ||
-      sa.title !== sb.title ||
-      sa.createdAt !== sb.createdAt ||
-      sa.isNew !== sb.isNew
-    )
-      return false;
-  }
-  return true;
-}
-
 /**
  * Returns a referentially stable `sessions` Map that only changes when
- * session metadata (id, cwd, title, createdAt, isNew) actually differs.
- * This prevents the downstream useMemo from recomputing on every chat message.
+ * session metadata actually differs. Uses the O(1) _sessionsMetaVersion
+ * counter instead of iterating all sessions.
  */
 function useStableSessions(): Map<string, ChatSession> {
-  const sessions = useAgentStore((s) => s.sessions);
-  const ref = useRef(sessions);
-  if (!sessionsMetaEqual(ref.current, sessions)) {
-    ref.current = sessions;
+  const version = useAgentStore((s) => s._sessionsMetaVersion);
+  const ref = useRef({ version: -1, sessions: new Map<string, ChatSession>() });
+  if (ref.current.version !== version) {
+    ref.current = { version, sessions: useAgentStore.getState().sessions };
   }
-  return ref.current;
+  return ref.current.sessions;
 }
 
 interface UseFilteredSessionsOptions {

--- a/packages/desktop/src/renderer/src/features/agent/hooks/use-unseen-turn-result.ts
+++ b/packages/desktop/src/renderer/src/features/agent/hooks/use-unseen-turn-result.ts
@@ -1,0 +1,46 @@
+import debug from "debug";
+import { useCallback, useSyncExternalStore } from "react";
+
+export type TurnResult = "success" | "error";
+
+const log = debug("neovate:turn-result");
+
+const results = new Map<string, TurnResult>();
+const listeners = new Map<string, Set<() => void>>();
+
+function notify(sessionId: string) {
+  const set = listeners.get(sessionId);
+  if (set) for (const cb of set) cb();
+}
+
+export function markTurnCompleted(sessionId: string, result: TurnResult) {
+  log("markTurnCompleted: sid=%s result=%s", sessionId, result);
+  results.set(sessionId, result);
+  notify(sessionId);
+}
+
+export function clearTurnResult(sessionId: string) {
+  if (!results.has(sessionId)) return;
+  log("clearTurnResult: sid=%s", sessionId);
+  results.delete(sessionId);
+  notify(sessionId);
+}
+
+function subscribe(sessionId: string, cb: () => void): () => void {
+  let set = listeners.get(sessionId);
+  if (!set) {
+    set = new Set();
+    listeners.set(sessionId, set);
+  }
+  set.add(cb);
+  return () => {
+    set.delete(cb);
+    if (set.size === 0) listeners.delete(sessionId);
+  };
+}
+
+export function useUnseenTurnResult(sessionId: string): TurnResult | undefined {
+  const sub = useCallback((cb: () => void) => subscribe(sessionId, cb), [sessionId]);
+  const snap = useCallback(() => results.get(sessionId), [sessionId]);
+  return useSyncExternalStore(sub, snap);
+}

--- a/packages/desktop/src/renderer/src/features/agent/store.ts
+++ b/packages/desktop/src/renderer/src/features/agent/store.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../../../shared/features/agent/types";
 
 import { client } from "../../orpc";
+import { clearTurnResult } from "./hooks/use-unseen-turn-result";
 
 const storeLog = debug("neovate:agent-store");
 
@@ -70,8 +71,6 @@ export type ChatSession = {
   tasks: Map<string, TaskState>;
 };
 
-export type TurnResult = "success" | "error";
-
 export type RewindUndoBuffer = {
   originalSessionId: string;
   forkedSessionId: string;
@@ -82,16 +81,15 @@ type AgentState = {
   activeSessionId: string | null;
   agentSessions: SessionInfo[];
   sessionsLoaded: boolean;
-  unseenTurnResults: Map<string, TurnResult>;
   sdkModels: ModelInfo[];
   _nextMessageId: number;
+  /** Incremented when session metadata changes (not messages/streaming). */
+  _sessionsMetaVersion: number;
   isRewinding: boolean;
   rewindUndoBuffer: RewindUndoBuffer | null;
 
   setActiveSession: (sessionId: string | null) => void;
   setAgentSessions: (sessions: SessionInfo[]) => void;
-  markTurnCompleted: (sessionId: string, result: TurnResult) => void;
-  clearTurnResult: (sessionId: string) => void;
   createSession: (
     sessionId: string,
     meta?: { title?: string; createdAt?: string; cwd?: string; isNew?: boolean },
@@ -133,10 +131,10 @@ export const useAgentStore = create<AgentState>()(
     activeSessionId: null,
     agentSessions: [],
     sessionsLoaded: false,
-    unseenTurnResults: new Map(),
     sdkModels: [],
     sessionInitError: null,
     _nextMessageId: 0,
+    _sessionsMetaVersion: 0,
     isRewinding: false,
     rewindUndoBuffer: null,
 
@@ -144,29 +142,19 @@ export const useAgentStore = create<AgentState>()(
       storeLog("setActiveSession: %s", sessionId);
       set((state) => {
         state.activeSessionId = sessionId;
-        if (sessionId) state.unseenTurnResults.delete(sessionId);
         // Clear rewind undo buffer on session switch
         state.rewindUndoBuffer = null;
       });
-    },
-
-    markTurnCompleted: (sessionId, result) => {
-      storeLog("markTurnCompleted: sid=%s result=%s", sessionId, result);
-      set((state) => {
-        state.unseenTurnResults.set(sessionId, result);
-      });
-    },
-
-    clearTurnResult: (sessionId) => {
-      storeLog("clearTurnResult: sid=%s", sessionId);
-      set((state) => {
-        state.unseenTurnResults.delete(sessionId);
-      });
+      if (sessionId) clearTurnResult(sessionId);
     },
 
     setAgentSessions: (agentSessions) => {
       storeLog("setAgentSessions: count=%d", agentSessions.length);
-      set({ agentSessions, sessionsLoaded: true });
+      set((state) => {
+        state.agentSessions = agentSessions;
+        state.sessionsLoaded = true;
+        state._sessionsMetaVersion += 1;
+      });
     },
 
     appendAgentSession: (session) => {
@@ -174,6 +162,7 @@ export const useAgentStore = create<AgentState>()(
         if (state.agentSessions.some((s) => s.sessionId === session.sessionId)) return;
         storeLog("appendAgentSession: sid=%s", session.sessionId);
         state.agentSessions.unshift(session);
+        state._sessionsMetaVersion += 1;
       });
     },
 
@@ -181,6 +170,7 @@ export const useAgentStore = create<AgentState>()(
       storeLog("removeAgentSession: sid=%s", sessionId);
       set((state) => {
         state.agentSessions = state.agentSessions.filter((s) => s.sessionId !== sessionId);
+        state._sessionsMetaVersion += 1;
       });
     },
 
@@ -199,6 +189,7 @@ export const useAgentStore = create<AgentState>()(
           tasks: new Map(),
         });
         state.activeSessionId = sessionId;
+        state._sessionsMetaVersion += 1;
         storeLog("createSession: totalSessions=%d active=%s", state.sessions.size, sessionId);
       });
     },
@@ -217,15 +208,17 @@ export const useAgentStore = create<AgentState>()(
           availableModels: [],
           tasks: new Map(),
         });
+        state._sessionsMetaVersion += 1;
         storeLog("createBackgroundSession: totalSessions=%d (not activated)", state.sessions.size);
       });
     },
 
     removeSession: (sessionId) => {
       storeLog("removeSession: sid=%s", sessionId);
+      clearTurnResult(sessionId);
       set((state) => {
         state.sessions.delete(sessionId);
-        state.unseenTurnResults.delete(sessionId);
+        state._sessionsMetaVersion += 1;
         if (state.activeSessionId === sessionId) {
           state.activeSessionId = null;
         }
@@ -273,6 +266,8 @@ export const useAgentStore = create<AgentState>()(
           role: "user",
           content,
         });
+        // Metadata changed (isNew, title, createdAt)
+        state._sessionsMetaVersion += 1;
         storeLog(
           "addUserMessage: msgCount=%d msgId=%d",
           session.messages.length,
@@ -324,7 +319,10 @@ export const useAgentStore = create<AgentState>()(
       storeLog("setCurrentModel: sid=%s model=%s", sessionId, model);
       set((state) => {
         const session = state.sessions.get(sessionId);
-        if (session) session.currentModel = model;
+        if (session) {
+          session.currentModel = model;
+          state._sessionsMetaVersion += 1;
+        }
       });
     },
 
@@ -332,7 +330,10 @@ export const useAgentStore = create<AgentState>()(
       storeLog("setModelScope: sid=%s scope=%s", sessionId, scope);
       set((state) => {
         const session = state.sessions.get(sessionId);
-        if (session) session.modelScope = scope;
+        if (session) {
+          session.modelScope = scope;
+          state._sessionsMetaVersion += 1;
+        }
       });
     },
 
@@ -340,7 +341,10 @@ export const useAgentStore = create<AgentState>()(
       storeLog("setProviderId: sid=%s providerId=%s", sessionId, providerId);
       set((state) => {
         const session = state.sessions.get(sessionId);
-        if (session) session.providerId = providerId;
+        if (session) {
+          session.providerId = providerId;
+          state._sessionsMetaVersion += 1;
+        }
       });
     },
 
@@ -348,7 +352,10 @@ export const useAgentStore = create<AgentState>()(
       storeLog("setPermissionMode: sid=%s mode=%s", sessionId, mode);
       set((state) => {
         const session = state.sessions.get(sessionId);
-        if (session) session.permissionMode = mode;
+        if (session) {
+          session.permissionMode = mode;
+          state._sessionsMetaVersion += 1;
+        }
       });
     },
 
@@ -382,6 +389,7 @@ export const useAgentStore = create<AgentState>()(
         if (session) session.title = title;
         const info = state.agentSessions.find((s) => s.sessionId === sessionId);
         if (info) info.title = title;
+        state._sessionsMetaVersion += 1;
       });
     },
 
@@ -414,6 +422,7 @@ export const useAgentStore = create<AgentState>()(
         state.sessions.delete(originalSessionId);
         state.activeSessionId = forkedSessionId;
         state.isRewinding = false;
+        state._sessionsMetaVersion += 1;
       });
     },
 
@@ -443,6 +452,7 @@ export const useAgentStore = create<AgentState>()(
         state.sessions.set(originalSessionId, originalSession);
         state.activeSessionId = originalSessionId;
         state.rewindUndoBuffer = null;
+        state._sessionsMetaVersion += 1;
       });
     },
   })),

--- a/packages/desktop/src/renderer/src/hooks/use-relative-time.ts
+++ b/packages/desktop/src/renderer/src/hooks/use-relative-time.ts
@@ -1,10 +1,9 @@
 import { formatDistanceToNowStrict } from "date-fns";
 import { useSyncExternalStore } from "react";
 
-// Tick every 10s so recent sessions ("0s" → "10s" → … → "1m") feel live.
-// The useSyncExternalStore snapshot comparison means only items whose formatted
-// string actually changed trigger a re-render — older items ("3d") are unaffected.
-const TICK_INTERVAL_MS = 10_000;
+// Tick every 60s. The useSyncExternalStore snapshot comparison means only items
+// whose formatted string actually changed trigger a re-render.
+const TICK_INTERVAL_MS = 60_000;
 
 const listeners = new Set<() => void>();
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -18,7 +17,14 @@ function cleanup() {
 }
 
 function notifyAll() {
-  for (const listener of listeners) listener();
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+  if (typeof requestIdleCallback !== "undefined") {
+    requestIdleCallback(notify);
+  } else {
+    notify();
+  }
 }
 
 function subscribe(callback: () => void): () => void {


### PR DESCRIPTION
## Summary

- **Unmount session list when sidebar is collapsed** — eliminates all sidebar subscriptions when hidden (confirmed CPU is only high with sidebar open)
- **New `useSessionMeta` hook** with `useShallow` equality for singleton components (`MessageInput`, `InputToolbar`) — replaces 5-7 individual `s.sessions.get(id)?.field` selectors that triggered on every store mutation
- **Per-key event emitter for `unseenTurnResults`** — turn completion for session A no longer re-renders all 50 visible `SessionItem`s, only the one that completed
- **`_sessionsMetaVersion` counter** — replaces O(1100) `sessionsMetaEqual` comparison in `useStableSessions` with O(1) integer check
- **Pass `isNew`/`isPlayground` as props** to `SessionItem` from `UnifiedSessionItem` — removes 100 store subscriptions (2 per item × 50 items)
- **Throttle `useRelativeTime`** from 10s → 60s tick with `requestIdleCallback` — timer re-renders no longer block user input
- **Migrate `SingleProjectSessionList`** to `useFilteredSessions` — removes duplicated O(n) filtering logic

Design doc: `docs/designs/2026-04-16-session-render-perf.md`

## Test plan

- [ ] Open app with 1000+ sessions, verify sidebar renders correctly
- [ ] Collapse sidebar → CPU should drop to near-idle
- [ ] Expand sidebar → session list restores without visual glitch
- [ ] Start a streaming chat session with sidebar open → no input lag when typing
- [ ] Complete a turn on a non-active session → only that session's indicator updates, not all items
- [ ] Switch between sessions → active highlight updates correctly
- [ ] Pin/unpin/archive sessions → list updates correctly
- [ ] Rename a session → title updates in sidebar
- [ ] Single-project mode → session list still works correctly
- [ ] `bun ready` passes (format + typecheck + lint + 583 tests)