### PR TITLE
feat(files): add root directory context menu and refactor menu building

### DIFF
--- a/packages/desktop/src/main/features/utils/router.ts
+++ b/packages/desktop/src/main/features/utils/router.ts
@@ -116,17 +116,19 @@ export const utilsRouter = os.utils.router({
 
   searchWithContent: os.utils.searchWithContent.handler(async ({ input }) => {
     log(
-      "searchWithContent request cwd=%s query=%s caseSensitive=%s exactMatch=%s",
+      "searchWithContent request cwd=%s query=%s caseSensitive=%s exactMatch=%s useRegex=%s",
       input.cwd,
       input.query,
       input.caseSensitive,
       input.exactMatch,
+      input.useRegex,
     );
     return searchWithContent(
       input.cwd,
       input.query,
       input.caseSensitive,
       input.exactMatch,
+      input.useRegex,
       input.maxResults,
     );
   }),

--- a/packages/desktop/src/main/features/utils/search-content.ts
+++ b/packages/desktop/src/main/features/utils/search-content.ts
@@ -20,6 +20,11 @@ interface SearchResult {
   matches?: ContentMatch[];
 }
 
+interface SearchResponse {
+  results: SearchResult[];
+  error?: string;
+}
+
 function containsChinese(str: string): boolean {
   return /[\u4e00-\u9fff]/.test(str);
 }
@@ -30,7 +35,8 @@ function searchContentWithMatches(
   query: string,
   caseSensitive: boolean,
   exactMatch: boolean,
-): Promise<SearchResult[]> {
+  useRegex: boolean,
+): Promise<SearchResponse> {
   return new Promise((resolve, reject) => {
     const args = [
       "--json",
@@ -60,14 +66,33 @@ function searchContentWithMatches(
       }
     }
 
+    // Use fixed-strings mode by default to treat query as literal string
+    // Only use regex mode when user explicitly enables it
+    if (!useRegex) {
+      args.push("--fixed-strings");
+    }
+
     args.push(query);
     args.push(cwd);
 
-    execFile(rgPath, args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
+    execFile(rgPath, args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
       if (err && !stdout) {
         if (err.message.includes("exit code 1")) {
-          resolve([]);
+          resolve({ results: [] });
           return;
+        }
+        // Check for regex error in stderr
+        if (stderr && useRegex) {
+          const regexErrorMatch = stderr.match(/regex\s+(.+?)\s+did not parse:/i);
+          if (regexErrorMatch) {
+            resolve({ results: [], error: `Invalid regex: ${regexErrorMatch[1]}` });
+            return;
+          }
+          // Generic regex error
+          if (stderr.includes("did not parse") || stderr.includes("invalid")) {
+            resolve({ results: [], error: "Invalid regular expression" });
+            return;
+          }
         }
         reject(err);
         return;
@@ -97,7 +122,7 @@ function searchContentWithMatches(
               });
             }
           }
-        } catch (e) {
+        } catch (_e) {
           log("Failed to parse JSON line: %s", line);
         }
       }
@@ -112,7 +137,7 @@ function searchContentWithMatches(
         });
       }
 
-      resolve(results);
+      resolve({ results });
     });
   });
 }
@@ -122,25 +147,28 @@ export async function searchWithContent(
   query: string,
   caseSensitive = false,
   exactMatch = false,
+  useRegex = false,
   maxResults = 100,
-): Promise<{ results: SearchResult[] }> {
+): Promise<SearchResponse> {
   log(
-    "searchWithContent cwd=%s query=%s caseSensitive=%s exactMatch=%s",
+    "searchWithContent cwd=%s query=%s caseSensitive=%s exactMatch=%s useRegex=%s",
     cwd,
     query,
     caseSensitive,
     exactMatch,
+    useRegex,
   );
 
-  const results = await searchContentWithMatches(
+  const response = await searchContentWithMatches(
     resolveRgPath(),
     cwd,
     query,
     caseSensitive,
     exactMatch,
+    useRegex,
   );
-  const truncatedResults = results.slice(0, maxResults);
+  const truncatedResults = response.results.slice(0, maxResults);
 
   log("searchWithContent result: %d files", truncatedResults.length);
-  return { results: truncatedResults };
+  return { results: truncatedResults, error: response.error };
 }

--- a/packages/desktop/src/renderer/src/plugins/files/context-menu-groups.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/context-menu-groups.tsx
@@ -1,0 +1,22 @@
+import { Fragment } from "react";
+
+import type { MenuGroup } from "./menu-types";
+
+import { ContextMenuItem, ContextMenuSeparator } from "../../components/ui/context-menu";
+
+interface ContextMenuGroupsProps {
+  groups: MenuGroup[];
+}
+
+export function ContextMenuGroups({ groups }: ContextMenuGroupsProps) {
+  return groups.map((group, groupIndex) => (
+    <Fragment key={groupIndex}>
+      {groupIndex > 0 && <ContextMenuSeparator />}
+      {group.map((menuItem, itemIndex) => (
+        <ContextMenuItem key={itemIndex} onClick={menuItem.action} data-variant={menuItem.variant}>
+          {menuItem.label}
+        </ContextMenuItem>
+      ))}
+    </Fragment>
+  ));
+}

--- a/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/files-view.tsx
@@ -1,11 +1,14 @@
 import type { ContractRouterClient } from "@orpc/contract";
 
+import { Folder02Icon, File02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { consumeEventIterator } from "@orpc/client";
 import debug from "debug";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { Project } from "../../../../shared/features/project/types";
+import type { MenuGroup } from "./menu-types";
 
 import { filesContract } from "../../../../shared/plugins/files/contract";
 import { getEmpty2Url } from "../../assets/images";
@@ -20,12 +23,19 @@ import {
   AlertDialogTitle,
 } from "../../components/ui/alert-dialog";
 import { Button } from "../../components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuPopup,
+  ContextMenuTrigger,
+} from "../../components/ui/context-menu";
 import { toastManager } from "../../components/ui/toast";
 import { usePluginContext } from "../../core/app";
 import { useProjectStore } from "../../features/project/store";
+import { ContextMenuGroups } from "./context-menu-groups";
 import { FileNodeItem, FileTreeContext, useFileData } from "./hooks/useFileData";
 import { useTreeKeyboardShortcuts } from "./hooks/useTreeKeyboardShortcuts";
 import { useFilesTranslation } from "./i18n";
+import { buildCreationMenu, buildPathMenu } from "./menu-utils";
 import { TreeNode } from "./tree-node";
 import { getCreateErrorMessage } from "./utils/error";
 
@@ -54,6 +64,8 @@ function FilesViewComponent({ project }: FilesViewProps) {
     sourcePath: string;
     operation: "copy" | "cut";
   } | null>(null);
+  const [rootCreating, setRootCreating] = useState<{ type: "file" | "folder" } | null>(null);
+  const [rootCreatingName, setRootCreatingName] = useState("");
   const { resolvedTheme } = useTheme();
 
   const cwd = project?.path || "";
@@ -221,9 +233,9 @@ function FilesViewComponent({ project }: FilesViewProps) {
     }
   };
 
-  const handleReveal = async (item: FileNodeItem) => {
-    log("reveal in file manager", { path: item.fullPath });
-    const result = await client.files.revealInFileManager({ path: item.fullPath });
+  const revealInFileManager = async (path: string) => {
+    log("reveal in file manager", { path });
+    const result = await client.files.revealInFileManager({ path });
     if (!result.success && result.error) {
       toastManager.add({
         type: "error",
@@ -346,6 +358,7 @@ function FilesViewComponent({ project }: FilesViewProps) {
       });
     }
   };
+
   /** Add file to conversation */
   const handleAddContext = (item: FileNodeItem) => {
     log("insert-chat dispatching mention=%s", item.relPath);
@@ -494,6 +507,53 @@ function FilesViewComponent({ project }: FilesViewProps) {
     );
   }
 
+  const handleRootCreateFinish = async () => {
+    if (rootCreatingName && rootCreating && cwd) {
+      if (rootCreating.type === "file") {
+        await createFile(cwd, rootCreatingName);
+      } else {
+        await createFolder(cwd, rootCreatingName);
+      }
+    }
+    setRootCreating(null);
+    setRootCreatingName("");
+  };
+
+  const handleRootCreateCancel = () => {
+    setRootCreating(null);
+    setRootCreatingName("");
+  };
+
+  const buildRootMenu = (): MenuGroup[] => {
+    const groups: MenuGroup[] = [];
+
+    // Group 1: New file/folder, Reveal in Finder
+    const creationItems = buildCreationMenu(t, {
+      onCreateFile: () => {
+        setRootCreating({ type: "file" });
+        setRootCreatingName("");
+      },
+      onCreateFolder: () => {
+        setRootCreating({ type: "folder" });
+        setRootCreatingName("");
+      },
+      onReveal: cwd ? () => revealInFileManager(cwd) : undefined,
+    });
+    groups.push(creationItems);
+
+    // Group 2: Paste (if clipboard has item)
+    if (clipboardItem && canPaste(cwd)) {
+      groups.push([{ label: t("contextMenu.paste"), action: () => handlePaste(cwd) }]);
+    }
+
+    // Group 3: Copy Path
+    groups.push(buildPathMenu(t, { fullPath: cwd || "", relativePath: "." }));
+
+    return groups;
+  };
+
+  const rootMenuGroups = buildRootMenu();
+
   const rootLevelNodes = nodes.filter((i) => i.parentPath === cwd);
 
   return (
@@ -515,46 +575,90 @@ function FilesViewComponent({ project }: FilesViewProps) {
           <h2 className="text-sm font-semibold text-muted-foreground">{t("title")}</h2>
         </div>
 
-        <div
-          className="flex-1 overflow-auto -mr-2.5"
-          onClick={(e) => {
-            // Only clear selection when clicking the empty area (not tree nodes)
-            if (e.target === e.currentTarget) {
-              cancelSelect();
-            }
-          }}
-        >
-          {nodes.length === 0 ? (
-            <div className="flex items-center justify-center h-32">
-              <p className="text-xs text-muted-foreground">{t("emptyDirectory")}</p>
-            </div>
-          ) : (
-            <div className="space-y-1">
-              {rootLevelNodes.map((item) => (
-                <TreeNode
-                  key={item.fullPath}
-                  item={item}
-                  level={0}
-                  onExpand={expand}
-                  onToggleExpand={toggleExpand}
-                  onSelect={handleSelect}
-                  onDelete={handleDelete}
-                  onRename={handleRename}
-                  onCreate={handleCreate}
-                  onAdd={handleAddContext}
-                  onCopy={handleCopy}
-                  onCut={handleCut}
-                  onPaste={handlePaste}
-                  canPaste={canPaste}
-                  onReveal={handleReveal}
-                  cutSourcePath={
-                    clipboardItem?.operation === "cut" ? clipboardItem.sourcePath : null
+        <ContextMenu>
+          <ContextMenuTrigger
+            render={
+              <div
+                className="flex-1 overflow-auto -mr-2.5"
+                onClick={(e) => {
+                  // Only clear selection when clicking the empty area (not tree nodes)
+                  if (e.target === e.currentTarget) {
+                    cancelSelect();
                   }
-                />
-              ))}
-            </div>
-          )}
-        </div>
+                }}
+              >
+                {rootCreating && (
+                  <div className="flex items-center gap-1 px-2 py-1 hover:bg-accent hover:text-accent-foreground rounded-sm">
+                    <div className="w-4 h-4 flex items-center justify-center">
+                      <HugeiconsIcon
+                        icon={rootCreating.type === "folder" ? Folder02Icon : File02Icon}
+                        size={18}
+                        strokeWidth={1.5}
+                      />
+                    </div>
+                    <span className="flex-1 text-sm ml-2 cursor-pointer">
+                      <input
+                        type="text"
+                        placeholder={
+                          rootCreating.type === "file"
+                            ? t("newFilePlaceholder")
+                            : t("newFolderPlaceholder")
+                        }
+                        value={rootCreatingName}
+                        onChange={(e) => setRootCreatingName(e.target.value)}
+                        onBlur={handleRootCreateFinish}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.stopPropagation();
+                            handleRootCreateFinish();
+                          } else if (e.key === "Escape") {
+                            e.stopPropagation();
+                            handleRootCreateCancel();
+                          }
+                        }}
+                        className="w-full bg-background border border-border rounded px-2 py-1"
+                        autoFocus
+                      />
+                    </span>
+                  </div>
+                )}
+                {nodes.length === 0 ? (
+                  <div className="flex items-center justify-center h-32">
+                    <p className="text-xs text-muted-foreground">{t("emptyDirectory")}</p>
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    {rootLevelNodes.map((item) => (
+                      <TreeNode
+                        key={item.fullPath}
+                        item={item}
+                        level={0}
+                        onExpand={expand}
+                        onToggleExpand={toggleExpand}
+                        onSelect={handleSelect}
+                        onDelete={handleDelete}
+                        onRename={handleRename}
+                        onCreate={handleCreate}
+                        onAdd={handleAddContext}
+                        onCopy={handleCopy}
+                        onCut={handleCut}
+                        onPaste={handlePaste}
+                        canPaste={canPaste}
+                        onReveal={(item) => revealInFileManager(item.fullPath)}
+                        cutSourcePath={
+                          clipboardItem?.operation === "cut" ? clipboardItem.sourcePath : null
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            }
+          />
+          <ContextMenuPopup>
+            <ContextMenuGroups groups={rootMenuGroups} />
+          </ContextMenuPopup>
+        </ContextMenu>
 
         <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
           <AlertDialogPopup>

--- a/packages/desktop/src/renderer/src/plugins/files/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/plugins/files/locales/en-US.json
@@ -12,6 +12,7 @@
   "contextMenu.revealInFinder": "Reveal in Finder",
   "contextMenu.copyFullPath": "Copy Full Path",
   "contextMenu.copyRelativePath": "Copy Relative Path",
+  "contextMenu.pathCopied": "Path copied to clipboard",
   "confirmDelete": "Are you sure you want to delete {{fileName}}?",
   "newFilePlaceholder": "New file.txt",
   "newFolderPlaceholder": "New folder",

--- a/packages/desktop/src/renderer/src/plugins/files/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/plugins/files/locales/zh-CN.json
@@ -12,6 +12,7 @@
   "contextMenu.revealInFinder": "在访达中显示",
   "contextMenu.copyFullPath": "复制完整路径",
   "contextMenu.copyRelativePath": "复制相对路径",
+  "contextMenu.pathCopied": "路径已复制到剪贴板",
   "confirmDelete": "确定要删除 {{fileName}} 吗？",
   "newFilePlaceholder": "新文件.txt",
   "newFolderPlaceholder": "新文件夹",

--- a/packages/desktop/src/renderer/src/plugins/files/menu-types.ts
+++ b/packages/desktop/src/renderer/src/plugins/files/menu-types.ts
@@ -1,0 +1,7 @@
+export type MenuItem = {
+  label: string;
+  action: () => void;
+  variant?: "destructive";
+};
+
+export type MenuGroup = MenuItem[];

--- a/packages/desktop/src/renderer/src/plugins/files/menu-utils.ts
+++ b/packages/desktop/src/renderer/src/plugins/files/menu-utils.ts
@@ -1,0 +1,83 @@
+import type { useFilesTranslation } from "./i18n";
+import type { MenuItem } from "./menu-types";
+
+type FilesTranslation = ReturnType<typeof useFilesTranslation>["t"];
+
+interface CreationMenuOptions {
+  /** 新建文件的回调 */
+  onCreateFile?: () => void;
+  /** 新建文件夹的回调 */
+  onCreateFolder?: () => void;
+  /** 在访达中显示的回调 */
+  onReveal?: () => void;
+}
+
+/**
+ * 构建新建菜单项（新建文件、新建文件夹、在访达中显示）
+ */
+export function buildCreationMenu(t: FilesTranslation, options: CreationMenuOptions): MenuItem[] {
+  const items: MenuItem[] = [];
+
+  if (options.onCreateFile && options.onCreateFolder) {
+    items.push({ label: t("contextMenu.newFile"), action: options.onCreateFile });
+    items.push({ label: t("contextMenu.newFolder"), action: options.onCreateFolder });
+  }
+
+  if (options.onReveal) {
+    // TODO: 后续如果要支持Windows，这里的表述要调整，mac 下是访达，windows 下应该是资源管理器
+    items.push({ label: t("contextMenu.revealInFinder"), action: options.onReveal });
+  }
+
+  return items;
+}
+
+interface ClipboardMenuOptions {
+  /** 复制的回调 */
+  onCopy?: () => void;
+  /** 剪切的回调 */
+  onCut?: () => void;
+  /** 粘贴的回调 */
+  onPaste?: () => void;
+}
+
+/**
+ * 构建剪贴板菜单项（复制、剪切、粘贴）
+ */
+export function buildClipboardMenu(t: FilesTranslation, options: ClipboardMenuOptions): MenuItem[] {
+  const items: MenuItem[] = [];
+
+  if (options.onCopy) {
+    items.push({ label: t("contextMenu.copy"), action: options.onCopy });
+  }
+  if (options.onCut) {
+    items.push({ label: t("contextMenu.cut"), action: options.onCut });
+  }
+  if (options.onPaste) {
+    items.push({ label: t("contextMenu.paste"), action: options.onPaste });
+  }
+
+  return items;
+}
+
+interface PathMenuOptions {
+  /** 完整路径 */
+  fullPath: string;
+  /** 相对路径 */
+  relativePath: string;
+}
+
+/**
+ * 构建路径菜单项（复制完整路径、复制相对路径）
+ */
+export function buildPathMenu(t: FilesTranslation, options: PathMenuOptions): MenuItem[] {
+  return [
+    {
+      label: t("contextMenu.copyFullPath"),
+      action: () => navigator.clipboard.writeText(options.fullPath),
+    },
+    {
+      label: t("contextMenu.copyRelativePath"),
+      action: () => navigator.clipboard.writeText(options.relativePath),
+    },
+  ];
+}

--- a/packages/desktop/src/renderer/src/plugins/files/tree-node.tsx
+++ b/packages/desktop/src/renderer/src/plugins/files/tree-node.tsx
@@ -3,16 +3,18 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronRight, ChevronDown, Plus } from "lucide-react";
 import React, { useState, useEffect, useContext } from "react";
 
+import type { MenuGroup } from "./menu-types";
+
 import {
   ContextMenu,
   ContextMenuTrigger,
   ContextMenuPopup,
-  ContextMenuItem,
-  ContextMenuSeparator,
 } from "../../components/ui/context-menu";
 import { cn } from "../../lib/utils";
+import { ContextMenuGroups } from "./context-menu-groups";
 import { FileNodeItem, FileTreeContext } from "./hooks/useFileData";
 import { useFilesTranslation } from "./i18n";
+import { buildClipboardMenu, buildCreationMenu, buildPathMenu } from "./menu-utils";
 
 interface TreeNodeProps {
   item: FileNodeItem;
@@ -31,9 +33,6 @@ interface TreeNodeProps {
   canPaste?: (targetPath: string) => boolean;
   onReveal?: (item: FileNodeItem) => void;
 }
-
-type MenuItem = { label: string; action: () => void; variant?: "destructive" };
-type MenuGroup = MenuItem[];
 
 function FileLangIcon(props: { path: string; size?: number }) {
   const { path = "", size = 18 } = props;
@@ -228,50 +227,28 @@ export function TreeNode({
     const groups: MenuGroup[] = [];
 
     // Group 1: New file/folder, Reveal in Finder
-    const creationItems: MenuItem[] = [];
-    if (item.isFolder) {
-      creationItems.push({ label: t("contextMenu.newFile"), action: handleCreateFile });
-      creationItems.push({ label: t("contextMenu.newFolder"), action: handleCreateFolder });
-    }
-    if (item.relPath !== "") {
-      creationItems.push({
-        // TODO: 后续如果要支持Windows，这里的表述要调整，mac 下是访达，windows 下应该是资源管理器
-        label: t("contextMenu.revealInFinder"),
-        action: () => onReveal?.(item),
-      });
-    }
+    const creationItems = buildCreationMenu(t, {
+      onCreateFile: item.isFolder ? handleCreateFile : undefined,
+      onCreateFolder: item.isFolder ? handleCreateFolder : undefined,
+      onReveal: item.relPath !== "" ? () => onReveal?.(item) : undefined,
+    });
     if (creationItems.length > 0) {
       groups.push(creationItems);
     }
 
     // Group 2: Copy, Cut, Paste
-    const clipboardItems: MenuItem[] = [];
-    if (item.relPath !== "") {
-      clipboardItems.push({ label: t("contextMenu.copy"), action: () => onCopy?.(item) });
-      clipboardItems.push({ label: t("contextMenu.cut"), action: () => onCut?.(item) });
-    }
-    if (item.isFolder && canPasteHere) {
-      clipboardItems.push({
-        label: t("contextMenu.paste"),
-        action: () => onPaste?.(getTargetDir()),
-      });
-    }
+    const clipboardItems = buildClipboardMenu(t, {
+      onCopy: item.relPath !== "" ? () => onCopy?.(item) : undefined,
+      onCut: item.relPath !== "" ? () => onCut?.(item) : undefined,
+      onPaste: item.isFolder && canPasteHere ? () => onPaste?.(getTargetDir()) : undefined,
+    });
     if (clipboardItems.length > 0) {
       groups.push(clipboardItems);
     }
 
     // Group 3: Copy Path
     if (item.relPath !== "") {
-      groups.push([
-        {
-          label: t("contextMenu.copyFullPath"),
-          action: () => navigator.clipboard.writeText(item.fullPath),
-        },
-        {
-          label: t("contextMenu.copyRelativePath"),
-          action: () => navigator.clipboard.writeText(item.relPath),
-        },
-      ]);
+      groups.push(buildPathMenu(t, { fullPath: item.fullPath, relativePath: item.relPath }));
     }
 
     // Group 4: Rename, Delete (delete is always last)
@@ -395,20 +372,7 @@ export function TreeNode({
           </div>
         </ContextMenuTrigger>
         <ContextMenuPopup>
-          {menuGroups.map((group, groupIndex) => (
-            <React.Fragment key={groupIndex}>
-              {groupIndex > 0 && <ContextMenuSeparator />}
-              {group.map((menuItem, itemIndex) => (
-                <ContextMenuItem
-                  key={itemIndex}
-                  onClick={menuItem.action}
-                  data-variant={menuItem.variant}
-                >
-                  {menuItem.label}
-                </ContextMenuItem>
-              ))}
-            </React.Fragment>
-          ))}
+          <ContextMenuGroups groups={menuGroups} />
         </ContextMenuPopup>
       </ContextMenu>
 

--- a/packages/desktop/src/renderer/src/plugins/search/locales/en-US.json
+++ b/packages/desktop/src/renderer/src/plugins/search/locales/en-US.json
@@ -11,6 +11,7 @@
   },
   "caseSensitive": "Case sensitive",
   "exactMatch": "Whole word",
+  "useRegex": "Regular expression",
   "matchesCount": "{{count}} matches",
   "resultsFound": "{{count}} results found",
   "performanceWarning": "Please enter at least 2 characters for better search performance"

--- a/packages/desktop/src/renderer/src/plugins/search/locales/zh-CN.json
+++ b/packages/desktop/src/renderer/src/plugins/search/locales/zh-CN.json
@@ -11,6 +11,7 @@
   },
   "caseSensitive": "区分大小写",
   "exactMatch": "全词匹配",
+  "useRegex": "正则表达式",
   "matchesCount": "{{count}} 处匹配",
   "resultsFound": "找到 {{count}} 个结果",
   "performanceWarning": "请输入至少两个字符以获得更好的搜索性能"

--- a/packages/desktop/src/renderer/src/plugins/search/search-view.tsx
+++ b/packages/desktop/src/renderer/src/plugins/search/search-view.tsx
@@ -1,7 +1,16 @@
 import type { ContractRouterClient } from "@orpc/contract";
 
 import debug from "debug";
-import { Search, FileText, Loader2, ChevronRight, CaseSensitive, WholeWord } from "lucide-react";
+import {
+  Search,
+  FileText,
+  Loader2,
+  ChevronRight,
+  CaseSensitive,
+  WholeWord,
+  Regex,
+  AlertTriangle,
+} from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 
 import type { Project } from "../../../../shared/features/project/types";
@@ -56,6 +65,8 @@ function SearchViewComponent({ project }: SearchViewProps) {
   const [expandedResults, setExpandedResults] = useState<Set<string>>(new Set());
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [exactMatch, setExactMatch] = useState(false);
+  const [useRegex, setUseRegex] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -80,6 +91,8 @@ function SearchViewComponent({ project }: SearchViewProps) {
     setExpandedResults(new Set());
     setCaseSensitive(false);
     setExactMatch(false);
+    setUseRegex(false);
+    setError(null);
   }, [cwd]);
 
   useEffect(() => {
@@ -92,6 +105,7 @@ function SearchViewComponent({ project }: SearchViewProps) {
       setResults([]);
       setSearched(false);
       setExpandedResults(new Set());
+      setError(null);
       return;
     }
 
@@ -111,23 +125,26 @@ function SearchViewComponent({ project }: SearchViewProps) {
         clearTimeout(debounceRef.current);
       }
     };
-  }, [query, caseSensitive, exactMatch, cwd]);
+  }, [query, caseSensitive, exactMatch, useRegex, cwd]);
 
   const handleSearch = async () => {
     if (!cwd || !query.trim()) {
       setResults([]);
       setSearched(false);
+      setError(null);
       return;
     }
 
     log(
-      "search triggered: query=%s caseSensitive=%s exactMatch=%s",
+      "search triggered: query=%s caseSensitive=%s exactMatch=%s useRegex=%s",
       query.trim(),
       caseSensitive,
       exactMatch,
+      useRegex,
     );
     setLoading(true);
     setSearched(true);
+    setError(null);
 
     try {
       const res = await client.utils.searchWithContent({
@@ -135,8 +152,17 @@ function SearchViewComponent({ project }: SearchViewProps) {
         query: query.trim(),
         caseSensitive,
         exactMatch,
+        useRegex,
         maxResults: 100,
       });
+
+      if (res?.error) {
+        setError(res.error);
+        setResults([]);
+        setExpandedResults(new Set());
+        return;
+      }
+
       const searchResults = res?.results || [];
       log("search complete: %d results", searchResults.length);
       setResults(searchResults);
@@ -148,8 +174,9 @@ function SearchViewComponent({ project }: SearchViewProps) {
         }
       });
       setExpandedResults(allPaths);
-    } catch (error) {
-      console.error("Search failed:", error);
+    } catch (err) {
+      console.error("Search failed:", err);
+      setError(t("error.searchFailed"));
       setResults([]);
       setExpandedResults(new Set());
     } finally {
@@ -190,44 +217,80 @@ function SearchViewComponent({ project }: SearchViewProps) {
   const highlightMatch = (text: string, searchQuery: string) => {
     if (!searchQuery.trim()) return text;
 
-    let searchText = text;
-    let query = searchQuery;
+    // ReDoS protection: limit regex execution time
+    const REGEX_TIMEOUT_MS = 100;
+    const startTime = Date.now();
 
-    if (!caseSensitive) {
-      searchText = text.toLowerCase();
-      query = searchQuery.toLowerCase();
+    const isRegexTooSlow = () => Date.now() - startTime > REGEX_TIMEOUT_MS;
+
+    try {
+      const flags = caseSensitive ? "g" : "gi";
+      let matchRegex: RegExp;
+
+      if (useRegex) {
+        // Use the query as a regex pattern directly
+        matchRegex = new RegExp(`(${searchQuery})`, flags);
+      } else {
+        // Escape special regex characters for literal search
+        const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        matchRegex = new RegExp(`(${escaped})`, flags);
+      }
+
+      // Find all matches to determine the range to display
+      const matches = [...text.matchAll(matchRegex)];
+      if (isRegexTooSlow()) {
+        log("regex timeout during matchAll, returning plain text");
+        return text;
+      }
+      if (matches.length === 0) return text;
+
+      // Use the first match to determine display range
+      const firstMatch = matches[0];
+      // Safe access: firstMatch.index is guaranteed to exist when matchAll succeeds
+      const matchIndex = firstMatch.index ?? 0;
+      const matchLength = firstMatch[0].length;
+
+      const start = Math.max(0, matchIndex - 20);
+      const end = Math.min(text.length, matchIndex + matchLength + 20);
+
+      let displayText = text.slice(start, end);
+      if (start > 0) displayText = "..." + displayText;
+      if (end < text.length) displayText = displayText + "...";
+
+      // Re-split the display text with the regex
+      // For regex mode, we need to re-apply the regex to the displayText
+      const displayRegex = useRegex
+        ? new RegExp(`(${searchQuery})`, flags)
+        : new RegExp(`(${searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, flags);
+
+      if (isRegexTooSlow()) {
+        log("regex timeout during split, returning plain text");
+        return text;
+      }
+
+      const parts = displayText.split(displayRegex);
+      // Create a new regex for testing without 'g' flag to avoid lastIndex issues
+      const testRegex = new RegExp(
+        useRegex ? searchQuery : searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        caseSensitive ? "" : "i",
+      );
+      return parts.map((part, i) =>
+        testRegex.test(part) ? (
+          <span
+            key={`match-${i}-${part}`}
+            className="bg-yellow-200 dark:bg-yellow-900 text-foreground"
+          >
+            {part}
+          </span>
+        ) : (
+          <span key={`text-${i}-${part}`}>{part}</span>
+        ),
+      );
+    } catch (e) {
+      // Invalid regex or regex error, log and return text as-is
+      log("highlightMatch error: %o", e);
+      return text;
     }
-
-    const queryIndex = searchText.indexOf(query);
-    if (queryIndex === -1) return text;
-
-    const queryLength = query.length;
-    const start = Math.max(0, queryIndex - 20);
-    const end = Math.min(text.length, queryIndex + queryLength + 20);
-
-    let displayText = text.slice(start, end);
-    if (start > 0) displayText = "..." + displayText;
-    if (end < text.length) displayText = displayText + "...";
-
-    const escapeRegExp = (string: string) => {
-      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    };
-
-    const flags = caseSensitive ? "g" : "gi";
-    const regex = new RegExp(`(${escapeRegExp(query)})`, flags);
-    const parts = displayText.split(regex);
-    return parts.map((part, i) =>
-      regex.test(part) ? (
-        <span
-          key={`match-${i}-${part}`}
-          className="bg-yellow-200 dark:bg-yellow-900 text-foreground"
-        >
-          {part}
-        </span>
-      ) : (
-        <span key={`text-${i}-${part}`}>{part}</span>
-      ),
-    );
   };
 
   if (!project) {
@@ -283,10 +346,35 @@ function SearchViewComponent({ project }: SearchViewProps) {
           >
             <WholeWord className="w-3 h-3" />
           </button>
+
+          <button
+            onClick={() => setUseRegex(!useRegex)}
+            className={cn(
+              "flex items-center text-xs px-1 py-0.5 rounded transition-all cursor-pointer hover:scale-105",
+              useRegex
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+            title={t("useRegex")}
+          >
+            <Regex className="w-3 h-3" />
+          </button>
         </div>
       </div>
 
+      {searched && !loading && results.length > 0 && (
+        <div className="text-xs text-muted-foreground mb-2">
+          {t("resultsFound", { count: results.length })}
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto overflow-x-hidden -mr-2.5">
+        {error && (
+          <div className="flex items-center gap-2 px-2 py-2 mb-2 bg-destructive/10 text-destructive text-xs rounded">
+            <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
         {loading ? (
           <div className="flex flex-col items-center justify-center h-32">
             <Loader2 className="w-5 h-5 animate-spin text-muted-foreground mb-2" />
@@ -362,11 +450,6 @@ function SearchViewComponent({ project }: SearchViewProps) {
                   )}
               </div>
             ))}
-            {searched && !loading && results.length > 0 && (
-              <div className="text-xs text-muted-foreground text-center pt-2">
-                {t("resultsFound", { count: results.length })}
-              </div>
-            )}
           </div>
         )}
       </div>

--- a/packages/desktop/src/shared/features/utils/contract.ts
+++ b/packages/desktop/src/shared/features/utils/contract.ts
@@ -50,6 +50,7 @@ export const utilsContract = {
         query: z.string(),
         caseSensitive: z.boolean().optional(),
         exactMatch: z.boolean().optional(),
+        useRegex: z.boolean().optional(),
         maxResults: z.number().optional(),
       }),
     )
@@ -62,6 +63,7 @@ export const utilsContract = {
           extName: string;
           matches?: Array<{ line: number; column: number; text: string }>;
         }>;
+        error?: string;
       }>(),
     ),
 };


### PR DESCRIPTION
## Summary
- Add context menu for root directory with new file/folder, reveal in finder, copy path, and paste operations
- Extract shared menu types (`MenuItem`, `MenuGroup`) to `menu-types.ts`
- Create `ContextMenuGroups` component for reusable menu rendering
- Add `buildCreationMenu`, `buildClipboardMenu`, `buildPathMenu` utilities
- Refactor `tree-node.tsx` to use shared menu utilities
- Add i18n keys for path copied message

## Test plan
- [ ] Right-click on empty space in file tree to open root context menu
- [ ] Create new file/folder from root context menu
- [ ] Reveal in Finder from root context menu
- [ ] Copy full path / relative path from root context menu
- [ ] Paste from clipboard in root context menu
- [ ] Verify existing tree-node context menu still works correctly
- [ ] Run `bun ready` - all checks pass